### PR TITLE
fix(sandbox): no traffic at 0% mix (closes #174)

### DIFF
--- a/game.js
+++ b/game.js
@@ -1394,7 +1394,8 @@ function getTrafficType() {
     const dist = STATE.trafficDistribution;
     const types = Object.keys(dist);
     const total = types.reduce((sum, type) => sum + (dist[type] || 0), 0);
-    if (total === 0) return TRAFFIC_TYPES.STATIC;
+    // All types at 0% means "no traffic", not "default to STATIC" (#174).
+    if (total === 0) return null;
 
     const r = Math.random() * total;
     let cumulative = 0;
@@ -1433,6 +1434,8 @@ function pickEntryNode(entryNodes, type) {
 
 function spawnRequest() {
     const type = getTrafficType();
+    // No traffic mix configured (all sliders at 0%) — nothing to spawn (#174).
+    if (type === null) return;
     const req = new Request(type);
     STATE.requests.push(req);
     const conns = STATE.internetNode.connections;


### PR DESCRIPTION
Closes #174 (reported by @toddmcintosh).

## Bug
`getTrafficType()` had `if (total === 0) return TRAFFIC_TYPES.STATIC;` — an all-zero traffic mix fell back to STATIC instead of meaning 'no traffic'. Sandbox kept firing STATIC requests with every slider at 0.

## Fix
All-zero mix → `getTrafficType()` returns `null` → `spawnRequest()` no-ops. Any slider above 0 resumes normal weighted spawning.

## Verified (browser)
- All sliders 0: 20 spawn ticks → 0 requests created
- READ at 1%: spawning resumes, type = READ
- Survival mode unaffected (its distribution always sums to 1.0)