### PR TITLE
feat: add Serverless Function compute variant (#144)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Build your architecture using the toolbar. Each service has a cost, capacity, an
 | **Queue**        | $45  | Queue:200 | Low       | **Buffer.** Buffers requests during spikes. Prevents drops.           |
 | **Load Balancer**| $50  | 20        | Medium    | **Distribution.** Distributes traffic to multiple instances.          |
 | **Compute**      | $60  | 4         | High      | **Processing.** Processes requests. **Upgradeable T1→T3.**            |
+| **Serverless Function** | $45 | 30 (auto) | Very Low + $0.03/req | **Pay-per-use Compute.** Auto-scales with traffic. Low upkeep, but charges $0.03 per request. Cheap when idle, expensive at high RPS. |
 | **CDN**          | $60  | 50        | Low       | **Delivery.** Caches STATIC content at edge (95% hit rate).           |
 | **SQL DB**       | $150 | 8         | Very High | **Database.** Handles READ/WRITE/SEARCH. **Upgradeable T1→T3.**      |
 | **NoSQL DB**     | $80  | 15        | High      | **Fast Database.** Handles READ/WRITE only (no SEARCH). **Upgradeable T1→T3.** |
@@ -108,6 +109,11 @@ A fully customizable testing environment for experimenting with any architecture
 
 **No game over in Sandbox** - experiment freely!
 
+### Recent Features (v2.3)
+
+- **Serverless Function** - Pay-per-use compute variant ($45 to place, $2/min upkeep, $0.03 per completed request). Auto-scales to capacity 30 with a 900ms cold-start processing time. Same routing topology as Compute (ALB/Queue/API Gateway upstream; Cache/DB/NoSQL/S3/Search/Replica downstream).
+- **Cost-aware Smart Hint** - Warns when a Serverless node's per-request cost is adding up at high RPS, nudging players toward a Compute node for sustained throughput.
+
 ### Recent Features (v2.2)
 
 - **Search Engine** - Specialized SEARCH handler, 3x faster than SQL DB (100ms vs 300ms). Upgradeable (Tiers 1-3: 12/25/40 capacity)
@@ -158,6 +164,7 @@ A fully customizable testing environment for experimenting with any architecture
 10. **Split DB Traffic with NoSQL:** Route READ/WRITE to NoSQL (faster, cheaper) and keep SQL DB for SEARCH queries only.
 11. **Search Engine for SEARCH Storms:** SEARCH is the heaviest traffic type (2.5x weight). A dedicated Search Engine processes it 3x faster than SQL DB.
 12. **Read Replica for READ offloading:** Under "API Heavy" or "Read Heavy" shifts, a Read Replica prevents your main DB from drowning in READ requests.
+13. **Serverless Function = pay-per-use:** Great for spiky traffic, but monitor finances — per-request cost ($0.03) adds up fast at high RPS.
 
 ## Tech Stack
 

--- a/game.js
+++ b/game.js
@@ -712,6 +712,12 @@ function updateFinancesDisplay() {
             cost: CONFIG.services.replica.cost,
         },
         {
+            key: "serverless",
+            label: i18n.t('serverless'),
+            color: "text-amber-400",
+            cost: CONFIG.services.serverless.cost,
+        },
+        {
             key: "apigw",
             label: i18n.t('apigw'),
             color: "text-fuchsia-400",
@@ -854,6 +860,12 @@ function checkSmartHints() {
   } else if (!hasCdn && STATE.trafficDistribution.STATIC > 0.3 &&
       !STATE.hints.dismissedHints.has("cdn")) {
     hint = { key: "hint_no_cdn", id: "cdn" };
+  } else if (
+    STATE.services.some(s => s.type === "serverless") &&
+    STATE.currentRPS > 8 &&
+    !STATE.hints.dismissedHints.has("serverless_expensive")
+  ) {
+    hint = { key: "hint_serverless_expensive", id: "serverless_expensive" };
   }
 
   if (hint) {
@@ -1085,6 +1097,7 @@ function resetGame(mode = "survival") {
                 apigw: 0,
                 nosql: 0,
                 cdn: 0,
+                serverless: 0,
             },
             countByService: {
                 // Count of each service purchased
@@ -1100,6 +1113,7 @@ function resetGame(mode = "survival") {
                 nosql: 0,
                 cdn: 0,
                 replica: 0,
+                serverless: 0,
             },
         },
     };
@@ -1674,6 +1688,16 @@ function createConnection(fromId, toId) {
     else if (t1 === "cache" && t2 === "replica") valid = true;
     else if (t1 === "replica" && t2 === "db") valid = true;
     else if (t1 === "replica" && t2 === "nosql") valid = true;
+    // Serverless Function connections (same topology as Compute)
+    else if (t1 === "alb" && t2 === "serverless") valid = true;
+    else if (t1 === "sqs" && t2 === "serverless") valid = true;
+    else if (t1 === "apigw" && t2 === "serverless") valid = true;
+    else if (t1 === "serverless" && t2 === "cache") valid = true;
+    else if (t1 === "serverless" && t2 === "db") valid = true;
+    else if (t1 === "serverless" && t2 === "nosql") valid = true;
+    else if (t1 === "serverless" && t2 === "s3") valid = true;
+    else if (t1 === "serverless" && t2 === "search") valid = true;
+    else if (t1 === "serverless" && t2 === "replica") valid = true;
 
     if (!valid) {
         new Audio("assets/sounds/click-9.mp3").play();
@@ -2030,7 +2054,7 @@ container.addEventListener("mousedown", (e) => {
             new Audio("assets/sounds/click-5.mp3").play();
         }
     } else if (
-        ["waf", "alb", "lambda", "db", "nosql", "s3", "sqs", "cache", "cdn", "apigw", "search", "replica"].includes(
+        ["waf", "alb", "lambda", "db", "nosql", "s3", "sqs", "cache", "cdn", "apigw", "search", "replica", "serverless"].includes(
             STATE.activeTool
         )
     ) {
@@ -2073,6 +2097,7 @@ container.addEventListener("mousedown", (e) => {
                 cdn: "cdn",
                 search: "search",
                 replica: "replica",
+                serverless: "serverless",
             };
 
             const serviceType = typeMap[STATE.activeTool];
@@ -2378,7 +2403,7 @@ function showTooltip(x, y, html) {
 
 // Setup UI tooltips
 function setupUITooltips() {
-    const tools = ["waf", "apigw", "sqs", "alb", "lambda", "db", "nosql", "cache", "s3", "cdn", "search", "replica"];
+    const tools = ["waf", "apigw", "sqs", "alb", "lambda", "db", "nosql", "cache", "s3", "cdn", "search", "replica", "serverless"];
     tools.forEach((toolId) => {
         const btn = document.getElementById(`tool-${toolId}`);
         if (!btn) return;
@@ -3349,8 +3374,8 @@ function loadGameState(saveData = null) {
                 autoRepair: 0,
                 mitigation: 0,
                 breach: 0,
-                byService: { waf: 0, alb: 0, compute: 0, db: 0, s3: 0, cache: 0, sqs: 0, search: 0, replica: 0, apigw: 0, nosql: 0, cdn: 0 },
-                countByService: { waf: 0, alb: 0, compute: 0, db: 0, s3: 0, cache: 0, sqs: 0, search: 0, replica: 0, apigw: 0, nosql: 0, cdn: 0 },
+                byService: { waf: 0, alb: 0, compute: 0, db: 0, s3: 0, cache: 0, sqs: 0, search: 0, replica: 0, apigw: 0, nosql: 0, cdn: 0, serverless: 0 },
+                countByService: { waf: 0, alb: 0, compute: 0, db: 0, s3: 0, cache: 0, sqs: 0, search: 0, replica: 0, apigw: 0, nosql: 0, cdn: 0, serverless: 0 },
             },
         };
 

--- a/index.html
+++ b/index.html
@@ -617,6 +617,17 @@
           <span data-i18n="compute_short" class="text-[10px] font-bold mt-1">Compute</span>
         </button>
 
+        <!-- Serverless Function -->
+        <button id="tool-serverless"
+          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
+          onclick="setTool('serverless')">
+          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
+            $45
+          </div>
+          <div class="w-0 h-0 border-l-[8px] border-l-transparent border-r-[8px] border-r-transparent border-b-[14px] border-b-amber-400 mb-1 shadow-[0_0_10px_rgba(251,191,36,0.6)]"></div>
+          <span data-i18n="serverless_short" class="text-[10px] font-bold mt-1">λ Func</span>
+        </button>
+
         <button id="tool-db"
           class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
           onclick="setTool('db')">
@@ -983,6 +994,10 @@
               <span data-i18n="compute_desc_short">Processes Requests ($60)</span>
             </li>
             <li class="flex justify-between">
+              <span data-i18n="serverless" class="text-amber-400 font-bold">Serverless Function</span>
+              <span data-i18n="serverless_desc_short">Pay-per-use compute ($45)</span>
+            </li>
+            <li class="flex justify-between">
               <span data-i18n="relational_db" class="text-red-400 font-bold">Relational DB</span>
               <span data-i18n="db_desc_short">Stores API Data ($150)</span>
             </li>
@@ -1185,6 +1200,16 @@
               Processes READ traffic faster than master DB (200ms vs 300ms). Must be connected to a SQL DB or NoSQL DB to function. Only accepts READ queries.
             </p>
             <p data-i18n="replica_flow" class="text-xs text-gray-500 mt-1">Flow: Compute → Replica → DB or Cache → Replica → DB</p>
+          </div>
+          <div class="bg-gray-800/50 p-3 rounded border border-amber-900/50">
+            <div class="flex justify-between items-center">
+              <strong data-i18n="serverless_full" class="text-amber-400">Serverless Function</strong>
+              <span class="text-green-400 font-mono text-sm">$45</span>
+            </div>
+            <p data-i18n="serverless_desc_long" class="text-sm text-gray-400 mt-1">
+              Auto-scales with traffic (capacity 30). Very low upkeep ($2/min) but charges $0.03 per completed request. Cheap for bursty / low-volume traffic; expensive at sustained high RPS. Same connection topology as Compute.
+            </p>
+            <p data-i18n="serverless_flow" class="text-xs text-gray-500 mt-1">Flow: ALB / Queue → Serverless → Cache / DB / NoSQL / S3</p>
           </div>
         </div>
       </div>

--- a/src/config.js
+++ b/src/config.js
@@ -27,6 +27,7 @@ const CONFIG = {
     nosql: 0x7c3aed, // Violet for NoSQL
     search: 0x06b6d4, // Cyan-500 for Search Engine
     replica: 0xf472b6, // Pink-400 for Read Replica
+    serverless: 0xfbbf24, // amber - lambda style
   },
   trafficTypes: {
     STATIC: {
@@ -280,6 +281,19 @@ const CONFIG = {
         { level: 2, capacity: 24, cost: 130 },
         { level: 3, capacity: 40, cost: 200 },
       ],
+    },
+    serverless: {
+      name: "Serverless Function",
+      cost: 45,
+      type: "serverless",
+      processingTime: 900,
+      capacity: 30,
+      upkeep: 2,
+      perRequestCost: 0.03,
+      tooltip: {
+        upkeep: "Very Low",
+        desc: "<b>Serverless Function.</b> Auto-scales with traffic. Very low upkeep but pays $0.03 per completed request. Great for spiky / low-volume traffic, expensive at high RPS.",
+      },
     },
   },
   survival: {

--- a/src/entities/Service.js
+++ b/src/entities/Service.js
@@ -98,6 +98,13 @@ class Service {
           roughness: 0.3,
         });
         break;
+      case "serverless":
+        geo = new THREE.TetrahedronGeometry(1.8, 0);
+        mat = new THREE.MeshStandardMaterial({
+          color: CONFIG.colors.serverless,
+          ...materialProps,
+        });
+        break;
     }
 
     this.mesh = new THREE.Mesh(geo, mat);
@@ -114,6 +121,7 @@ class Service {
     else if (type === "nosql") this.mesh.position.y += 1;
     else if (type === "search") this.mesh.position.y += 1.5;
     else if (type === "replica") this.mesh.position.y += 1;
+    else if (type === "serverless") this.mesh.position.y += 1.5;
     else this.mesh.position.y += 1;
 
     this.mesh.castShadow = true;
@@ -308,8 +316,8 @@ class Service {
       }
     }
 
-    // COMPUTE PULL LOGIC
-    if (this.type === "compute") {
+    // COMPUTE / SERVERLESS PULL LOGIC
+    if (this.type === "compute" || this.type === "serverless") {
       // Check if we have space in our queue+processing
       // We want the UPSTREAM queue (SQS) to do the buffering, not the compute node local queue.
       // So we only pull if we are running low on work locally.
@@ -354,7 +362,7 @@ class Service {
       let job = this.processing[i];
 
       const processingTime =
-        this.type === "compute"
+        this.type === "compute" || this.type === "serverless"
           ? this.config.processingTime * job.req.processingWeight
           : this.config.processingTime;
 
@@ -371,6 +379,16 @@ class Service {
             : 0;
         const totalFailChance = Math.min(1, failChance + healthPenalty);
         if (Math.random() < totalFailChance) {
+          // Serverless pays per invocation even when the function errors out
+          if (this.type === "serverless") {
+            const cost = this.config.perRequestCost || 0;
+            STATE.money -= cost;
+            if (STATE.finances) {
+              STATE.finances.expenses.upkeep += cost;
+              STATE.finances.expenses.byService.serverless =
+                (STATE.finances.expenses.byService.serverless || 0) + cost;
+            }
+          }
           failRequest(job.req);
           continue;
         }
@@ -577,10 +595,24 @@ class Service {
           continue;
         }
 
-        if (this.type === "compute") {
+        if (this.type === "compute" || this.type === "serverless") {
+          // Per-request cost for serverless (AWS Lambda style - charged per invocation,
+          // including failed ones since you still pay for execution time)
+          const chargePerRequest = () => {
+            if (this.type !== "serverless") return;
+            const cost = this.config.perRequestCost || 0;
+            STATE.money -= cost;
+            if (STATE.finances) {
+              STATE.finances.expenses.upkeep += cost;
+              STATE.finances.expenses.byService.serverless =
+                (STATE.finances.expenses.byService.serverless || 0) + cost;
+            }
+          };
+
           const destType = job.req.destination;
 
           if (destType === "blocked") {
+            chargePerRequest();
             failRequest(job.req);
             continue;
           }
@@ -588,6 +620,7 @@ class Service {
           if (job.req.isCacheable) {
             const cacheTarget = this.findConnectedService("cache");
             if (cacheTarget) {
+              chargePerRequest();
               job.req.flyTo(cacheTarget);
               continue;
             }
@@ -597,30 +630,33 @@ class Service {
           if (destType === "db") {
             if (job.req.type === "SEARCH") {
               const searchTarget = this.findConnectedService("search");
-              if (searchTarget) { job.req.flyTo(searchTarget); continue; }
+              if (searchTarget) { chargePerRequest(); job.req.flyTo(searchTarget); continue; }
               const sqlTarget = this.findConnectedService("db");
-              if (sqlTarget) { job.req.flyTo(sqlTarget); continue; }
+              if (sqlTarget) { chargePerRequest(); job.req.flyTo(sqlTarget); continue; }
             } else if (job.req.type === "READ") {
               const replicaTarget = this.findConnectedService("replica");
-              if (replicaTarget) { job.req.flyTo(replicaTarget); continue; }
+              if (replicaTarget) { chargePerRequest(); job.req.flyTo(replicaTarget); continue; }
               const nosqlTarget = this.findConnectedService("nosql");
-              if (nosqlTarget) { job.req.flyTo(nosqlTarget); continue; }
+              if (nosqlTarget) { chargePerRequest(); job.req.flyTo(nosqlTarget); continue; }
               const sqlTarget = this.findConnectedService("db");
-              if (sqlTarget) { job.req.flyTo(sqlTarget); continue; }
+              if (sqlTarget) { chargePerRequest(); job.req.flyTo(sqlTarget); continue; }
             } else {
               const nosqlTarget = this.findConnectedService("nosql");
-              if (nosqlTarget) { job.req.flyTo(nosqlTarget); continue; }
+              if (nosqlTarget) { chargePerRequest(); job.req.flyTo(nosqlTarget); continue; }
               const sqlTarget = this.findConnectedService("db");
-              if (sqlTarget) { job.req.flyTo(sqlTarget); continue; }
+              if (sqlTarget) { chargePerRequest(); job.req.flyTo(sqlTarget); continue; }
             }
+            chargePerRequest();
             failRequest(job.req);
             continue;
           }
 
           const directTarget = this.findConnectedService(destType);
           if (directTarget) {
+            chargePerRequest();
             job.req.flyTo(directTarget);
           } else {
+            chargePerRequest();
             failRequest(job.req);
           }
         } else {

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -459,6 +459,16 @@ const DE_TRANSLATIONS = {
     "replica_flow": "Flow: Compute → Replica → DB or Cache → Replica → DB",
     "replica_desc_short": "Offloads READ from DB ($100)",
     "tip_read_replica": "Add a Read Replica to offload READ traffic from your overloaded DB",
+    // Serverless Function
+    "serverless": "Serverless Function",
+    "serverless_short": "λ Func",
+    "serverless_desc": "<b>Serverless Function.</b> Auto-scales with traffic. Very low upkeep but pays $0.03 per completed request.",
+    "serverless_full": "Serverless Function",
+    "serverless_desc_long": "Auto-scales with traffic (capacity 30). Very low upkeep ($2/min) but charges $0.03 per completed request. Cheap for bursty / low-volume traffic; expensive at sustained high RPS. Same connection topology as Compute.",
+    "serverless_flow": "Flow: ALB / Queue → Serverless → Cache / DB / NoSQL / S3",
+    "serverless_desc_short": "Pay-per-use compute ($45)",
+    "tip_serverless": "Serverless is cheap when idle but pays per request — pair it with CDN/Cache to keep invocations low",
+    "hint_serverless_expensive": "💡 Your Serverless is racking up per-request costs at this RPS. Consider adding a Compute node for cheaper sustained throughput.",
     // Smart Hints
     "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
     "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -458,6 +458,16 @@ const EN_TRANSLATIONS = {
     "replica_flow": "Flow: Compute → Replica → DB or Cache → Replica → DB",
     "replica_desc_short": "Offloads READ from DB ($100)",
     "tip_read_replica": "Add a Read Replica to offload READ traffic from your overloaded DB",
+    // Serverless Function
+    "serverless": "Serverless Function",
+    "serverless_short": "λ Func",
+    "serverless_desc": "<b>Serverless Function.</b> Auto-scales with traffic. Very low upkeep but pays $0.03 per completed request.",
+    "serverless_full": "Serverless Function",
+    "serverless_desc_long": "Auto-scales with traffic (capacity 30). Very low upkeep ($2/min) but charges $0.03 per completed request. Cheap for bursty / low-volume traffic; expensive at sustained high RPS. Same connection topology as Compute.",
+    "serverless_flow": "Flow: ALB / Queue → Serverless → Cache / DB / NoSQL / S3",
+    "serverless_desc_short": "Pay-per-use compute ($45)",
+    "tip_serverless": "Serverless is cheap when idle but pays per request — pair it with CDN/Cache to keep invocations low",
+    "hint_serverless_expensive": "💡 Your Serverless is racking up per-request costs at this RPS. Consider adding a Compute node for cheaper sustained throughput.",
     // Smart Hints
     "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
     "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -459,6 +459,16 @@ const FR_TRANSLATIONS = {
     "replica_flow": "Flow: Compute → Replica → DB or Cache → Replica → DB",
     "replica_desc_short": "Offloads READ from DB ($100)",
     "tip_read_replica": "Add a Read Replica to offload READ traffic from your overloaded DB",
+    // Serverless Function
+    "serverless": "Serverless Function",
+    "serverless_short": "λ Func",
+    "serverless_desc": "<b>Serverless Function.</b> Auto-scales with traffic. Very low upkeep but pays $0.03 per completed request.",
+    "serverless_full": "Serverless Function",
+    "serverless_desc_long": "Auto-scales with traffic (capacity 30). Very low upkeep ($2/min) but charges $0.03 per completed request. Cheap for bursty / low-volume traffic; expensive at sustained high RPS. Same connection topology as Compute.",
+    "serverless_flow": "Flow: ALB / Queue → Serverless → Cache / DB / NoSQL / S3",
+    "serverless_desc_short": "Pay-per-use compute ($45)",
+    "tip_serverless": "Serverless is cheap when idle but pays per request — pair it with CDN/Cache to keep invocations low",
+    "hint_serverless_expensive": "💡 Your Serverless is racking up per-request costs at this RPS. Consider adding a Compute node for cheaper sustained throughput.",
     // Smart Hints
     "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
     "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -411,6 +411,16 @@ const KO_TRANSLATIONS = {
     "replica_flow": "Flow: Compute → Replica → DB or Cache → Replica → DB",
     "replica_desc_short": "Offloads READ from DB ($100)",
     "tip_read_replica": "Add a Read Replica to offload READ traffic from your overloaded DB",
+    // Serverless Function
+    "serverless": "Serverless Function",
+    "serverless_short": "λ Func",
+    "serverless_desc": "<b>Serverless Function.</b> Auto-scales with traffic. Very low upkeep but pays $0.03 per completed request.",
+    "serverless_full": "Serverless Function",
+    "serverless_desc_long": "Auto-scales with traffic (capacity 30). Very low upkeep ($2/min) but charges $0.03 per completed request. Cheap for bursty / low-volume traffic; expensive at sustained high RPS. Same connection topology as Compute.",
+    "serverless_flow": "Flow: ALB / Queue → Serverless → Cache / DB / NoSQL / S3",
+    "serverless_desc_short": "Pay-per-use compute ($45)",
+    "tip_serverless": "Serverless is cheap when idle but pays per request — pair it with CDN/Cache to keep invocations low",
+    "hint_serverless_expensive": "💡 Your Serverless is racking up per-request costs at this RPS. Consider adding a Compute node for cheaper sustained throughput.",
     // Smart Hints
     "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
     "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",

--- a/src/locales/nep.js
+++ b/src/locales/nep.js
@@ -459,6 +459,16 @@ const NE_TRANSLATIONS = {
     "replica_flow": "Flow: Compute → Replica → DB or Cache → Replica → DB",
     "replica_desc_short": "Offloads READ from DB ($100)",
     "tip_read_replica": "Add a Read Replica to offload READ traffic from your overloaded DB",
+    // Serverless Function
+    "serverless": "Serverless Function",
+    "serverless_short": "λ Func",
+    "serverless_desc": "<b>Serverless Function.</b> Auto-scales with traffic. Very low upkeep but pays $0.03 per completed request.",
+    "serverless_full": "Serverless Function",
+    "serverless_desc_long": "Auto-scales with traffic (capacity 30). Very low upkeep ($2/min) but charges $0.03 per completed request. Cheap for bursty / low-volume traffic; expensive at sustained high RPS. Same connection topology as Compute.",
+    "serverless_flow": "Flow: ALB / Queue → Serverless → Cache / DB / NoSQL / S3",
+    "serverless_desc_short": "Pay-per-use compute ($45)",
+    "tip_serverless": "Serverless is cheap when idle but pays per request — pair it with CDN/Cache to keep invocations low",
+    "hint_serverless_expensive": "💡 Your Serverless is racking up per-request costs at this RPS. Consider adding a Compute node for cheaper sustained throughput.",
     // Smart Hints
     "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
     "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",

--- a/src/locales/pt-BR.js
+++ b/src/locales/pt-BR.js
@@ -468,6 +468,16 @@ const PT_BR_TRANSLATIONS = {
     "replica_flow": "Flow: Compute → Replica → DB or Cache → Replica → DB",
     "replica_desc_short": "Offloads READ from DB ($100)",
     "tip_read_replica": "Add a Read Replica to offload READ traffic from your overloaded DB",
+    // Serverless Function
+    "serverless": "Serverless Function",
+    "serverless_short": "λ Func",
+    "serverless_desc": "<b>Serverless Function.</b> Auto-scales with traffic. Very low upkeep but pays $0.03 per completed request.",
+    "serverless_full": "Serverless Function",
+    "serverless_desc_long": "Auto-scales with traffic (capacity 30). Very low upkeep ($2/min) but charges $0.03 per completed request. Cheap for bursty / low-volume traffic; expensive at sustained high RPS. Same connection topology as Compute.",
+    "serverless_flow": "Flow: ALB / Queue → Serverless → Cache / DB / NoSQL / S3",
+    "serverless_desc_short": "Pay-per-use compute ($45)",
+    "tip_serverless": "Serverless is cheap when idle but pays per request — pair it with CDN/Cache to keep invocations low",
+    "hint_serverless_expensive": "💡 Your Serverless is racking up per-request costs at this RPS. Consider adding a Compute node for cheaper sustained throughput.",
     // Smart Hints
     "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
     "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",

--- a/src/locales/zh.js
+++ b/src/locales/zh.js
@@ -467,6 +467,16 @@ const ZH_TRANSLATIONS = {
     "replica_flow": "Flow: Compute → Replica → DB or Cache → Replica → DB",
     "replica_desc_short": "Offloads READ from DB ($100)",
     "tip_read_replica": "Add a Read Replica to offload READ traffic from your overloaded DB",
+    // Serverless Function
+    "serverless": "Serverless Function",
+    "serverless_short": "λ Func",
+    "serverless_desc": "<b>Serverless Function.</b> Auto-scales with traffic. Very low upkeep but pays $0.03 per completed request.",
+    "serverless_full": "Serverless Function",
+    "serverless_desc_long": "Auto-scales with traffic (capacity 30). Very low upkeep ($2/min) but charges $0.03 per completed request. Cheap for bursty / low-volume traffic; expensive at sustained high RPS. Same connection topology as Compute.",
+    "serverless_flow": "Flow: ALB / Queue → Serverless → Cache / DB / NoSQL / S3",
+    "serverless_desc_short": "Pay-per-use compute ($45)",
+    "tip_serverless": "Serverless is cheap when idle but pays per request — pair it with CDN/Cache to keep invocations low",
+    "hint_serverless_expensive": "💡 Your Serverless is racking up per-request costs at this RPS. Consider adding a Compute node for cheaper sustained throughput.",
     // Smart Hints
     "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
     "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",


### PR DESCRIPTION
## Summary
Closes #144. Adds a pay-per-use compute node (**Serverless Function**) so players can compare always-on Compute vs serverless/lambda-style execution.

## What's new

| Property          | Compute    | Serverless Function |
|------------------:|:----------:|:-------------------:|
| cost              | $60       | $45                |
| upkeep / min      | 12         | 2 (very low)        |
| capacity          | 4 (T1)     | 30 (auto-scaled)    |
| processingTime    | 600ms      | 900ms (cold start)  |
| per-request cost  | 0          | **$0.03 / req**    |
| tiers             | yes        | no (managed)        |
| 3D shape          | cylinder   | amber tetrahedron   |

**Teaching moment:** cheap when idle / bursty, expensive at sustained high RPS. A new smart hint fires when `currentRPS > 8` and the player is running serverless, suggesting they add a Compute node.

Serverless uses the **same connection topology as Compute** (ALB / Queue / API Gateway upstream; Cache / DB / NoSQL / S3 / Search / Replica downstream), so existing architectures drop it in seamlessly.

## Test Plan
- [x] Toolbar button appears, places amber tetrahedron
- [x] All Compute-style connections work (sqs→serverless, serverless→db, etc.)
- [x] $0.03 deducted per request (success AND failure — matches AWS billing)
- [x] Finances panel shows serverless expenses
- [x] Smart hint 'hint_serverless_expensive' triggers at high RPS
- [x] No upgrade option (intentional — serverless auto-scales)
- [x] Save / load preserves serverless nodes