### PR TITLE
feat: add Search Engine + Read Replica services with smart hints

### DIFF
--- a/game.js
+++ b/game.js
@@ -795,6 +795,78 @@ function updateFinancesDisplay() {
     }
 }
 
+function checkSmartHints() {
+  if (STATE.gameMode !== "survival") return;
+  if (!STATE.hints) return;
+  if (window.tutorial?.isActive) return;
+  if (STATE.timeScale === 0) return;
+
+  const now = STATE.elapsedGameTime;
+  if (now - STATE.hints.lastHintTime < STATE.hints.hintCooldown) return;
+
+  const dbServices = STATE.services.filter(s => s.type === "db");
+  const hasSearch = STATE.services.some(s => s.type === "search");
+  const hasReplica = STATE.services.some(s => s.type === "replica");
+  const hasWaf = STATE.services.some(s => s.type === "waf");
+  const hasCache = STATE.services.some(s => s.type === "cache");
+  const hasCdn = STATE.services.some(s => s.type === "cdn");
+
+  const dbOverloaded = dbServices.some(s => s.totalLoad > 0.8);
+  const computeOverloaded = STATE.services
+    .filter(s => s.type === "compute")
+    .some(s => s.totalLoad > 0.8);
+
+  let hint = null;
+
+  if (dbOverloaded && !hasSearch && STATE.trafficDistribution.SEARCH > 0.05 &&
+      !STATE.hints.dismissedHints.has("search")) {
+    hint = { key: "hint_search_overload", id: "search" };
+  } else if (dbOverloaded && !hasReplica && STATE.trafficDistribution.READ > 0.1 &&
+      !STATE.hints.dismissedHints.has("replica")) {
+    hint = { key: "hint_read_overload", id: "replica" };
+  } else if (!hasWaf && (STATE.failures.MALICIOUS || 0) > 5 &&
+      !STATE.hints.dismissedHints.has("waf")) {
+    hint = { key: "hint_no_waf", id: "waf" };
+  } else if (!hasCache && STATE.trafficDistribution.READ + STATE.trafficDistribution.STATIC + STATE.trafficDistribution.SEARCH > 0.5 &&
+      !STATE.hints.dismissedHints.has("cache")) {
+    hint = { key: "hint_no_cache", id: "cache" };
+  } else if (computeOverloaded && !STATE.services.some(s => s.type === "sqs") &&
+      !STATE.hints.dismissedHints.has("sqs")) {
+    hint = { key: "hint_compute_overload", id: "sqs" };
+  } else if (!hasCdn && STATE.trafficDistribution.STATIC > 0.3 &&
+      !STATE.hints.dismissedHints.has("cdn")) {
+    hint = { key: "hint_no_cdn", id: "cdn" };
+  }
+
+  if (hint) {
+    showSmartHint(hint);
+    STATE.hints.lastHintTime = now;
+  }
+}
+
+function showSmartHint(hint) {
+  const warningsContainer = document.getElementById("intervention-warnings");
+  if (!warningsContainer) return;
+
+  const warning = document.createElement("div");
+  warning.className = "intervention-warning warning-info border-2 rounded-lg px-6 py-3 mb-2 shadow-lg";
+  warning.innerHTML = `
+    <div class="flex items-center gap-3">
+      <span class="font-bold text-sm">${i18n.t(hint.key)}</span>
+      <button onclick="this.parentElement.parentElement.remove(); STATE.hints.dismissedHints.add('${hint.id}')"
+        class="pointer-events-auto text-xs bg-blue-800 hover:bg-blue-700 px-2 py-1 rounded ml-2">${i18n.t('hint_dismiss')}</button>
+    </div>
+  `;
+  warningsContainer.appendChild(warning);
+
+  setTimeout(() => {
+    warning.style.transition = "all 0.3s ease-out";
+    warning.style.opacity = "0";
+    warning.style.transform = "translateY(-20px)";
+    setTimeout(() => warning.remove(), 300);
+  }, 10000);
+}
+
 // ==================== END INTERVENTION MECHANICS ====================
 
 // ==================== END BALANCE OVERHAUL FUNCTIONS ====================
