### PR TITLE
fix(balance): APIGW tier ceilings + specialized-service routing preference (closes #166, #167)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -214,21 +214,26 @@ const CONFIG = {
       },
     },
     apigw: {
+      // Rate limits and capacity bumped 2026-06 (#166): the previous ceiling
+      // (T3 rateLimit=80 RPS, capacity=80) throttled legit traffic at endgame
+      // load (~200 RPS). Players learned to remove the gateway to survive,
+      // inverting the intended lesson (throttle > hard-fail). New ceilings
+      // scale with the ×4 RPS milestone so the gateway stays useful late-game.
       name: "API Gateway",
       cost: 70,
       type: "apigw",
       processingTime: 30,
-      capacity: 40,
+      capacity: 60,
       upkeep: 8,
-      rateLimit: 20,
+      rateLimit: 30,
       tooltip: {
         upkeep: "Medium",
         desc: "<b>API Gateway.</b> Rate limits traffic. Throttled requests lose less reputation than failures.",
       },
       tiers: [
-        { level: 1, capacity: 40, rateLimit: 20, cost: 0 },
-        { level: 2, capacity: 60, rateLimit: 40, cost: 120 },
-        { level: 3, capacity: 80, rateLimit: 80, cost: 200 },
+        { level: 1, capacity: 60,  rateLimit: 30,  cost: 0 },
+        { level: 2, capacity: 100, rateLimit: 80,  cost: 120 },
+        { level: 3, capacity: 160, rateLimit: 200, cost: 200 },
       ],
     },
     nosql: {

--- a/src/entities/Service.js
+++ b/src/entities/Service.js
@@ -618,7 +618,29 @@ class Service {
           }
 
           if (job.req.isCacheable) {
+            // Prefer specialized services over Cache when they're a better fit (#167):
+            // - SEARCH cache hit rate is only 15%, so routing through Cache is mostly
+            //   wasted latency. If a Search Engine is connected, use it directly.
+            // - READ hit rate is 40%, but if Cache is heavily loaded, its queue delay
+            //   outweighs the savings — prefer Read Replica when both are connected
+            //   and Cache is >60% loaded.
+            if (job.req.type === "SEARCH") {
+              const searchDirect = this.findConnectedService("search");
+              if (searchDirect) {
+                chargePerRequest();
+                job.req.flyTo(searchDirect);
+                continue;
+              }
+            }
             const cacheTarget = this.findConnectedService("cache");
+            if (job.req.type === "READ" && cacheTarget && cacheTarget.totalLoad > 0.6) {
+              const replicaDirect = this.findConnectedService("replica");
+              if (replicaDirect) {
+                chargePerRequest();
+                job.req.flyTo(replicaDirect);
+                continue;
+              }
+            }
             if (cacheTarget) {
               chargePerRequest();
               job.req.flyTo(cacheTarget);


### PR DESCRIPTION
Closes #166 and #167 — both surfaced from @mhdsbq's INFINITY-mode run in [discussion #137](https://github.com/pshenok/server-survival/discussions/137).

## #166 — API Gateway rate ceiling too low for endgame

Previous tiers capped at 80 RPS / 80 capacity. At the ×4 milestone with 200+ RPS sustained load the gateway throttled the majority of legit traffic and became net-negative — players learned to remove it, inverting the intended lesson (throttle > hard-fail).

New ceilings scale with the ×4 RPS milestone so the gateway stays useful late-game while T1 stays valid for early / small architectures:

| Tier | Old capacity | New capacity | Old rateLimit | New rateLimit |
|-----:|-------------:|-------------:|--------------:|--------------:|
| 1 | 40 | 60 | 20 | 30 |
| 2 | 60 | 100 | 40 | 80 |
| 3 | 80 | 160 | 80 | 200 |

Upkeep and cost unchanged so the economic curve is preserved.

## #167 — Read Replica and Search Engine underused

Previous Compute routing short-circuited to Cache for every cacheable request. Because Cache is checked first, Replica and Search Engine only saw traffic on Cache miss **and** only if they were connected downstream from Cache. Players who wired them to Compute directly (more intuitive) ended up with dead specialized infra — exactly what @mhdsbq described.

Two surgical adjustments in the Compute routing pass:

1. **SEARCH bypasses Cache** when a Search Engine is directly connected. SEARCH's cache hit rate is 15% — routing through Cache is mostly wasted latency, and Search Engine is 3× faster than SQL DB for the same traffic.

2. **READ prefers Read Replica when Cache load > 60%.** Cache still wins at low load (40% hit rate is a real save), but under saturation the queue delay outweighs the savings and Replica becomes the smart fallback.

Architectures that only connect Cache (no specialized services) are unchanged. This is purely a load-aware preference for players who wire up the full stack.

## Verified

Programmatic browser-sim covering three cases:

| Case | Setup | Expected | Result |
|------|-------|----------|--------|
| A | Compute has Cache + Search connected, SEARCH request | Search +1, Cache 0 | ✅ |
| B | Compute has Cache + Replica connected, cache load < 60%, READ | Cache +1, Replica 0 | ✅ |
| C | Compute has Cache + Replica connected, cache load > 60%, READ | Cache 0, Replica +1 | ✅ |

## Test plan for reviewers

- Level 9 "Rate Limit Gateway": place APIGW → survival at throttling should be easier now (200 RPS ceiling covers the burst pattern)
- Late-game Survival: connect Cache + Replica to Compute, run past ×2 RPS milestone → observe traffic split between Cache (hits) and Replica (bypass on saturation)
- Any architecture with Search Engine → Search Engine should now receive SEARCH traffic even when Cache is present