### PR TITLE
fix: re-render tutorial when language is changed mid-session

### DIFF
--- a/src/tutorial.js
+++ b/src/tutorial.js
@@ -196,6 +196,9 @@ class Tutorial {
     setupEventListeners() {
         this.nextBtn?.addEventListener('click', () => this.nextStep());
         this.skipBtn?.addEventListener('click', () => this.skip());
+        window.addEventListener('localeChanged', () => {
+            if (this.isActive) this.showStep();
+        });
     }
 
     isCompleted() {


### PR DESCRIPTION
## Summary

- Convert `TUTORIAL_STEPS` from a static array to a `getTutorialSteps()` function so tutorial text is evaluated lazily at render time
- Add `localeChanged` event listener to the `Tutorial` class so `showStep()` is called whenever the language changes mid-tutorial

Previously, all tutorial text was evaluated once at script load time (before the user selects a language), meaning switching languages had no effect on the tutorial popup. This fix ensures the tutorial always reflects the currently selected language.

This bug affects all language options, not just any single locale.

## Test plan

- [x] Start a Survival game to open the tutorial
- [x] Switch language mid-tutorial and verify the tutorial text updates immediately
- [x] Verify tutorial buttons ("Next", "Skip Tutorial") also update to the selected language
- [x] Verify tutorial step progression still works correctly after a language switch
- [x] Verify other languages are unaffected when no language switch occurs