### PR TITLE
fix(campaign): remove unwinnable STATIC/UPLOAD doom traffic across 7 levels (closes #162)

### DIFF
--- a/src/campaign/levels.js
+++ b/src/campaign/levels.js
@@ -139,7 +139,10 @@ const CAMPAIGN_LEVELS = [
             ],
             connections: [["internet", 0], [0, 1], [1, 2], [2, 3]],
         },
-        trafficDistribution: { STATIC: 0.05, READ: 0.75, WRITE: 0.1, UPLOAD: 0, SEARCH: 0.05, MALICIOUS: 0.05 },
+        // STATIC has no destination on this level (no Storage/CDN in preBuilt, not in
+        // allowedServices) so any STATIC traffic was doomed to fail — moved to READ
+        // which is the actual lesson here. Same fix as Level 5 (see #159, #162).
+        trafficDistribution: { STATIC: 0, READ: 0.8, WRITE: 0.1, UPLOAD: 0, SEARCH: 0.05, MALICIOUS: 0.05 },
         rps: 6,
         allowedServices: ["cache"],
         objectives: {
@@ -211,7 +214,9 @@ const CAMPAIGN_LEVELS = [
             ],
             connections: [["internet", 0], [0, 1], [1, 2], [2, 4], [4, 3], [2, 3]],
         },
-        trafficDistribution: { STATIC: 0.1, READ: 0.45, WRITE: 0.15, UPLOAD: 0.05, SEARCH: 0.15, MALICIOUS: 0.1 },
+        // STATIC + UPLOAD have no destination on this level — moved into READ
+        // (the actual lesson is Read Replica offloading reads). Same fix as L5.
+        trafficDistribution: { STATIC: 0, READ: 0.6, WRITE: 0.15, UPLOAD: 0, SEARCH: 0.15, MALICIOUS: 0.1 },
         rps: 7,
         allowedServices: ["replica"],
         objectives: {
@@ -247,7 +252,9 @@ const CAMPAIGN_LEVELS = [
             ],
             connections: [["internet", 0], [0, 1], [1, 2], [2, 4], [4, 3], [2, 3]],
         },
-        trafficDistribution: { STATIC: 0.05, READ: 0.2, WRITE: 0.1, UPLOAD: 0.05, SEARCH: 0.5, MALICIOUS: 0.1 },
+        // STATIC + UPLOAD have no destination — moved into SEARCH which is the
+        // actual focus of this level (Search Engine for full-text queries).
+        trafficDistribution: { STATIC: 0, READ: 0.2, WRITE: 0.1, UPLOAD: 0, SEARCH: 0.6, MALICIOUS: 0.1 },
         rps: 6,
         allowedServices: ["search"],
         objectives: {
@@ -283,7 +290,9 @@ const CAMPAIGN_LEVELS = [
             ],
             connections: [["internet", 0], [0, 1], [1, 2], [2, 4], [4, 3], [2, 3]],
         },
-        trafficDistribution: { STATIC: 0.05, READ: 0.4, WRITE: 0.3, UPLOAD: 0.05, SEARCH: 0.1, MALICIOUS: 0.1 },
+        // STATIC + UPLOAD have no destination — split into READ/WRITE which is
+        // the actual lesson here (NoSQL is the alternative for transactional READs/WRITEs).
+        trafficDistribution: { STATIC: 0, READ: 0.45, WRITE: 0.35, UPLOAD: 0, SEARCH: 0.1, MALICIOUS: 0.1 },
         rps: 7,
         allowedServices: ["nosql"],
         objectives: {
@@ -318,7 +327,10 @@ const CAMPAIGN_LEVELS = [
             ],
             connections: [["internet", 0], [0, 1], [1, 2], [2, 3]],
         },
-        trafficDistribution: { STATIC: 0.1, READ: 0.4, WRITE: 0.2, UPLOAD: 0.05, SEARCH: 0.15, MALICIOUS: 0.1 },
+        // STATIC + UPLOAD have no destination — moved into READ. The lesson is
+        // API Gateway throttling under burst pressure, which is what 15% extra READ
+        // load lets us demonstrate without the unwinnable doom-traffic (fixes #162).
+        trafficDistribution: { STATIC: 0, READ: 0.55, WRITE: 0.2, UPLOAD: 0, SEARCH: 0.15, MALICIOUS: 0.1 },
         rps: 4,
         burstPattern: { enabled: true, intervalSec: 8, burstSize: 25 },
         allowedServices: ["apigw"],
