### PR TITLE
spawn rate fix

### DIFF
--- a/game.js
+++ b/game.js
@@ -2217,9 +2217,14 @@ function animate(time) {
     // Apply traffic burst multiplier from random events
     const effectiveRPS =
         STATE.currentRPS * (STATE.intervention?.trafficBurstMultiplier || 1.0);
-    if (effectiveRPS > 0 && STATE.spawnTimer > 1 / effectiveRPS) {
-        STATE.spawnTimer = 0;
-        spawnRequest();
+    if (effectiveRPS > 0) {
+        const spawnInterval = 1 / effectiveRPS;
+        // Spawn multiple requests if timeScale causes large dt jumps
+        // This ensures correct spawn rate even when fast forwarding
+        while (STATE.spawnTimer >= spawnInterval) {
+            STATE.spawnTimer -= spawnInterval;
+            spawnRequest();
+        }
         // Only ramp up in survival mode - use logarithmic growth
         if (STATE.gameMode === "survival") {
             const gameTime = STATE.elapsedGameTime;


### PR DESCRIPTION
## Fix: Compute load not increasing during fast forward

**Problem:** When fast forwarding (3x speed), compute services weren't accumulating load because the spawn logic only spawned one request per frame, even when large `dt` values required multiple spawns.

**Fix:** Changed spawn logic from `if` to `while` loop to spawn multiple requests per frame when needed, ensuring correct spawn rate at any `timeScale`.

**Impact:** Compute queues now correctly fill during fast forward, making infrastructure testing accurate.