### PR TITLE
docs(campaign): Level 5 briefing — clarify that queue alone can't win (discussion #170)

### DIFF
--- a/src/campaign/levels.js
+++ b/src/campaign/levels.js
@@ -163,7 +163,7 @@ const CAMPAIGN_LEVELS = [
         id: 5, chapter: 2,
         title: "Buffer the Spikes",
         scenario: "Your traffic is bursty — quiet for 5 seconds, then 20 requests at once. Compute can't keep up and requests drop.",
-        learn: "Message Queue (max 200) buffers bursts so Compute processes them at its own pace. Prevents drops during spikes.",
+        learn: "Message Queue (max 200) buffers bursts so Compute processes them at its own pace. But a queue only buys time — it can't add throughput. Sustained load here exceeds Compute Tier 1, so upgrade Compute too, or the queue will eventually saturate.",
         icon: "📊",
         diagramHighlights: { 2: "critical" },
         budget: 180,


### PR DESCRIPTION
Follow-up to [discussion #170](https://github.com/pshenok/server-survival/discussions/170) where @latevis built the correct topology but lost anyway.

## The confusion
Level 5's learn text said the Queue "prevents drops during spikes" — implying it's sufficient on its own. It isn't:

| | |
|---|---|
| Sustained load | ~8 req/s (5 base + 15-burst every 5s) |
| Compute T1 throughput | ~5 req/s |
| Deficit | ~3 req/s → 200-slot queue saturates at ~72s |
| Intended solve | Upgrade Compute to T2 (~13 req/s) — affordable at level start ($135 vs $100) |

A player who only places the Queue watches a seemingly-winning run collapse at the 72-second mark. Brutal, and nothing in the game explains why.

## The fix
One-line briefing text change. New learn text:

> Message Queue (max 200) buffers bursts so Compute processes them at its own pace. **But a queue only buys time — it can't add throughput. Sustained load here exceeds Compute Tier 1, so upgrade Compute too, or the queue will eventually saturate.**

Which is also just… true of real infrastructure, so the educational value improves.

## Verified
- Briefing modal renders the new text correctly (screenshot-checked in browser)
- No behavior/balance changes — text only