### PR TITLE
fix(sim): SQS→Compute pull path capped at ~4 req/s regardless of Compute tier

### DIFF
--- a/src/entities/Service.js
+++ b/src/entities/Service.js
@@ -318,17 +318,25 @@ class Service {
 
     // COMPUTE / SERVERLESS PULL LOGIC
     if (this.type === "compute" || this.type === "serverless") {
-      // Check if we have space in our queue+processing
-      // We want the UPSTREAM queue (SQS) to do the buffering, not the compute node local queue.
-      // So we only pull if we are running low on work locally.
-      // If we have ANY work in our local queue, we should process that first before pulling more.
-      // We allow a tiny buffer (e.g. 1) so there's no gap in processing.
-      const pullThreshold = 1;
+      // Keep the local pipeline full. The upstream SQS does the long-term
+      // buffering, but Compute must pull aggressively enough to saturate its
+      // own processing slots.
+      //
+      // The previous logic pulled at most ONE request per frame and only when
+      // (queue + inFlight) <= 1. Because a request spends ~0.5s in flight from
+      // SQS to Compute, that capped the SQS→Compute path at ~4 req/s no matter
+      // how upgraded the Compute was — making the Queue topology strictly worse
+      // than a direct ALB link and soft-locking Campaign Level 5 (#170) and
+      // degrading late-game Queue setups (#166).
+      //
+      // New logic: pull until processing + queue + inFlight covers effective
+      // capacity plus a small buffer, so the pipeline never starves while
+      // requests are in flight.
+      const capacity = this.getEffectiveCapacity();
+      const pipelineTarget = capacity + 2;
+      let freeSlots = pipelineTarget - (this.processing.length + this.queue.length + this.incomingCount);
 
-      // Current load logic: count requests in queue and incoming (in flight)
-      const pendingWork = this.queue.length + this.incomingCount;
-
-      if (pendingWork <= pullThreshold) {
+      if (freeSlots > 0) {
         // Find upstream SQS services
         const upstreamSQS = STATE.services.filter(s =>
           s.type === 'sqs' &&
@@ -337,19 +345,23 @@ class Service {
         );
 
         if (upstreamSQS.length > 0) {
-          // Round robin pull
+          // Round robin pull across upstream queues until slots are filled
+          // or every queue is empty this frame.
           if (typeof this.upstreamRR === 'undefined') this.upstreamRR = 0;
 
-          // Try up to the number of upstream sources (don't loop forever)
-          for (let i = 0; i < upstreamSQS.length; i++) {
-            const idx = (this.upstreamRR + i) % upstreamSQS.length;
+          let emptyStreak = 0;
+          while (freeSlots > 0 && emptyStreak < upstreamSQS.length) {
+            const idx = this.upstreamRR % upstreamSQS.length;
             const sqs = upstreamSQS[idx];
+            this.upstreamRR = (idx + 1) % upstreamSQS.length;
 
             const req = sqs.popRequest();
             if (req) {
               req.flyTo(this);
-              this.upstreamRR = (idx + 1) % upstreamSQS.length;
-              break;
+              freeSlots--;
+              emptyStreak = 0;
+            } else {
+              emptyStreak++;
             }
           }
         }


### PR DESCRIPTION
Root cause found via @latevis's detailed play-by-play in [discussion #170](https://github.com/pshenok/server-survival/discussions/170). They built the correct Level 5 topology (ALB → Queue → Compute T2) and still lost — juggling five queues that all saturated.

## The bug

The Compute pull logic moved at most **one request per frame**, and only when `(queue + inFlight) <= 1`. Since a request spends ~0.5s flying from SQS to Compute, at most 2 requests were ever in flight:

**SQS → Compute throughput ≈ 4 req/s, regardless of Compute tier.**

Level 5's sustained load is ~8 req/s. Upgrading Compute to T2 (13 req/s) or even T3 (23 req/s) changed nothing — the pipe feeding it was the bottleneck. This also explains @mhdsbq's observation in discussion #137 that the Queue was 'a downgrade on availability' (#166): any Queue-fronted topology was strictly worse than a direct ALB link, which pushes in batches.

## The fix

Pull until the local pipeline (processing + queue + in-flight) covers effective capacity + 2, draining round-robin across all upstream queues each frame. SQS still does the long-term buffering — Compute just no longer starves while requests are in flight.

## Verified (browser sim)

| Test | Before | After |
|------|--------|-------|
| Single frame, stuffed queue, Compute T2 | pulls 1 | pulls 12 (cap 10 + 2) |
| Sustained 8 req/s × 60s | unbounded queue growth | queue stays at 1-2 |
| Exact Level 5 pattern × 90s | saturated at ~72s | max depth 17 / 200 |

## Player impact

- Campaign Level 5 is now winnable through its intended topology (Queue + Compute upgrade)
- Queue-fronted architectures in Survival no longer underperform direct links
- Serverless (also a puller) benefits identically