### PR TITLE
Allow scroll for bottom toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
 
     <!-- UI Overlay: Bottom Toolbar -->
     <div class="absolute bottom-6 left-0 w-full z-10 pointer-events-none flex justify-center">
-        <div class="glass-panel rounded-2xl p-2 pointer-events-auto flex items-center gap-2 shadow-2xl">
+        <div class="glass-panel rounded-2xl p-2 pointer-events-auto overflow-y-auto flex items-center gap-2 shadow-2xl">
 
 
 


### PR DESCRIPTION
That allow access to toolbar on the mobile version which is cut currently on the edges of the screens.