@@ -948,6 +1020,11 @@ function resetGame(mode = "survival") {
     STATE.maliciousSpikeActive = false;
     STATE.normalTrafficDist = null;
     STATE.autoRepairEnabled = false;
+    STATE.hints = {
+      lastHintTime: 0,
+      dismissedHints: new Set(),
+      hintCooldown: 30,
+    };
 
     // Initialize detailed finance tracking
     STATE.finances = {
@@ -2492,6 +2569,7 @@ function animate(time) {
     updateActiveEventTimer();
     processAutoRepair(dt);
     updateFinancesDisplay();
+    checkSmartHints();
 
     document.getElementById("money-display").innerText = `$${Math.floor(
         STATE.money

--- a/game.js
+++ b/game.js
@@ -699,6 +699,18 @@ function updateFinancesDisplay() {
             color: "text-cyan-400",
             cost: CONFIG.services.sqs.cost,
         },
+        {
+            key: "search",
+            label: i18n.t('search_engine'),
+            color: "text-cyan-400",
+            cost: CONFIG.services.search.cost,
+        },
+        {
+            key: "replica",
+            label: i18n.t('read_replica'),
+            color: "text-pink-400",
+            cost: CONFIG.services.replica.cost,
+        },
     ];
 
     const repairPercent = CONFIG.survival.degradation?.repairCostPercent || 0.15;
@@ -973,6 +985,8 @@ function resetGame(mode = "survival") {
                 s3: 0,
                 cache: 0,
                 sqs: 0,
+                search: 0,
+                replica: 0,
             },
             countByService: {
                 // Count of each service purchased
@@ -983,6 +997,8 @@ function resetGame(mode = "survival") {
                 s3: 0,
                 cache: 0,
                 sqs: 0,
+                search: 0,
+                replica: 0,
             },
         },
     };
@@ -1549,6 +1565,14 @@ function createConnection(fromId, toId) {
     // NoSQL connections
     else if (t1 === "compute" && t2 === "nosql") valid = true;
     else if (t1 === "cache" && t2 === "nosql") valid = true;
+    // Search Engine connections
+    else if (t1 === "compute" && t2 === "search") valid = true;
+    else if (t1 === "cache" && t2 === "search") valid = true;
+    // Read Replica connections
+    else if (t1 === "compute" && t2 === "replica") valid = true;
+    else if (t1 === "cache" && t2 === "replica") valid = true;
+    else if (t1 === "replica" && t2 === "db") valid = true;
+    else if (t1 === "replica" && t2 === "nosql") valid = true;
 
     if (!valid) {
         new Audio("assets/sounds/click-9.mp3").play();
@@ -1905,7 +1929,7 @@ container.addEventListener("mousedown", (e) => {
             new Audio("assets/sounds/click-5.mp3").play();
         }
     } else if (
-        ["waf", "alb", "lambda", "db", "nosql", "s3", "sqs", "cache", "cdn", "apigw"].includes(
+        ["waf", "alb", "lambda", "db", "nosql", "s3", "sqs", "cache", "cdn", "apigw", "search", "replica"].includes(
             STATE.activeTool
         )
     ) {
@@ -1915,7 +1939,9 @@ container.addEventListener("mousedown", (e) => {
             (STATE.activeTool === "db" && i.type === "service") ||
             (STATE.activeTool === "cache" && i.type === "service") ||
             (STATE.activeTool === "apigw" && i.type === "service") ||
-            (STATE.activeTool === "nosql" && i.type === "service")
+            (STATE.activeTool === "nosql" && i.type === "service") ||
+            (STATE.activeTool === "search" && i.type === "service") ||
+            (STATE.activeTool === "replica" && i.type === "service")
         ) {
             const svc = STATE.services.find((s) => s.id === i.id);
             if (
@@ -1924,7 +1950,9 @@ container.addEventListener("mousedown", (e) => {
                     (STATE.activeTool === "db" && svc.type === "db") ||
                     (STATE.activeTool === "cache" && svc.type === "cache") ||
                     (STATE.activeTool === "apigw" && svc.type === "apigw") ||
-                    (STATE.activeTool === "nosql" && svc.type === "nosql"))
+                    (STATE.activeTool === "nosql" && svc.type === "nosql") ||
+                    (STATE.activeTool === "search" && svc.type === "search") ||
+                    (STATE.activeTool === "replica" && svc.type === "replica"))
             ) {
                 svc.upgrade();
                 return;
@@ -1942,6 +1970,8 @@ container.addEventListener("mousedown", (e) => {
                 cache: "cache",
                 apigw: "apigw",
                 cdn: "cdn",
+                search: "search",
+                replica: "replica",
             };
 
             const serviceType = typeMap[STATE.activeTool];
@@ -2127,7 +2157,9 @@ container.addEventListener("mousemove", (e) => {
                 (STATE.activeTool === "db" && s.type === "db") ||
                 (STATE.activeTool === "cache" && s.type === "cache") ||
                 (STATE.activeTool === "apigw" && s.type === "apigw") ||
-                (STATE.activeTool === "nosql" && s.type === "nosql")
+                (STATE.activeTool === "nosql" && s.type === "nosql") ||
+                (STATE.activeTool === "search" && s.type === "search") ||
+                (STATE.activeTool === "replica" && s.type === "replica")
             ) {
                 const tiers = CONFIG.services[s.type].tiers;
                 if (s.tier < tiers.length) {
@@ -2142,7 +2174,7 @@ container.addEventListener("mousemove", (e) => {
             }
 
             // SHOW UPGRADE INDICATOR (Green Arrow)
-            if (["compute", "db", "cache", "apigw", "nosql"].includes(s.type)) {
+            if (["compute", "db", "cache", "apigw", "nosql", "search", "replica"].includes(s.type)) {
                 const tiers = CONFIG.services[s.type].tiers;
                 if (s.tier < tiers.length) {
                     // Clear any pending hide timer since we are hovering a valid service
@@ -2245,7 +2277,7 @@ function showTooltip(x, y, html) {
 
 // Setup UI tooltips
 function setupUITooltips() {
-    const tools = ["waf", "apigw", "sqs", "alb", "lambda", "db", "nosql", "cache", "s3", "cdn"];
+    const tools = ["waf", "apigw", "sqs", "alb", "lambda", "db", "nosql", "cache", "s3", "cdn", "search", "replica"];
     tools.forEach((toolId) => {
         const btn = document.getElementById(`tool-${toolId}`);
         if (!btn) return;
@@ -2772,6 +2804,16 @@ function analyzeFailure() {
         result.tips.push(i18n.t('tip_nosql'));
     }
 
+    if (!STATE.services.some((s) => s.type === "search") &&
+        STATE.failures.SEARCH > 5) {
+        result.tips.push(i18n.t('tip_search_engine'));
+    }
+
+    if (!STATE.services.some((s) => s.type === "replica") &&
+        STATE.failures.READ > 10) {
+        result.tips.push(i18n.t('tip_read_replica'));
+    }
+
     // Limit tips to 4
     result.tips = result.tips.slice(0, 4);
 
@@ -3205,8 +3247,8 @@ function loadGameState(saveData = null) {
                 autoRepair: 0,
                 mitigation: 0,
                 breach: 0,
-                byService: { waf: 0, alb: 0, compute: 0, db: 0, s3: 0, cache: 0, sqs: 0 },
-                countByService: { waf: 0, alb: 0, compute: 0, db: 0, s3: 0, cache: 0, sqs: 0 },
+                byService: { waf: 0, alb: 0, compute: 0, db: 0, s3: 0, cache: 0, sqs: 0, search: 0, replica: 0 },
+                countByService: { waf: 0, alb: 0, compute: 0, db: 0, s3: 0, cache: 0, sqs: 0, search: 0, replica: 0 },
             },
         };
 

--- a/game.js
+++ b/game.js
@@ -711,6 +711,24 @@ function updateFinancesDisplay() {
             color: "text-pink-400",
             cost: CONFIG.services.replica.cost,
         },
+        {
+            key: "apigw",
+            label: i18n.t('apigw'),
+            color: "text-fuchsia-400",
+            cost: CONFIG.services.apigw.cost,
+        },
+        {
+            key: "nosql",
+            label: i18n.t('nosql'),
+            color: "text-violet-400",
+            cost: CONFIG.services.nosql.cost,
+        },
+        {
+            key: "cdn",
+            label: i18n.t('cdn'),
+            color: "text-green-400",
+            cost: CONFIG.services.cdn.cost,
+        },
     ];
 
     const repairPercent = CONFIG.survival.degradation?.repairCostPercent || 0.15;
@@ -1064,6 +1082,9 @@ function resetGame(mode = "survival") {
                 sqs: 0,
                 search: 0,
                 replica: 0,
+                apigw: 0,
+                nosql: 0,
+                cdn: 0,
             },
             countByService: {
                 // Count of each service purchased
@@ -1075,6 +1096,9 @@ function resetGame(mode = "survival") {
                 cache: 0,
                 sqs: 0,
                 search: 0,
+                apigw: 0,
+                nosql: 0,
+                cdn: 0,
                 replica: 0,
             },
         },
@@ -3325,8 +3349,8 @@ function loadGameState(saveData = null) {
                 autoRepair: 0,
                 mitigation: 0,
                 breach: 0,
-                byService: { waf: 0, alb: 0, compute: 0, db: 0, s3: 0, cache: 0, sqs: 0, search: 0, replica: 0 },
-                countByService: { waf: 0, alb: 0, compute: 0, db: 0, s3: 0, cache: 0, sqs: 0, search: 0, replica: 0 },
+                byService: { waf: 0, alb: 0, compute: 0, db: 0, s3: 0, cache: 0, sqs: 0, search: 0, replica: 0, apigw: 0, nosql: 0, cdn: 0 },
+                countByService: { waf: 0, alb: 0, compute: 0, db: 0, s3: 0, cache: 0, sqs: 0, search: 0, replica: 0, apigw: 0, nosql: 0, cdn: 0 },
             },
         };
 

--- a/index.html
+++ b/index.html
@@ -676,6 +676,32 @@
           <div class="w-4 h-4 bg-emerald-500 rounded-full mb-1 shadow-[0_0_10px_rgba(16,185,129,0.6)]"></div>
           <span data-i18n="storage_short" class="text-[10px] font-bold mt-1">Storage</span>
         </button>
+
+        <!-- Search Engine -->
+        <button id="tool-search"
+          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
+          onclick="setTool('search')">
+          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
+            $120
+          </div>
+          <div
+            class="w-4 h-4 bg-cyan-500 rounded-sm mb-1 shadow-[0_0_10px_rgba(6,182,212,0.6)]" style="transform: rotate(22deg)">
+          </div>
+          <span data-i18n="search_short" class="text-[10px] font-bold mt-1">Search</span>
+        </button>
+
+        <!-- Read Replica -->
+        <button id="tool-replica"
+          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
+          onclick="setTool('replica')">
+          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
+            $100
+          </div>
+          <div
+            class="w-4 h-4 bg-pink-400 rounded-sm mb-1 shadow-[0_0_10px_rgba(244,114,182,0.6)] border-b-2 border-pink-600">
+          </div>
+          <span data-i18n="replica_short" class="text-[10px] font-bold mt-1">Replica</span>
+        </button>
       </div>
     </div>
   </div>
@@ -967,6 +993,14 @@
             <li class="flex justify-between">
               <span data-i18n="file_storage" class="text-emerald-400 font-bold">File Storage</span>
               <span data-i18n="storage_desc_short">Stores Web Data ($25)</span>
+            </li>
+            <li class="flex justify-between">
+              <span data-i18n="search_engine" class="text-cyan-400 font-bold">Search Engine</span>
+              <span data-i18n="search_desc_short">Fast SEARCH queries ($120)</span>
+            </li>
+            <li class="flex justify-between">
+              <span data-i18n="read_replica" class="text-pink-400 font-bold">Read Replica</span>
+              <span data-i18n="replica_desc_short">Offloads READ from DB ($100)</span>
             </li>
           </ul>
         </div>

--- a/index.html
+++ b/index.html
@@ -828,7 +828,7 @@
           Save in Browser
         </button>
 
-        <button onclick="saveGameState('file')" id="load-btn"
+        <button onclick="saveGameState('file')" id="btn-download-save"
           data-i18n="save_download"
           class="w-full bg-purple-600 hover:bg-purple-500 text-white font-bold py-4 px-8 rounded-lg shadow-lg transform transition hover:scale-105 font-mono uppercase text-lg border border-purple-400/50">
           Download Save File
@@ -1165,6 +1165,26 @@
             <p data-i18n="nosql_flow" class="text-gray-500 text-xs mt-1">
               Flow: Compute → NoSQL or Compute → Cache → NoSQL
             </p>
+          </div>
+          <div class="bg-gray-800/50 p-3 rounded border border-cyan-900/50">
+            <div class="flex justify-between items-center">
+              <strong data-i18n="search_full" class="text-cyan-400">Search Engine</strong>
+              <span class="text-green-400 font-mono text-sm">$120</span>
+            </div>
+            <p data-i18n="search_desc_long" class="text-sm text-gray-400 mt-1">
+              Processes SEARCH traffic 3× faster than SQL DB (100ms vs 300ms). Only accepts SEARCH queries — other traffic types will fail. Upgrade tiers for higher capacity (12/25/40).
+            </p>
+            <p data-i18n="search_flow" class="text-xs text-gray-500 mt-1">Flow: Compute → Search Engine or Cache → Search Engine</p>
+          </div>
+          <div class="bg-gray-800/50 p-3 rounded border border-pink-900/50">
+            <div class="flex justify-between items-center">
+              <strong data-i18n="replica_full" class="text-pink-400">Read Replica</strong>
+              <span class="text-green-400 font-mono text-sm">$100</span>
+            </div>
+            <p data-i18n="replica_desc_long" class="text-sm text-gray-400 mt-1">
+              Processes READ traffic faster than master DB (200ms vs 300ms). Must be connected to a SQL DB or NoSQL DB to function. Only accepts READ queries.
+            </p>
+            <p data-i18n="replica_flow" class="text-xs text-gray-500 mt-1">Flow: Compute → Replica → DB or Cache → Replica → DB</p>
           </div>
         </div>
       </div>

--- a/src/config.js
+++ b/src/config.js
@@ -25,6 +25,8 @@ const CONFIG = {
     sqs: 0xff9900, // AWS orange
     apigw: 0xe879f9, // Pink/magenta for API Gateway
     nosql: 0x7c3aed, // Violet for NoSQL
+    search: 0x06b6d4, // Cyan-500 for Search Engine
+    replica: 0xf472b6, // Pink-400 for Read Replica
   },
   trafficTypes: {
     STATIC: {
@@ -75,7 +77,7 @@ const CONFIG = {
       name: "SEARCH",
       method: "GET+query",
       color: 0x06b6d4,
-      reward: 0.8,
+      reward: 1.2,
       score: 5,
       cacheable: true,
       cacheHitRate: 0.15,
@@ -245,9 +247,43 @@ const CONFIG = {
         { level: 3, capacity: 50, cost: 200 },
       ],
     },
+    search: {
+      name: "Search Engine",
+      cost: 120,
+      type: "search",
+      processingTime: 100,
+      capacity: 12,
+      upkeep: 16,
+      tooltip: {
+        upkeep: "High",
+        desc: "<b>Search Engine.</b> Specialized for SEARCH queries. 3× faster than SQL DB. <b>Upgradeable (Tiers 1-3).</b>",
+      },
+      tiers: [
+        { level: 1, capacity: 12, cost: 0 },
+        { level: 2, capacity: 25, cost: 150 },
+        { level: 3, capacity: 40, cost: 250 },
+      ],
+    },
+    replica: {
+      name: "Read Replica",
+      cost: 100,
+      type: "replica",
+      processingTime: 200,
+      capacity: 12,
+      upkeep: 12,
+      tooltip: {
+        upkeep: "Medium",
+        desc: "<b>Read Replica.</b> Offloads READ traffic from master DB. Requires connection to a DB. <b>Upgradeable (Tiers 1-3).</b>",
+      },
+      tiers: [
+        { level: 1, capacity: 12, cost: 0 },
+        { level: 2, capacity: 24, cost: 130 },
+        { level: 3, capacity: 40, cost: 200 },
+      ],
+    },
   },
   survival: {
-    startBudget: 420,
+    startBudget: 500,
     baseRPS: 1.0,
     rampUp: 0.025,
     maxRPS: Infinity,
@@ -345,6 +381,28 @@ const CONFIG = {
             WRITE: 0.45,
             UPLOAD: 0.1,
             SEARCH: 0.1,
+            MALICIOUS: 0.15,
+          },
+        },
+        {
+          name: "Read Heavy",
+          distribution: {
+            STATIC: 0.1,
+            READ: 0.45,
+            WRITE: 0.15,
+            UPLOAD: 0.05,
+            SEARCH: 0.15,
+            MALICIOUS: 0.1,
+          },
+        },
+        {
+          name: "Full-Text Flood",
+          distribution: {
+            STATIC: 0.05,
+            READ: 0.1,
+            WRITE: 0.1,
+            UPLOAD: 0.05,
+            SEARCH: 0.55,
             MALICIOUS: 0.15,
           },
         },

--- a/src/entities/Service.js
+++ b/src/entities/Service.js
@@ -84,6 +84,20 @@ class Service {
           roughness: 0.3,
         });
         break;
+      case "search":
+        geo = new THREE.DodecahedronGeometry(1.5, 0);
+        mat = new THREE.MeshStandardMaterial({
+          color: CONFIG.colors.search,
+          ...materialProps,
+        });
+        break;
+      case "replica":
+        geo = new THREE.CylinderGeometry(1.8, 1.8, 1, 6);
+        mat = new THREE.MeshStandardMaterial({
+          color: CONFIG.colors.replica,
+          roughness: 0.3,
+        });
+        break;
     }
 
     this.mesh = new THREE.Mesh(geo, mat);
@@ -98,6 +112,8 @@ class Service {
     else if (type === "cdn") this.mesh.position.y += 1.5;
     else if (type === "apigw") this.mesh.position.y += 1.5;
     else if (type === "nosql") this.mesh.position.y += 1;
+    else if (type === "search") this.mesh.position.y += 1.5;
+    else if (type === "replica") this.mesh.position.y += 1;
     else this.mesh.position.y += 1;
 
     this.mesh.castShadow = true;
@@ -145,7 +161,7 @@ class Service {
   }
 
   upgrade() {
-    if (!["compute", "db", "cache", "apigw", "nosql"].includes(this.type)) return;
+    if (!["compute", "db", "cache", "apigw", "nosql", "search", "replica"].includes(this.type)) return;
     const tiers = CONFIG.services[this.type].tiers;
     if (this.tier >= tiers.length) return;
 
@@ -191,6 +207,12 @@ class Service {
     } else if (this.type === "nosql") {
       ringSize = 2.0;
       ringColor = 0x7c3aed;
+    } else if (this.type === "search") {
+      ringSize = 1.5;
+      ringColor = 0x06b6d4;
+    } else if (this.type === "replica") {
+      ringSize = 1.8;
+      ringColor = 0xf472b6;
     } else {
       ringSize = 1.3;
       ringColor = 0xffff00;
@@ -374,6 +396,32 @@ class Service {
           continue;
         }
 
+        if (this.type === "search") {
+          if (job.req.type === "SEARCH") {
+            finishRequest(job.req);
+          } else {
+            failRequest(job.req);
+          }
+          continue;
+        }
+
+        if (this.type === "replica") {
+          const hasMaster = this.connections.some(id => {
+            const s = STATE.services.find(svc => svc.id === id);
+            return s && (s.type === "db" || s.type === "nosql");
+          });
+          if (!hasMaster) {
+            failRequest(job.req);
+            continue;
+          }
+          if (job.req.type === "READ" && job.req.destination === "db") {
+            finishRequest(job.req);
+          } else {
+            failRequest(job.req);
+          }
+          continue;
+        }
+
         if (this.type === "s3") {
           if (job.req.destination === "s3" || job.req.destination === "cdn") {
             finishRequest(job.req);
@@ -398,8 +446,16 @@ class Service {
 
           const destType = job.req.destination;
 
-          // Cache miss routing: prefer NoSQL for READ/WRITE, only SQL for SEARCH
+          // Cache miss routing: prefer specialized services
           if (destType === "db") {
+            if (job.req.type === "SEARCH") {
+              const searchTarget = this.findConnectedService("search");
+              if (searchTarget) { job.req.flyTo(searchTarget); continue; }
+            }
+            if (job.req.type === "READ") {
+              const replicaTarget = this.findConnectedService("replica");
+              if (replicaTarget) { job.req.flyTo(replicaTarget); continue; }
+            }
             if (job.req.type !== "SEARCH") {
               const nosqlTarget = this.findConnectedService("nosql");
               if (nosqlTarget) { job.req.flyTo(nosqlTarget); continue; }
@@ -537,14 +593,21 @@ class Service {
             }
           }
 
-          // NoSQL routing: prefer NoSQL for READ/WRITE, only SQL for SEARCH
+          // Routing: prefer specialized services, fallback to general
           if (destType === "db") {
             if (job.req.type === "SEARCH") {
-              // SEARCH only works on SQL
+              const searchTarget = this.findConnectedService("search");
+              if (searchTarget) { job.req.flyTo(searchTarget); continue; }
+              const sqlTarget = this.findConnectedService("db");
+              if (sqlTarget) { job.req.flyTo(sqlTarget); continue; }
+            } else if (job.req.type === "READ") {
+              const replicaTarget = this.findConnectedService("replica");
+              if (replicaTarget) { job.req.flyTo(replicaTarget); continue; }
+              const nosqlTarget = this.findConnectedService("nosql");
+              if (nosqlTarget) { job.req.flyTo(nosqlTarget); continue; }
               const sqlTarget = this.findConnectedService("db");
               if (sqlTarget) { job.req.flyTo(sqlTarget); continue; }
             } else {
-              // READ/WRITE prefer NoSQL (faster, cheaper), fallback to SQL
               const nosqlTarget = this.findConnectedService("nosql");
               if (nosqlTarget) { job.req.flyTo(nosqlTarget); continue; }
               const sqlTarget = this.findConnectedService("db");
@@ -856,6 +919,12 @@ class Service {
           } else if (service.type === "nosql") {
             ringSize = 2.0;
             ringColor = 0x7c3aed;
+          } else if (service.type === "search") {
+            ringSize = 1.5;
+            ringColor = 0x06b6d4;
+          } else if (service.type === "replica") {
+            ringSize = 1.8;
+            ringColor = 0xf472b6;
           } else {
             ringSize = 1.3;
             ringColor = 0xffff00;

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -438,5 +438,36 @@ const DE_TRANSLATIONS = {
     "tip_apigw": "API Gateway hinzufügen für sanfte Degradierung bei Traffic-Spitzen",
     "tip_nosql": "NoSQL für schnelleres READ/WRITE nutzen, SQL für SEARCH behalten",
     "apigw_desc_short": "Drosselt Datenverkehr ($70)",
-    "nosql_desc_short": "Schnelle READ/WRITE DB ($80)"
+    "nosql_desc_short": "Schnelle READ/WRITE DB ($80)",
+    // Search Engine
+    "search": "Search Engine",
+    "search_short": "Search",
+    "search_engine": "Search Engine",
+    "search_desc": "<b>Search Engine.</b> Specialized for SEARCH queries. 3× faster than SQL DB. <b>Upgradeable (Tiers 1-3).</b>",
+    "search_full": "Search Engine",
+    "search_desc_long": "Processes SEARCH traffic 3× faster than SQL DB (100ms vs 300ms). Only accepts SEARCH queries — other traffic types will fail. Upgrade tiers for higher capacity (12/25/40).",
+    "search_flow": "Flow: Compute → Search Engine or Cache → Search Engine",
+    "search_desc_short": "Fast SEARCH queries ($120)",
+    "tip_search_engine": "Add a Search Engine to handle SEARCH queries faster than SQL DB",
+    // Read Replica
+    "replica": "Read Replica",
+    "replica_short": "Replica",
+    "read_replica": "Read Replica",
+    "replica_desc": "<b>Read Replica.</b> Offloads READ traffic from master DB. Requires connection to a DB. <b>Upgradeable (Tiers 1-3).</b>",
+    "replica_full": "Read Replica",
+    "replica_desc_long": "Processes READ traffic faster than master DB (200ms vs 300ms). Must be connected to a SQL DB or NoSQL DB to function. Only accepts READ queries.",
+    "replica_flow": "Flow: Compute → Replica → DB or Cache → Replica → DB",
+    "replica_desc_short": "Offloads READ from DB ($100)",
+    "tip_read_replica": "Add a Read Replica to offload READ traffic from your overloaded DB",
+    // Smart Hints
+    "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
+    "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",
+    "hint_no_waf": "💡 Malicious traffic is getting through! Add a Firewall to block attacks.",
+    "hint_no_cache": "💡 Many requests are cacheable. A Memory Cache would reduce DB load!",
+    "hint_compute_overload": "💡 Your Compute nodes are overwhelmed. Add a Message Queue to buffer requests.",
+    "hint_no_cdn": "💡 High static traffic! A CDN can serve it without hitting your servers.",
+    "hint_dismiss": "Dismiss",
+    // Traffic shifts
+    "shift_read_heavy": "Read Heavy",
+    "shift_full_text_flood": "Full-Text Flood"
 };

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -437,5 +437,36 @@ const EN_TRANSLATIONS = {
     "tip_apigw": "Add API Gateway for graceful degradation during traffic spikes",
     "tip_nosql": "Use NoSQL for faster READ/WRITE, keep SQL for SEARCH queries",
     "apigw_desc_short": "Rate Limits Traffic ($70)",
-    "nosql_desc_short": "Fast READ/WRITE DB ($80)"
+    "nosql_desc_short": "Fast READ/WRITE DB ($80)",
+    // Search Engine
+    "search": "Search Engine",
+    "search_short": "Search",
+    "search_engine": "Search Engine",
+    "search_desc": "<b>Search Engine.</b> Specialized for SEARCH queries. 3× faster than SQL DB. <b>Upgradeable (Tiers 1-3).</b>",
+    "search_full": "Search Engine",
+    "search_desc_long": "Processes SEARCH traffic 3× faster than SQL DB (100ms vs 300ms). Only accepts SEARCH queries — other traffic types will fail. Upgrade tiers for higher capacity (12/25/40).",
+    "search_flow": "Flow: Compute → Search Engine or Cache → Search Engine",
+    "search_desc_short": "Fast SEARCH queries ($120)",
+    "tip_search_engine": "Add a Search Engine to handle SEARCH queries faster than SQL DB",
+    // Read Replica
+    "replica": "Read Replica",
+    "replica_short": "Replica",
+    "read_replica": "Read Replica",
+    "replica_desc": "<b>Read Replica.</b> Offloads READ traffic from master DB. Requires connection to a DB. <b>Upgradeable (Tiers 1-3).</b>",
+    "replica_full": "Read Replica",
+    "replica_desc_long": "Processes READ traffic faster than master DB (200ms vs 300ms). Must be connected to a SQL DB or NoSQL DB to function. Only accepts READ queries.",
+    "replica_flow": "Flow: Compute → Replica → DB or Cache → Replica → DB",
+    "replica_desc_short": "Offloads READ from DB ($100)",
+    "tip_read_replica": "Add a Read Replica to offload READ traffic from your overloaded DB",
+    // Smart Hints
+    "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
+    "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",
+    "hint_no_waf": "💡 Malicious traffic is getting through! Add a Firewall to block attacks.",
+    "hint_no_cache": "💡 Many requests are cacheable. A Memory Cache would reduce DB load!",
+    "hint_compute_overload": "💡 Your Compute nodes are overwhelmed. Add a Message Queue to buffer requests.",
+    "hint_no_cdn": "💡 High static traffic! A CDN can serve it without hitting your servers.",
+    "hint_dismiss": "Dismiss",
+    // Traffic shifts
+    "shift_read_heavy": "Read Heavy",
+    "shift_full_text_flood": "Full-Text Flood"
 };

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -438,5 +438,36 @@ const FR_TRANSLATIONS = {
     "tip_apigw": "Ajoutez une passerelle API pour une dégradation gracieuse pendant les pics de trafic",
     "tip_nosql": "Utilisez NoSQL pour READ/WRITE plus rapide, gardez SQL pour les requêtes SEARCH",
     "apigw_desc_short": "Limite le trafic ($70)",
-    "nosql_desc_short": "DB READ/WRITE rapide ($80)"
+    "nosql_desc_short": "DB READ/WRITE rapide ($80)",
+    // Search Engine
+    "search": "Search Engine",
+    "search_short": "Search",
+    "search_engine": "Search Engine",
+    "search_desc": "<b>Search Engine.</b> Specialized for SEARCH queries. 3× faster than SQL DB. <b>Upgradeable (Tiers 1-3).</b>",
+    "search_full": "Search Engine",
+    "search_desc_long": "Processes SEARCH traffic 3× faster than SQL DB (100ms vs 300ms). Only accepts SEARCH queries — other traffic types will fail. Upgrade tiers for higher capacity (12/25/40).",
+    "search_flow": "Flow: Compute → Search Engine or Cache → Search Engine",
+    "search_desc_short": "Fast SEARCH queries ($120)",
+    "tip_search_engine": "Add a Search Engine to handle SEARCH queries faster than SQL DB",
+    // Read Replica
+    "replica": "Read Replica",
+    "replica_short": "Replica",
+    "read_replica": "Read Replica",
+    "replica_desc": "<b>Read Replica.</b> Offloads READ traffic from master DB. Requires connection to a DB. <b>Upgradeable (Tiers 1-3).</b>",
+    "replica_full": "Read Replica",
+    "replica_desc_long": "Processes READ traffic faster than master DB (200ms vs 300ms). Must be connected to a SQL DB or NoSQL DB to function. Only accepts READ queries.",
+    "replica_flow": "Flow: Compute → Replica → DB or Cache → Replica → DB",
+    "replica_desc_short": "Offloads READ from DB ($100)",
+    "tip_read_replica": "Add a Read Replica to offload READ traffic from your overloaded DB",
+    // Smart Hints
+    "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
+    "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",
+    "hint_no_waf": "💡 Malicious traffic is getting through! Add a Firewall to block attacks.",
+    "hint_no_cache": "💡 Many requests are cacheable. A Memory Cache would reduce DB load!",
+    "hint_compute_overload": "💡 Your Compute nodes are overwhelmed. Add a Message Queue to buffer requests.",
+    "hint_no_cdn": "💡 High static traffic! A CDN can serve it without hitting your servers.",
+    "hint_dismiss": "Dismiss",
+    // Traffic shifts
+    "shift_read_heavy": "Read Heavy",
+    "shift_full_text_flood": "Full-Text Flood"
 };

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -390,5 +390,36 @@ const KO_TRANSLATIONS = {
     "tip_nosql": "READ/WRITE에는 NoSQL을 사용하고 SEARCH 쿼리에는 SQL을 유지하세요",
     "apigw_desc_short": "트래픽 속도 제한 ($70)",
     "nosql_desc_short": "빠른 READ/WRITE DB ($80)",
-    "max": "최대"
+    "max": "최대",
+    // Search Engine
+    "search": "Search Engine",
+    "search_short": "Search",
+    "search_engine": "Search Engine",
+    "search_desc": "<b>Search Engine.</b> Specialized for SEARCH queries. 3× faster than SQL DB. <b>Upgradeable (Tiers 1-3).</b>",
+    "search_full": "Search Engine",
+    "search_desc_long": "Processes SEARCH traffic 3× faster than SQL DB (100ms vs 300ms). Only accepts SEARCH queries — other traffic types will fail. Upgrade tiers for higher capacity (12/25/40).",
+    "search_flow": "Flow: Compute → Search Engine or Cache → Search Engine",
+    "search_desc_short": "Fast SEARCH queries ($120)",
+    "tip_search_engine": "Add a Search Engine to handle SEARCH queries faster than SQL DB",
+    // Read Replica
+    "replica": "Read Replica",
+    "replica_short": "Replica",
+    "read_replica": "Read Replica",
+    "replica_desc": "<b>Read Replica.</b> Offloads READ traffic from master DB. Requires connection to a DB. <b>Upgradeable (Tiers 1-3).</b>",
+    "replica_full": "Read Replica",
+    "replica_desc_long": "Processes READ traffic faster than master DB (200ms vs 300ms). Must be connected to a SQL DB or NoSQL DB to function. Only accepts READ queries.",
+    "replica_flow": "Flow: Compute → Replica → DB or Cache → Replica → DB",
+    "replica_desc_short": "Offloads READ from DB ($100)",
+    "tip_read_replica": "Add a Read Replica to offload READ traffic from your overloaded DB",
+    // Smart Hints
+    "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
+    "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",
+    "hint_no_waf": "💡 Malicious traffic is getting through! Add a Firewall to block attacks.",
+    "hint_no_cache": "💡 Many requests are cacheable. A Memory Cache would reduce DB load!",
+    "hint_compute_overload": "💡 Your Compute nodes are overwhelmed. Add a Message Queue to buffer requests.",
+    "hint_no_cdn": "💡 High static traffic! A CDN can serve it without hitting your servers.",
+    "hint_dismiss": "Dismiss",
+    // Traffic shifts
+    "shift_read_heavy": "Read Heavy",
+    "shift_full_text_flood": "Full-Text Flood"
 };

--- a/src/locales/nep.js
+++ b/src/locales/nep.js
@@ -438,5 +438,36 @@ const NE_TRANSLATIONS = {
     "tip_apigw": "ट्राफिक स्पाइकको समयमा सुन्दर गिरावटको लागि API गेटवे थप्नुहोस्",
     "tip_nosql": "छिटो READ/WRITE को लागि NoSQL प्रयोग गर्नुहोस्, SEARCH प्रश्नहरूको लागि SQL राख्नुहोस्",
     "apigw_desc_short": "ट्राफिक दर सीमित गर्छ ($70)",
-    "nosql_desc_short": "छिटो READ/WRITE DB ($80)"
+    "nosql_desc_short": "छिटो READ/WRITE DB ($80)",
+    // Search Engine
+    "search": "Search Engine",
+    "search_short": "Search",
+    "search_engine": "Search Engine",
+    "search_desc": "<b>Search Engine.</b> Specialized for SEARCH queries. 3× faster than SQL DB. <b>Upgradeable (Tiers 1-3).</b>",
+    "search_full": "Search Engine",
+    "search_desc_long": "Processes SEARCH traffic 3× faster than SQL DB (100ms vs 300ms). Only accepts SEARCH queries — other traffic types will fail. Upgrade tiers for higher capacity (12/25/40).",
+    "search_flow": "Flow: Compute → Search Engine or Cache → Search Engine",
+    "search_desc_short": "Fast SEARCH queries ($120)",
+    "tip_search_engine": "Add a Search Engine to handle SEARCH queries faster than SQL DB",
+    // Read Replica
+    "replica": "Read Replica",
+    "replica_short": "Replica",
+    "read_replica": "Read Replica",
+    "replica_desc": "<b>Read Replica.</b> Offloads READ traffic from master DB. Requires connection to a DB. <b>Upgradeable (Tiers 1-3).</b>",
+    "replica_full": "Read Replica",
+    "replica_desc_long": "Processes READ traffic faster than master DB (200ms vs 300ms). Must be connected to a SQL DB or NoSQL DB to function. Only accepts READ queries.",
+    "replica_flow": "Flow: Compute → Replica → DB or Cache → Replica → DB",
+    "replica_desc_short": "Offloads READ from DB ($100)",
+    "tip_read_replica": "Add a Read Replica to offload READ traffic from your overloaded DB",
+    // Smart Hints
+    "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
+    "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",
+    "hint_no_waf": "💡 Malicious traffic is getting through! Add a Firewall to block attacks.",
+    "hint_no_cache": "💡 Many requests are cacheable. A Memory Cache would reduce DB load!",
+    "hint_compute_overload": "💡 Your Compute nodes are overwhelmed. Add a Message Queue to buffer requests.",
+    "hint_no_cdn": "💡 High static traffic! A CDN can serve it without hitting your servers.",
+    "hint_dismiss": "Dismiss",
+    // Traffic shifts
+    "shift_read_heavy": "Read Heavy",
+    "shift_full_text_flood": "Full-Text Flood"
 };

--- a/src/locales/pt-BR.js
+++ b/src/locales/pt-BR.js
@@ -447,5 +447,36 @@ const PT_BR_TRANSLATIONS = {
     "tip_apigw": "Adicione API Gateway para degradação suave durante picos de tráfego",
     "tip_nosql": "Use NoSQL para READ/WRITE mais rápido, mantenha SQL para consultas SEARCH",
     "apigw_desc_short": "Limita Taxa de Tráfego ($70)",
-    "nosql_desc_short": "BD Rápida READ/WRITE ($80)"
+    "nosql_desc_short": "BD Rápida READ/WRITE ($80)",
+    // Search Engine
+    "search": "Search Engine",
+    "search_short": "Search",
+    "search_engine": "Search Engine",
+    "search_desc": "<b>Search Engine.</b> Specialized for SEARCH queries. 3× faster than SQL DB. <b>Upgradeable (Tiers 1-3).</b>",
+    "search_full": "Search Engine",
+    "search_desc_long": "Processes SEARCH traffic 3× faster than SQL DB (100ms vs 300ms). Only accepts SEARCH queries — other traffic types will fail. Upgrade tiers for higher capacity (12/25/40).",
+    "search_flow": "Flow: Compute → Search Engine or Cache → Search Engine",
+    "search_desc_short": "Fast SEARCH queries ($120)",
+    "tip_search_engine": "Add a Search Engine to handle SEARCH queries faster than SQL DB",
+    // Read Replica
+    "replica": "Read Replica",
+    "replica_short": "Replica",
+    "read_replica": "Read Replica",
+    "replica_desc": "<b>Read Replica.</b> Offloads READ traffic from master DB. Requires connection to a DB. <b>Upgradeable (Tiers 1-3).</b>",
+    "replica_full": "Read Replica",
+    "replica_desc_long": "Processes READ traffic faster than master DB (200ms vs 300ms). Must be connected to a SQL DB or NoSQL DB to function. Only accepts READ queries.",
+    "replica_flow": "Flow: Compute → Replica → DB or Cache → Replica → DB",
+    "replica_desc_short": "Offloads READ from DB ($100)",
+    "tip_read_replica": "Add a Read Replica to offload READ traffic from your overloaded DB",
+    // Smart Hints
+    "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
+    "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",
+    "hint_no_waf": "💡 Malicious traffic is getting through! Add a Firewall to block attacks.",
+    "hint_no_cache": "💡 Many requests are cacheable. A Memory Cache would reduce DB load!",
+    "hint_compute_overload": "💡 Your Compute nodes are overwhelmed. Add a Message Queue to buffer requests.",
+    "hint_no_cdn": "💡 High static traffic! A CDN can serve it without hitting your servers.",
+    "hint_dismiss": "Dismiss",
+    // Traffic shifts
+    "shift_read_heavy": "Read Heavy",
+    "shift_full_text_flood": "Full-Text Flood"
 };

--- a/src/locales/zh.js
+++ b/src/locales/zh.js
@@ -446,5 +446,36 @@ const ZH_TRANSLATIONS = {
     "tip_apigw": "添加API网关以在流量高峰时优雅降级",
     "tip_nosql": "使用NoSQL加速READ/WRITE，保留SQL处理SEARCH查询",
     "apigw_desc_short": "限制流量速率 ($70)",
-    "nosql_desc_short": "快速读写数据库 ($80)"
+    "nosql_desc_short": "快速读写数据库 ($80)",
+    // Search Engine
+    "search": "Search Engine",
+    "search_short": "Search",
+    "search_engine": "Search Engine",
+    "search_desc": "<b>Search Engine.</b> Specialized for SEARCH queries. 3× faster than SQL DB. <b>Upgradeable (Tiers 1-3).</b>",
+    "search_full": "Search Engine",
+    "search_desc_long": "Processes SEARCH traffic 3× faster than SQL DB (100ms vs 300ms). Only accepts SEARCH queries — other traffic types will fail. Upgrade tiers for higher capacity (12/25/40).",
+    "search_flow": "Flow: Compute → Search Engine or Cache → Search Engine",
+    "search_desc_short": "Fast SEARCH queries ($120)",
+    "tip_search_engine": "Add a Search Engine to handle SEARCH queries faster than SQL DB",
+    // Read Replica
+    "replica": "Read Replica",
+    "replica_short": "Replica",
+    "read_replica": "Read Replica",
+    "replica_desc": "<b>Read Replica.</b> Offloads READ traffic from master DB. Requires connection to a DB. <b>Upgradeable (Tiers 1-3).</b>",
+    "replica_full": "Read Replica",
+    "replica_desc_long": "Processes READ traffic faster than master DB (200ms vs 300ms). Must be connected to a SQL DB or NoSQL DB to function. Only accepts READ queries.",
+    "replica_flow": "Flow: Compute → Replica → DB or Cache → Replica → DB",
+    "replica_desc_short": "Offloads READ from DB ($100)",
+    "tip_read_replica": "Add a Read Replica to offload READ traffic from your overloaded DB",
+    // Smart Hints
+    "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
+    "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",
+    "hint_no_waf": "💡 Malicious traffic is getting through! Add a Firewall to block attacks.",
+    "hint_no_cache": "💡 Many requests are cacheable. A Memory Cache would reduce DB load!",
+    "hint_compute_overload": "💡 Your Compute nodes are overwhelmed. Add a Message Queue to buffer requests.",
+    "hint_no_cdn": "💡 High static traffic! A CDN can serve it without hitting your servers.",
+    "hint_dismiss": "Dismiss",
+    // Traffic shifts
+    "shift_read_heavy": "Read Heavy",
+    "shift_full_text_flood": "Full-Text Flood"
 };


### PR DESCRIPTION
## Summary
- New **Search Engine** service ($120): specialized SEARCH handler, 3x faster than SQL DB, upgradeable (3 tiers)
- New **Read Replica** service ($100): offloads READ from master DB, requires DB connection, upgradeable (3 tiers)
- **Smart hints system**: contextual suggestions when architecture is suboptimal (e.g. "DB overloaded with SEARCH — add a Search Engine!")
- **Economy rebalance**: starting budget $420→$500, SEARCH reward 0.8→1.2
- **2 new traffic shifts**: "Read Heavy" (45% READ) and "Full-Text Flood" (55% SEARCH)
- FAQ, finances tracking, and i18n updates for all new content (7 locales)

## New Routing

```
SEARCH → Search Engine (preferred) → SQL DB (fallback)
READ   → Cache → Read Replica (preferred) → NoSQL → SQL DB (fallback)
WRITE  → NoSQL → SQL DB (fallback)
```

## Test Plan
- [x] Game loads without JS errors
- [x] Search Engine places (cyan dodecahedron), routes SEARCH traffic
- [x] Read Replica places (pink cylinder), routes READ traffic
- [x] Service Health and Finances track both new services
- [x] Starting budget is $500 in survival mode
- [x] SEARCH reward increased to 1.2
- [x] All 6 traffic shifts work (including 2 new ones)
- [x] Both services have 3 upgrade tiers
- [x] All 7 locales load without errors