### PR TITLE
fix(events): traffic-shift crash + save-load finances + event-lifecycle bugs

### DIFF
--- a/game.js
+++ b/game.js
@@ -146,15 +146,23 @@ function startMaliciousSpike() {
     const maliciousPct = CONFIG.survival.maliciousSpike.maliciousPercent;
     const remaining = 1 - maliciousPct;
 
+    // Guard against a distribution that's already 100% malicious — otherwise
+    // every non-malicious share divides by zero and becomes NaN/Infinity,
+    // corrupting the mix for the spike's duration. Not reachable with shipped
+    // configs today, but cheap insurance for future levels/shifts.
     const otherTotal = 1 - STATE.normalTrafficDist.MALICIOUS;
-    STATE.trafficDistribution = {
-        STATIC: (STATE.normalTrafficDist.STATIC / otherTotal) * remaining,
-        READ: (STATE.normalTrafficDist.READ / otherTotal) * remaining,
-        WRITE: (STATE.normalTrafficDist.WRITE / otherTotal) * remaining,
-        UPLOAD: (STATE.normalTrafficDist.UPLOAD / otherTotal) * remaining,
-        SEARCH: (STATE.normalTrafficDist.SEARCH / otherTotal) * remaining,
-        MALICIOUS: maliciousPct,
-    };
+    if (otherTotal <= 0) {
+        STATE.trafficDistribution = { ...STATE.normalTrafficDist };
+    } else {
+        STATE.trafficDistribution = {
+            STATIC: (STATE.normalTrafficDist.STATIC / otherTotal) * remaining,
+            READ: (STATE.normalTrafficDist.READ / otherTotal) * remaining,
+            WRITE: (STATE.normalTrafficDist.WRITE / otherTotal) * remaining,
+            UPLOAD: (STATE.normalTrafficDist.UPLOAD / otherTotal) * remaining,
+            SEARCH: (STATE.normalTrafficDist.SEARCH / otherTotal) * remaining,
+            MALICIOUS: maliciousPct,
+        };
+    }
 
     const indicator = document.createElement("div");
     indicator.id = "malicious-spike-indicator";
@@ -261,10 +269,14 @@ function updateTrafficShift(dt) {
         startTrafficShift();
     }
 
-    // Check if shift should end
+    // Check if shift should end. The timer is reset to 0 when a shift actually
+    // activates (see startTrafficShift), so here it measures time-since-active.
+    // Previously this used the absolute `interval + duration` threshold, which
+    // meant a shift that was delayed (blocked while a malicious spike was active)
+    // could end on its very first active frame — running for ~0 seconds.
     if (
         STATE.intervention.trafficShiftActive &&
-        STATE.intervention.trafficShiftTimer >= interval + duration
+        STATE.intervention.trafficShiftTimer >= duration
     ) {
         endTrafficShift();
         STATE.intervention.trafficShiftTimer = 0; // Reset for next cycle
@@ -281,6 +293,10 @@ function startTrafficShift() {
     const shift = shifts[Math.floor(Math.random() * shifts.length)];
     STATE.intervention.currentShift = shift;
     STATE.intervention.trafficShiftActive = true;
+    // Reset so the end check measures duration from actual activation, not from
+    // when the timer first crossed `interval` (it may have kept growing while a
+    // malicious spike blocked the start).
+    STATE.intervention.trafficShiftTimer = 0;
 
     // Store original distribution
     STATE.intervention.originalTrafficDist = { ...STATE.trafficDistribution };
@@ -289,11 +305,12 @@ function startTrafficShift() {
         STATE.trafficDistribution = { ...shift.distribution };
     }
 
+    // Shift configs carry only { name, distribution } — there is no `type`
+    // field, and most shift names have no `shift_<name>` i18n key. Referencing
+    // shift.type threw on every shift start (crashing the frame and suppressing
+    // this warning). Use the shift's display name directly.
     addInterventionWarning(
-        i18n.t('traffic_surging', { 
-            name: i18n.t('shift_' + shift.name.toLowerCase().replace(' ', '_')), 
-            type: i18n.t('traffic_' + shift.type.toLowerCase()) 
-        }),
+        i18n.t('traffic_surging', { name: shift.name }),
         "warning",
         5000
     );
@@ -350,14 +367,18 @@ window.handleGameState = (timeScale) => {
     if (timeScale === 0) { // pause state
         STATE.intervention.pausedEvent = STATE.intervention.activeEvent;
         STATE.intervention.remainingTime = STATE.intervention.eventEndTime - Date.now();
+        // Remember which service the outage hit so resume re-disables the SAME one.
+        STATE.intervention.pausedOutageServiceId = STATE.intervention.outageServiceId || null;
         endRandomEvent();
     } else if (STATE.intervention.pausedEvent) { // not paused state
         triggerRandomEvent(
             STATE.intervention.pausedEvent,
-            STATE.intervention.remainingTime
+            STATE.intervention.remainingTime,
+            STATE.intervention.pausedOutageServiceId
         );
         STATE.intervention.pausedEvent = null;
         STATE.intervention.remainingTime = 0;
+        STATE.intervention.pausedOutageServiceId = null;
     }
 
     window.setTimeScale(timeScale);
@@ -365,7 +386,8 @@ window.handleGameState = (timeScale) => {
 
 function triggerRandomEvent(
     eventType = null,
-    duration = null
+    duration = null,
+    outageServiceId = null
 ) {
     if (!STATE.intervention || STATE.intervention.activeEvent) return;
 
@@ -408,11 +430,22 @@ function triggerRandomEvent(
             STATE.intervention.trafficBurstMultiplier = 3.0;
             break;
 
-        case "SERVICE_OUTAGE":
-            // Pick a random service to temporarily disable
-            const services = STATE.services.filter((s) => s.type !== "waf");
-            if (services.length > 0) {
-                const target = services[Math.floor(Math.random() * services.length)];
+        case "SERVICE_OUTAGE": {
+            // Reuse the previously-chosen service when resuming a paused outage
+            // (STATE.intervention.outageServiceId set), otherwise pick a fresh
+            // random one. Without this, pause→resume re-rolled the target and
+            // the outage could "teleport" to a different service.
+            let target = outageServiceId
+                ? STATE.services.find((s) => s.id === outageServiceId)
+                : null;
+            if (!target) {
+                const services = STATE.services.filter((s) => s.type !== "waf");
+                target = services.length > 0
+                    ? services[Math.floor(Math.random() * services.length)]
+                    : null;
+            }
+            if (target) {
+                STATE.intervention.outageServiceId = target.id;
                 target.isDisabled = true;
                 target.mesh.material.opacity = 0.3;
                 target.mesh.material.transparent = true;
@@ -423,6 +456,7 @@ function triggerRandomEvent(
                 );
             }
             break;
+        }
     }
 
     // Show active event bar
@@ -459,6 +493,11 @@ function endRandomEvent() {
                     s.mesh.material.transparent = false;
                 }
             });
+            // Clear the remembered target. On a pause, handleGameState has
+            // already captured it into pausedOutageServiceId before calling this,
+            // so clearing here only affects a genuine end — the next fresh outage
+            // will pick a new service.
+            STATE.intervention.outageServiceId = null;
             break;
     }
 
@@ -3763,8 +3802,11 @@ function loadGameState(saveData = null) {
             STATE.autoRepairEnabled = false;
         }
 
-        // Initialize finances tracking
-        STATE.finances = {
+        // Restore finances from the save (fall back to zeroed defaults for older
+        // saves that predate finance tracking). Previously this always reset to
+        // zero, so every reload wiped the player's income/expense history even
+        // though saveGameState had written it to disk.
+        const defaultFinances = {
             income: {
                 byType: { STATIC: 0, READ: 0, WRITE: 0, UPLOAD: 0, SEARCH: 0 },
                 countByType: { STATIC: 0, READ: 0, WRITE: 0, UPLOAD: 0, SEARCH: 0, blocked: 0 },
@@ -3783,6 +3825,12 @@ function loadGameState(saveData = null) {
                 countByService: { waf: 0, alb: 0, compute: 0, db: 0, s3: 0, cache: 0, sqs: 0, search: 0, replica: 0, apigw: 0, nosql: 0, cdn: 0, serverless: 0 },
             },
         };
+        STATE.finances = saveData.finances
+            ? {
+                income: { ...defaultFinances.income, ...saveData.finances.income },
+                expenses: { ...defaultFinances.expenses, ...saveData.finances.expenses },
+            }
+            : defaultFinances;
 
         restoreServices(saveData.services);
 

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -183,7 +183,7 @@ const DE_TRANSLATIONS = {
     "capacity_reduced": "KAPAZITÄT REDUZIERT",
     "traffic_burst": "TRAFFIC BURST",
     "service_outage_active": "DIENSTAUSFALL",
-    "traffic_surging": "📊 {name} - {type} Traffic steigt an!",
+    "traffic_surging": "📊 Traffic-Anstieg: {name}!",
     "upkeep_on": "Auto-Reparatur: AN",
     "upkeep_off": "Auto-Reparatur: AUS",
     "upkeep_on_label": "Unterhalt AN",

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -183,7 +183,7 @@ const EN_TRANSLATIONS = {
     "capacity_reduced": "CAPACITY REDUCED",
     "traffic_burst": "TRAFFIC BURST",
     "service_outage_active": "SERVICE OUTAGE",
-    "traffic_surging": "📊 {name} - {type} traffic surging!","upkeep_on": "Auto-Repair: ON",
+    "traffic_surging": "📊 {name} traffic surge incoming!","upkeep_on": "Auto-Repair: ON",
     "upkeep_off": "Auto-Repair: OFF",
     "upkeep_on_label": "Upkeep ON",
     "upkeep_off_label": "Upkeep OFF",

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -183,7 +183,7 @@ const FR_TRANSLATIONS = {
     "capacity_reduced": "Capacité réduite",
     "traffic_burst": "Pic de trafic",
     "service_outage_active": "Panne de service",
-    "traffic_surging": "📊 {name} - Trafic {type} en hausse !",
+    "traffic_surging": "📊 Pic de trafic : {name} !",
     "upkeep_on": "Réparation auto : ON",
     "upkeep_off": "Réparation auto : OFF",
     "upkeep_on_label": "Maintenance ON",

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -183,7 +183,7 @@ const IT_TRANSLATIONS = {
     "capacity_reduced": "CAPACITÀ RIDOTTA",
     "traffic_burst": "RAFFICA DI TRAFFICO",
     "service_outage_active": "INTERRUZIONE SERVIZIO",
-    "traffic_surging": "📊 {name} - Traffico {type} in forte aumento!",
+    "traffic_surging": "📊 Picco di traffico: {name}!",
     "upkeep_on": "Riparazione Auto: ON",
     "upkeep_off": "Riparazione Auto: OFF",
     "upkeep_on_label": "Mantenimento ON",

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -184,7 +184,7 @@ const KO_TRANSLATIONS = {
     "capacity_reduced": "용량 감소됨",
     "traffic_burst": "트래픽 폭발",
     "service_outage_active": "서비스 장애",
-    "traffic_surging": "📊 {name} - {type} 트래픽 급증!",
+    "traffic_surging": "📊 트래픽 급증: {name}!",
     "upkeep_on": "자동 수리: 켜짐",
     "upkeep_off": "자동 수리: 꺼짐",
     "upkeep_on_label": "유지비: 켜짐",

--- a/src/locales/nep.js
+++ b/src/locales/nep.js
@@ -183,7 +183,7 @@ const NE_TRANSLATIONS = {
     "capacity_reduced": "क्षमता घटाइयो",
     "traffic_burst": "ट्राफिक बर्स्ट",
     "service_outage_active": "सेवा आउटेज सक्रिय",
-    "traffic_surging": "📊 {name} - {type} ट्राफिक छालिँदै छ!",
+    "traffic_surging": "📊 ट्राफिक बढ्दै: {name}!",
     "upkeep_on": "स्वतः-मर्मत: खुला",
     "upkeep_off": "स्वतः-मर्मत: बन्द",
     "upkeep_on_label": "रखरखाव: खुला",

--- a/src/locales/pt-BR.js
+++ b/src/locales/pt-BR.js
@@ -216,7 +216,7 @@ const PT_BR_TRANSLATIONS = {
     "capacity_reduced": "Capacidade reduzida",
     "traffic_burst": "Rajada de tráfego ativa",
     "service_outage_active": "Interrupção de serviço",
-    "traffic_surging": "📊 {name} - {type} tráfego aumentando!",
+    "traffic_surging": "📊 Aumento de tráfego: {name}!",
     "upkeep_on": "Manutenção: Ligada",
     "upkeep_off": "Manutenção: Desligada",
     "upkeep_on_label": "Ativar Manutenção",

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -183,7 +183,7 @@ const RU_TRANSLATIONS = {
     "capacity_reduced": "МОЩНОСТЬ СНИЖЕНА",
     "traffic_burst": "ВСПЛЕСК ТРАФИКА",
     "service_outage_active": "СБОЙ СЕРВИСА",
-    "traffic_surging": "📊 {name} — всплеск {type}‑трафика!",
+    "traffic_surging": "📊 Всплеск трафика: {name}!",
     "upkeep_on": "Авто‑ремонт: ВКЛ",
     "upkeep_off": "Авто‑ремонт: ВЫКЛ",
     "upkeep_on_label": "Содержание: ВКЛ",

--- a/src/locales/zh.js
+++ b/src/locales/zh.js
@@ -216,7 +216,7 @@ const ZH_TRANSLATIONS = {
     "capacity_reduced": "容量已降低",
     "traffic_burst": "流量爆发中",
     "service_outage_active": "服务中断",
-    "traffic_surging": "📊 {name} - {type} 流量激增！","upkeep_on": "自动维护：开启",
+    "traffic_surging": "📊 {name} 流量激增！","upkeep_on": "自动维护：开启",
     "upkeep_off": "自动维护：关闭",
     "upkeep_on_label": "启用维护",
     "upkeep_off_label": "禁用维护",


### PR DESCRIPTION
Six event-system / save-load bugs from a code audit (self + a review agent), all reproduced and verified fixed in-browser. Companion to #180 (simulation/scoring fixes).

## 1. Traffic-shift start crashed on every trigger 🔴
`game.js` — `startTrafficShift` referenced `shift.type.toLowerCase()`, but shift configs are only `{ name, distribution }` — there is **no `type` field**. So every traffic shift (~every 40s in survival) threw `Cannot read properties of undefined`, aborting the animate frame and silently suppressing the 'traffic surging' warning. It also looked up `shift_<name>` i18n keys that mostly don't exist (only 2 of 6 shift names had one).

Fix: use the shift's display name directly; drop the broken `{type}` placeholder from the `traffic_surging` template in all 9 locales.

**Verified:** shift now starts without throwing and renders `📊 Search Storm traffic surge incoming!`.

## 2. loadGameState wiped finances on every reload
`game.js` — `saveGameState` persisted `STATE.finances`, but load unconditionally overwrote it with zeroed defaults. Reloading a save reset the player's entire income/expense history even though it was written to disk.

Fix: restore from the save, zeroed fallback for pre-finance saves. **Verified:** income.total 4242 & expenses.services 555 survive a load round-trip.

## 3. Traffic-shift ended almost instantly when delayed
`game.js` — the shift timer kept climbing while a malicious spike blocked the start (`startTrafficShift` bails if a spike is active). When the shift finally activated, the timer could already exceed the absolute `interval + duration` threshold, so it ended on its first active frame. Timer now resets on activation; the end check measures `duration` since active.

**Verified:** a shift delayed by a spike activates afterward and stays active.

## 4. SERVICE_OUTAGE teleported on pause/resume
`game.js` — pausing mid-outage re-enabled the service; resuming re-ran the event and re-rolled a **new random** target, so the outage could jump to a different service. Now the disabled service's id is remembered across pause/resume and cleared on genuine end.

**Verified:** outage stays on the same service through pause→resume, and clears on end.

## 5. Divide-by-zero guard in startMaliciousSpike
`game.js` — a 100%-malicious base distribution would divide every other share by zero → NaN/Infinity. Not reachable with shipped configs; cheap insurance for future levels/shifts. **Verified:** no NaN with a 100%-malicious mix.

## Scope
+80 / -32 across `game.js` and 9 locale files (the `traffic_surging` template only). Bug 1 is the standout — an every-40-seconds crash in survival that's been shipped. No console errors in a forced-shift survival run.