### PR TITLE
fix(ui): tooltip stats refresh while pointer is stationary (closes #173)

### DIFF
--- a/game.js
+++ b/game.js
@@ -2485,7 +2485,16 @@ container.addEventListener("mousedown", (e) => {
     }
 });
 
+// Last known pointer position over the canvas — lets the animate loop
+// refresh the hover tooltip in real time while the mouse is stationary (#173).
+let lastPointerPos = null;
+let tooltipRefreshAcc = 0;
+container.addEventListener("mouseleave", () => {
+    lastPointerPos = null;
+});
+
 container.addEventListener("mousemove", (e) => {
+    lastPointerPos = { x: e.clientX, y: e.clientY };
     if (isDraggingNode && draggedNode) {
         const hit = getIntersect(e.clientX, e.clientY);
         if (hit.pos) {
@@ -2997,6 +3006,23 @@ function animate(time) {
     processAutoRepair(dt);
     updateFinancesDisplay();
     checkSmartHints();
+
+    // Live tooltip refresh (#173): while the pointer sits still over a service,
+    // replay the last mousemove at ~4 Hz so the tooltip's load/queue/rate stats
+    // keep updating. Reuses the full hover pipeline — zero duplicated logic.
+    tooltipRefreshAcc += clampedDt;
+    if (tooltipRefreshAcc >= 0.25) {
+        tooltipRefreshAcc = 0;
+        if (lastPointerPos && !isDraggingNode && !isPanning) {
+            const tooltipEl = document.getElementById("tooltip");
+            if (tooltipEl && tooltipEl.style.display === "block") {
+                container.dispatchEvent(new MouseEvent("mousemove", {
+                    clientX: lastPointerPos.x,
+                    clientY: lastPointerPos.y,
+                }));
+            }
+        }
+    }
 
     document.getElementById("money-display").innerText = `$${Math.floor(
         STATE.money


### PR DESCRIPTION
Closes #173 (reported by @toddmcintosh).

## Bug
Tooltip content was only rebuilt inside the `mousemove` handler. Hover a busy service, hold the mouse still → the load/queue/rate numbers freeze until you wiggle the pointer.

## Fix
- Remember the last pointer position over the canvas (cleared on `mouseleave`)
- From the animate loop, replay a synthetic `mousemove` at ~4 Hz while a tooltip is visible (skipped during node-drag and camera-pan)

This reuses the entire existing hover pipeline — service stats, upgrade indicator positioning, unlink highlighting — with zero duplicated rendering logic. 4 Hz is enough for smooth-feeling stats without measurable CPU cost.

## Verified (browser)
With the pointer stationary over a DB node and its queue filling: tooltip Queue stat updated 0 → 7 through the exact dispatch path the animate block runs. Guards (visible tooltip, no drag, no pan, pointer on canvas) all validated.

## Notes
- No behavior change when no tooltip is shown (guard short-circuits)
- Works in all 3 game modes since it hooks the shared animate loop