### PR TITLE
style: Updating default colors for Links for better contrast

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -18,8 +18,8 @@ const CONFIG = {
     db: 0xdc2626,
     waf: 0xa855f7,
     s3: 0x10b981,
-    line: 0x475569,
-    lineActive: 0x38bdf8,
+    lineActive: 0x00FFFF,
+    line: 0x00FF85,
     requestFail: 0xef4444,
     cache: 0xdc382d, // Redis red
     sqs: 0xff9900, // AWS orange


### PR DESCRIPTION
## Description

This PR updates the visual style of the connection lines (`line` and `lineActive`) in `src/config.js`.

It fixes #71

## Changes:

- `line`: Changed from gray (`0x475569`) to Neon Green (`0x00FF85`).
- `lineActive`: Changed from light blue (`0x38bdf8`) to Cyan (`0x00FFFF`).


## Improvements:

- **Visibility & Accessibility**: The previous colors had lower contrast against the dark background (0x050505). The new neon colors are significantly more vibrant, making the connections instantly readable even when the game grid is busy.
- **Thematic Consistency**: The new colors match the "Server Survival" cyber/tech aesthetic much better (resembling circuit board traces or fiber optics) compared to the muted standard UI colors.
- **State Differentiation**: The active state (Cyan) is clearly distinguishable from the idle state (Green), while both maintain the same high-energy visual language.


## New Links style

<img width="786" height="506" alt="image" src="https://github.com/user-attachments/assets/08b2e361-68b3-46c4-a2f9-9466efb0ca49" />


## Compatibility with current elements

### The "Green" Family (Idle Lines)

- New Color: 0x00FF85 (Neon Green)
- Closest Match: s3 Node (0x10b981) and STATIC Traffic (0x4ade80).
- Analysis: 
  - The new Neon Green is much brighter than the s3 node, which makes sense: the "electricity" (lines) should look like light, while the node feels like physical hardware.
  - Since STATIC traffic travels to s3, having the lines be in the same green color family creates a nice visual logic: "Green stuff travels on green lines."


### The "Cyan" Family (Active Lines)
- New Color: 0x00FFFF (Pure Cyan)
- Closest Match: SEARCH Traffic (0x06b6d4) and alb Node (0x3b82f6 - Blue).
- Analysis: The new Cyan is noticeably brighter than the SEARCH traffic color.
It creates a "supercharged" feel when lines become active. It sits nicely between the Blue (READ) and Green (STATIC) spectrums of your game.

### Summary
The new colors don't conflict with the existing ones. They are sufficiently brighter/more saturated to visually "pop" off the grid without looking identical to the nodes or traffic particles. It will give your game a more "glowing circuit" look compared to the previous muted gray/slate colors.
