### PR TITLE
Refund full price and update expenses

### DIFF
--- a/game.js
+++ b/game.js
@@ -1673,7 +1673,10 @@ function deleteObject(id) {
 
     svc.destroy();
     STATE.services = STATE.services.filter((s) => s.id !== id);
-    STATE.money += Math.floor(svc.config.cost / 2);
+    STATE.money += svc.config.cost;
+    STATE.finances.expenses.services -= svc.config.cost
+    STATE.finances.expenses.byService[svc.type] -= svc.config.cost
+    STATE.finances.expenses.countByService[svc.type] -= 1
     STATE.sound.playDelete();
     updateRepairCostTable();
 }


### PR DESCRIPTION
Closes: https://github.com/pshenok/server-survival/issues/129

Current state:
1. When one places an object and then demolishes it, only half of the object's price will be refunded.
2. When one demolishes an object, the expenses do not update (I don't know if this is intentional).

PR state:
1. Demolishing an object results in 100% refund.
2. Demolishing an object results in expenses update.


https://github.com/user-attachments/assets/50114aa1-65c8-46c4-a744-a554bf7d594a

