### PR TITLE
fix(routing): Cache no longer swallows undeliverable STATIC traffic (closes #88)

### DIFF
--- a/src/entities/Service.js
+++ b/src/entities/Service.js
@@ -494,7 +494,13 @@ class Service {
             if (sqlTarget) { job.req.flyTo(sqlTarget); continue; }
             failRequest(job.req);
           } else {
-            const target = this.findConnectedService(destType);
+            // Storage-family destinations are interchangeable on a miss (#88):
+            // STATIC's destination is "cdn" but a Cache wired to S3 should still
+            // deliver it — both are static-content origins.
+            let target = this.findConnectedService(destType);
+            if (!target && (destType === "cdn" || destType === "s3")) {
+              target = this.findConnectedService(destType === "cdn" ? "s3" : "cdn");
+            }
             if (target) {
               job.req.flyTo(target);
             } else {
@@ -653,10 +659,22 @@ class Service {
                 continue;
               }
             }
+            // Only route through Cache if a miss can still reach its destination
+            // from there (#88). A Cache wired only to the DB must not swallow
+            // STATIC traffic whose destination is Storage — those requests
+            // should use Compute's direct S3 link instead.
             if (cacheTarget) {
-              chargePerRequest();
-              job.req.flyTo(cacheTarget);
-              continue;
+              const dest = job.req.destination;
+              const cacheCanDeliver =
+                dest === "db"
+                  ? true // cache-miss cascade handles search/replica/nosql/db
+                  : !!(cacheTarget.findConnectedService("s3") ||
+                       cacheTarget.findConnectedService("cdn"));
+              if (cacheCanDeliver) {
+                chargePerRequest();
+                job.req.flyTo(cacheTarget);
+                continue;
+              }
             }
           }
 
@@ -685,7 +703,13 @@ class Service {
             continue;
           }
 
-          const directTarget = this.findConnectedService(destType);
+          // Storage-family destinations are interchangeable (#88): STATIC's
+          // destination is "cdn" but a Compute wired directly to S3 must still
+          // deliver it — both are static-content origins.
+          let directTarget = this.findConnectedService(destType);
+          if (!directTarget && (destType === "cdn" || destType === "s3")) {
+            directTarget = this.findConnectedService(destType === "cdn" ? "s3" : "cdn");
+          }
           if (directTarget) {
             chargePerRequest();
             job.req.flyTo(directTarget);


### PR DESCRIPTION
Closes #88 (reported by @FridayPush back in December — sorry for the wait, and thanks for the clear repro).

## Bug
With a Cache between Compute and DB (but not wired to Storage), STATIC requests were still routed into the Cache. On a miss, the Cache had no path to Storage → `failRequest` → reputation loss for a correctly-built architecture. Exactly the screenshot in the issue.

## Root cause family
Digging in revealed three related gaps around storage-family destinations (STATIC's destination is `cdn`, UPLOAD's is `s3`):

| # | Gap | Fix |
|---|-----|-----|
| 1 | Compute sent every cacheable request into Cache, even when the Cache couldn't deliver it onward | Route through Cache only if a miss can still reach the destination from there |
| 2 | Cache-miss forwarding matched destination literally (`cdn` ≠ connected `s3`) | cdn↔s3 fallback — both are static-content origins |
| 3 | Compute's direct path had the same literal match, so Compute→S3 couldn't deliver STATIC at all without a cache in between | Same cdn↔s3 fallback |

## Verified (browser, exact repro from the issue)
Topology: Compute→Cache→DB, Compute→S3 (Cache NOT wired to Storage):

| Traffic | → Cache | → S3 |
|---------|--------:|-----:|
| STATIC ×3 | 0 | 3 |
| READ ×3 | 3 | 0 |

Plus: wiring Cache→S3 makes STATIC use the Cache again (intended behavior — 90% hit rate is worth it when the miss path exists), and a forced miss with destination `cdn` falls back to a connected S3.

## Player impact
The 'separate cache for DB and direct S3 link' layout @FridayPush wanted to build now works as expected.