@@ -381,7 +393,9 @@ const CAMPAIGN_LEVELS = [
             ],
             connections: [["internet", 0], [0, 1], [1, 2]],
         },
-        trafficDistribution: { STATIC: 0.05, READ: 0.1, WRITE: 0.05, UPLOAD: 0.05, SEARCH: 0.05, MALICIOUS: 0.7 },
+        // STATIC + UPLOAD have no destination — moved into READ. MALICIOUS stays at
+        // 0.7 because the lesson is layered DDoS defense (WAF + APIGW).
+        trafficDistribution: { STATIC: 0, READ: 0.2, WRITE: 0.05, UPLOAD: 0, SEARCH: 0.05, MALICIOUS: 0.7 },
         rps: 8,
         allowedServices: ["waf", "apigw"],
         objectives: {
@@ -416,7 +430,9 @@ const CAMPAIGN_LEVELS = [
             ],
             connections: [["internet", 0], [0, 1], [1, 2], [2, 3]],
         },
-        trafficDistribution: { STATIC: 0.1, READ: 0.4, WRITE: 0.2, UPLOAD: 0.05, SEARCH: 0.1, MALICIOUS: 0.15 },
+        // STATIC + UPLOAD have no destination — moved into READ. The lesson here
+        // is redundancy (multiple WAFs surviving a forced outage event).
+        trafficDistribution: { STATIC: 0, READ: 0.55, WRITE: 0.2, UPLOAD: 0, SEARCH: 0.1, MALICIOUS: 0.15 },
         rps: 6,
         forceOutageAtSec: 30,
         allowedServices: ["waf"],


### PR DESCRIPTION
Closes #162 — Level 9 "Rate Limit Gateway" reported unwinnable by @markd315.

This is the same class of bug as the original Level 5 soft-lock (#159), but it turns out to be **systemic**: 7 of the 14 campaign levels include STATIC and/or UPLOAD traffic but have no Storage/CDN in `preBuilt` AND no Storage/CDN in `allowedServices`. That % of the traffic mix is impossible to route — every request fails, dragging baseline failure rate and reputation.

## Audit (programmatic)

| Level | Title | Doomed % | Lesson |
|------:|-------|---------:|--------|
| 4  | Cache the DB        |  5% | Memory Cache for repeated READs |
| 6  | Scale Reads         | 15% | Read Replica offload |
| 7  | Search Done Right   | 10% | Search Engine |
| 8  | NoSQL for Speed     | 10% | NoSQL transactional path |
| **9** | **Rate Limit Gateway** | **15%** | **API Gateway throttling** ← Mark's report |
| 11 | Defense in Depth    | 10% | WAF + APIGW vs DDoS |
| 12 | High Availability   | 15% | Multiple WAFs survive Service Outage |

## Fix

Zero out `STATIC` + `UPLOAD` on the 7 affected levels and redistribute the percentage into the **lesson-relevant** traffic type so the simulation still stresses what the level is supposed to teach:

| Level | Redistributed into |
|------:|--------------------|
| 4  | READ |
| 6  | READ |
| 7  | SEARCH |
| 8  | READ + WRITE |
| 9  | READ (bursty API load is the lesson) |
| 11 | READ (MALICIOUS stays at 0.7 — the DDoS is the lesson) |
| 12 | READ (steady load while a WAF gets killed) |

Each affected line has a code comment explaining the redistribution and pointing to #159/#162 for future readers.

## Why this is the right fix (vs. adding S3/CDN to `allowedServices`)

Adding Storage to each level would muddy the lesson — these levels are about Cache / Replica / Search Engine / NoSQL / API Gateway / WAF, not about routing STATIC content. The presence of unwinnable doom traffic in the mix was always incidental noise; removing it surfaces the lesson cleanly.

## Verified

- `node --check src/campaign/levels.js` passes
- All 14 levels still sum to exactly 1.0
- Programmatic re-audit confirms zero doom-traffic levels remain
- Level 9 starts cleanly in the browser with the expected pre-built architecture (WAF → ALB → Compute → DB) and $220 budget

## Test plan for reviewers

1. Open Level 9 "Rate Limit Gateway" in Campaign mode
2. Apply Mark's repro from #162: add API Gateway, route Internet → WAF → APIGW → ALB → Compute → DB, upgrade Compute twice
3. Press Play — level should now be passable. Watch the failure-rate objective: should stay well under 10%
4. (Optional) Same for levels 4, 6, 7, 8, 11, 12 — none should show STATIC or UPLOAD attempts in the Failures table