### PR TITLE
Fix: Tooltip for CDN was not displayed

### DIFF
--- a/game.js
+++ b/game.js
@@ -2197,7 +2197,7 @@ function showTooltip(x, y, html) {
 
 // Setup UI tooltips
 function setupUITooltips() {
-    const tools = ["waf", "sqs", "alb", "lambda", "db", "cache", "s3"];
+    const tools = ["waf", "sqs", "alb", "lambda", "db", "cache", "s3", "cdn"];
     tools.forEach((toolId) => {
         const btn = document.getElementById(`tool-${toolId}`);
         if (!btn) return;


### PR DESCRIPTION
Tooltips were not displayed for CDN-loaded assets because `setupUITooltips` did not include CDN in its tool list.

This change adds it, restoring correct tooltip behavior.

Fixes #113
