### PR TITLE
Fix timeScale so fast-forward affects RPS growth

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -49,6 +49,7 @@ const STATE = {
 
     // Balance overhaul state
     gameStartTime: 0,
+    elapsedGameTime: 0,
     fraudSpikeTimer: 0,
     fraudSpikeActive: false,
     normalTrafficDist: null


### PR DESCRIPTION
Issue recap: Fast-forwarding (setTimeScale > 1) sped up money/score/reputation but RPS growth still used real time, so load ramp barely changed when accelerating. Players could see this by running setTimeScale(10)—RPS rose far slower than expected.

Fix: Track simulated elapsed time (STATE.elapsedGameTime) and drive target RPS/upkeep scaling from it, so timeScale now accelerates or pauses load growth consistently.

Persistence: Reset and advance the simulated clock on game start/loop, and restore it on load so survival progression matches the chosen speed.

Behavior: RPS display now reflects the accelerated curve (simulated req/s), while real-time throughput is currentRPS * timeScale, aligning game load with fast-forward/pause.