### PR TITLE
fix(sim): request leaks, double-counted scoring & disabled-service routing

### DIFF
--- a/game.js
+++ b/game.js
@@ -1486,7 +1486,6 @@ function updateScore(req, outcome) {
     if (outcome === "MALICIOUS_BLOCKED") {
         STATE.score.maliciousBlocked += points.MALICIOUS_BLOCKED_SCORE;
         STATE.score.total += points.MALICIOUS_BLOCKED_SCORE;
-        STATE.score.total += points.MALICIOUS_BLOCKED_SCORE;
 
         // Mitigation cost for blocking attacks
         const mitigationCost = CONFIG.survival.SCORE_POINTS.MALICIOUS_MITIGATION_COST || 1.0;
@@ -1499,7 +1498,6 @@ function updateScore(req, outcome) {
         req.type === TRAFFIC_TYPES.MALICIOUS &&
         outcome === "MALICIOUS_PASSED"
     ) {
-        STATE.reputation += points.MALICIOUS_PASSED_REPUTATION;
         STATE.reputation += points.MALICIOUS_PASSED_REPUTATION;
         STATE.failures.MALICIOUS++;
 
@@ -2196,6 +2194,19 @@ function deleteObject(id) {
         c.mesh.material.dispose();
     });
     STATE.connections = STATE.connections.filter((c) => !toRemove.includes(c));
+
+    // Clean up any requests tied to this service — sitting in its queue, in its
+    // processing slots, or in flight toward it. Without this they'd be stranded
+    // on the destroyed service (whose update() never runs again) and freeze in
+    // the scene forever. Collected from every source and de-duped, then removed
+    // cleanly (no reputation penalty — the player is restructuring, not dropping
+    // production traffic).
+    const orphaned = new Set([
+        ...svc.queue,
+        ...svc.processing.map((job) => job.req),
+        ...STATE.requests.filter((r) => r.target === svc),
+    ]);
+    orphaned.forEach((r) => removeRequest(r));
 
     svc.destroy();
     STATE.services = STATE.services.filter((s) => s.id !== id);

--- a/src/entities/Service.js
+++ b/src/entities/Service.js
@@ -246,7 +246,11 @@ class Service {
 
       if (this.type === "waf" && req.type === TRAFFIC_TYPES.MALICIOUS) {
         updateScore(req, "MALICIOUS_BLOCKED");
-        req.destroy();
+        // Must go through removeRequest (not raw destroy) — otherwise the blocked
+        // request stays in STATE.requests forever and is ticked every frame. This
+        // fires on every WAF block (a large fraction of all traffic), so raw
+        // destroy() leaked the request array unbounded over a session.
+        removeRequest(req);
         continue;
       }
 
@@ -255,8 +259,12 @@ class Service {
   }
 
   findConnectedService(serviceType) {
+    // Skip disabled services (e.g. during a SERVICE_OUTAGE event) so routing
+    // falls through to a healthy alternative instead of stalling traffic on a
+    // node with 0 effective capacity — otherwise the redundancy the player
+    // built (the whole point of the High Availability level) does nothing.
     return STATE.services.find(
-      (s) => this.connections.includes(s.id) && s.type === serviceType
+      (s) => this.connections.includes(s.id) && s.type === serviceType && !s.isDisabled
     );
   }
 
@@ -529,7 +537,7 @@ class Service {
           // We look for any connected service that isn't Internet
           const connectedServices = this.connections
             .map((id) => STATE.services.find((s) => s.id === id))
-            .filter((s) => s && s.type !== "internet");
+            .filter((s) => s && s.type !== "internet" && !s.isDisabled);
 
           if (connectedServices.length > 0) {
             // Simple round robin or just pick first


### PR DESCRIPTION
Five confirmed bugs from a code audit (self + two review agents), all reproduced and verified fixed in-browser.

## 1. WAF-blocked MALICIOUS requests leaked forever 🔴 highest impact
`Service.js` — the WAF block path called `req.destroy()` directly instead of `removeRequest()`. Blocked requests stayed in `STATE.requests` and were ticked every frame for the rest of the session. This fires on **every block** — a large fraction of all traffic (20% baseline, 50-70% during DDoS spikes) — so the array grew unbounded and degraded long sessions. Likely contributor to 'gets heavy after a while' on marathon runs.

**Verified:** 10 WAF blocks → 0 left in STATE.requests (was 10).

## 2. Double reputation penalty on malicious leak
`game.js` `updateScore` — `reputation += MALICIOUS_PASSED_REPUTATION` ran twice → -10 per leak instead of the configured -5. The failures panel (`count × abs(-5)`) and the console log both reported -5, so the UI lied and the game was harder than designed.

**Verified:** one leak = -5 rep (was -10).

## 3. Double score.total on malicious block
`game.js` `updateScore` — `score.total += MALICIOUS_BLOCKED_SCORE` ran twice while the `maliciousBlocked` category incremented once, so total never matched its own breakdown.

**Verified:** score.total == maliciousBlocked after blocks (was 2×).

## 4. Routing ignored disabled services
`Service.js` — `findConnectedService()` and the CDN origin filter didn't exclude `isDisabled` nodes. During a SERVICE_OUTAGE event, traffic routed into the disabled node (0 effective capacity) and stalled instead of falling back to a healthy alternative — defeating the redundancy the High Availability level teaches.

**Verified:** WRITE routes to healthy DB when NoSQL is disabled (was → disabled NoSQL).

## 5. Deleting a service under load stranded its requests
`game.js` `deleteObject` — removed the service but left requests in its queue/processing, and in-flight requests landed in the now-orphaned queue whose `update()` never runs → frozen in the scene forever. Now collects requests from the queue, processing slots, and any in flight toward it, removing them cleanly (no rep penalty — restructuring shouldn't punish).

**Verified:** deleting a DB holding in-flight + queued + processing + stray requests leaves 0 stranded.

## Scope
+24 / -5 across `game.js` and `src/entities/Service.js`. No behavior change to healthy-path routing. Full sandbox verification harness passed all five (ALL_PASS: true), no console errors.

A separate PR will cover the event-system / save-load findings (finances lost on reload, shift/spike timer race, outage pause-resume teleport).