### PR TITLE
fix: seven bugs from code audit (routing loop, drag overlap, resource leaks)

### DIFF
--- a/game.js
+++ b/game.js
@@ -960,6 +960,7 @@ scene.fog = new THREE.FogExp2(CONFIG.colors.bg, 0.008);
 let isDraggingNode = false;
 let draggedNode = null;
 let dragOffset = new THREE.Vector3();
+let dragStartPos = new THREE.Vector3();
 
 const aspect = window.innerWidth / window.innerHeight;
 const d = 50;
@@ -2077,7 +2078,6 @@ function createConnection(fromId, toId) {
     else if (t1 === "waf" && t2 === "alb") valid = true;
     else if (t1 === "waf" && t2 === "sqs") valid = true;
     else if (t1 === "sqs" && t2 === "alb") valid = true;
-    else if (t1 === "alb" && t2 === "sqs") valid = true;
     else if (t1 === "sqs" && t2 === "compute") valid = true;
     else if (t1 === "alb" && t2 === "compute") valid = true;
     else if (t1 === "compute" && t2 === "cache") valid = true;
@@ -2414,6 +2414,13 @@ window.addEventListener("keyup", (e) => {
     keysPressed[e.key] = false;
 });
 
+// Clear all held keys when the window loses focus — otherwise a keyup missed
+// during an alt-tab / focus switch leaves the key "stuck" and the camera pans
+// forever until that key is pressed and released again.
+window.addEventListener("blur", () => {
+    for (const k in keysPressed) keysPressed[k] = false;
+});
+
 container.addEventListener("contextmenu", (e) => e.preventDefault());
 
 container.addEventListener("mousedown", (e) => {
@@ -2452,6 +2459,7 @@ container.addEventListener("mousedown", (e) => {
         }
         if (draggedNode) {
             isDraggingNode = true;
+            dragStartPos.copy(draggedNode.position);
             const hit = getIntersect(e.clientX, e.clientY);
             if (hit.pos) {
                 dragOffset.copy(draggedNode.position).sub(hit.pos);
@@ -2553,14 +2561,14 @@ container.addEventListener("mousemove", (e) => {
 
             draggedNode.position.copy(newPos);
 
-            if (draggedNode.mesh) {
-                draggedNode.mesh.position.x = newPos.x;
-                draggedNode.mesh.position.z = newPos.z;
-            } else {
+            if (draggedNode === STATE.internetNode) {
                 STATE.internetNode.mesh.position.x = newPos.x;
                 STATE.internetNode.mesh.position.z = newPos.z;
                 STATE.internetNode.ring.position.x = newPos.x;
                 STATE.internetNode.ring.position.z = newPos.z;
+            } else if (draggedNode.mesh) {
+                draggedNode.mesh.position.x = newPos.x;
+                draggedNode.mesh.position.z = newPos.z;
             }
 
             updateConnectionsForNode(draggedNode.id);
@@ -2878,18 +2886,28 @@ container.addEventListener("mouseup", (e) => {
     if (isDraggingNode && draggedNode) {
         isDraggingNode = false;
 
-        const snapped = snapToGrid(draggedNode.position);
+        let snapped = snapToGrid(draggedNode.position);
+
+        // Reject a drop onto a tile already occupied by another service —
+        // otherwise the two overlap and whichever mesh the raycaster hits first
+        // makes the other permanently unselectable (can't delete/upgrade it).
+        const occupied = STATE.services.some(
+            (s) => s !== draggedNode && s.position.distanceTo(snapped) < 1
+        );
+        if (occupied) {
+            snapped = snapToGrid(dragStartPos);
+        }
 
         draggedNode.position.copy(snapped);
 
-        if (draggedNode.mesh) {
-            draggedNode.mesh.position.x = snapped.x;
-            draggedNode.mesh.position.z = snapped.z;
-        } else {
+        if (draggedNode === STATE.internetNode) {
             STATE.internetNode.mesh.position.x = snapped.x;
             STATE.internetNode.mesh.position.z = snapped.z;
             STATE.internetNode.ring.position.x = snapped.x;
             STATE.internetNode.ring.position.z = snapped.z;
+        } else if (draggedNode.mesh) {
+            draggedNode.mesh.position.x = snapped.x;
+            draggedNode.mesh.position.z = snapped.z;
         }
 
         updateConnectionsForNode(draggedNode.id);
@@ -3514,7 +3532,11 @@ window.toggleUpkeep = () => {
 window.clearAllServices = () => {
     STATE.services.forEach((s) => s.destroy());
     STATE.services = [];
-    STATE.connections.forEach((c) => connectionGroup.remove(c.mesh));
+    STATE.connections.forEach((c) => {
+        connectionGroup.remove(c.mesh);
+        c.mesh.geometry.dispose();
+        c.mesh.material.dispose();
+    });
     STATE.connections = [];
     STATE.internetNode.connections = [];
     STATE.requests.forEach((r) => r.destroy());

--- a/src/campaign/campaign.js
+++ b/src/campaign/campaign.js
@@ -71,6 +71,10 @@ class CampaignController {
         }
 
         this.active = true;
+        // Monotonic session id: distinguishes "this level attempt" from a
+        // later retry/next that reuses the controller. Stale burst callbacks
+        // scheduled by a previous attempt compare against this and bail.
+        this._session = (this._session || 0) + 1;
         STATE.campaign.active = true;
         STATE.campaign.currentLevelId = levelId;
         STATE.campaign.level = level;
@@ -99,10 +103,12 @@ class CampaignController {
             STATE.campaign.burstTimer += dt;
             if (STATE.campaign.burstTimer >= bp.intervalSec) {
                 STATE.campaign.burstTimer = 0;
+                const session = this._session;
                 for (let i = 0; i < bp.burstSize; i++) {
                     setTimeout(() => {
-                        // Bail if the level ended or campaign exited while this burst was in flight.
-                        if (!this.active || STATE.campaign.ended) return;
+                        // Bail if the level ended, campaign exited, or a different
+                        // level session started (retry/next) while this burst was in flight.
+                        if (session !== this._session || !this.active || STATE.campaign.ended) return;
                         if (typeof spawnRequest === "function") spawnRequest();
                     }, i * 20);
                 }
@@ -224,9 +230,12 @@ class CampaignController {
     _persistWin(levelId, stars, elapsed) {
         const progress = this.loadProgress();
         const existing = progress.completed[levelId] || { stars: 0, bestTimeSec: Infinity };
+        // Guard against a malformed/hand-edited entry missing bestTimeSec —
+        // Math.min(undefined, elapsed) is NaN and would poison the best time forever.
+        const prevBest = Number.isFinite(existing.bestTimeSec) ? existing.bestTimeSec : Infinity;
         progress.completed[levelId] = {
-            stars: Math.max(existing.stars, stars),
-            bestTimeSec: Math.min(existing.bestTimeSec, elapsed),
+            stars: Math.max(existing.stars || 0, stars),
+            bestTimeSec: Math.min(prevBest, elapsed),
             lastPlayed: Date.now(),
         };
         progress.highestUnlocked = Math.max(progress.highestUnlocked, levelId + 1);


### PR DESCRIPTION
A follow-up audit (two parallel agents over routing, drag/drop, campaign, and resource cleanup) surfaced seven distinct bugs. All verified in-browser before fixing.

### 1. `ALB → SQS` routing loop + permanent request leak *(most severe)*
`alb → sqs` was the only rule in the connection-validity table whose reverse (`sqs → alb`) is also valid. SQS's forwarding pushes to ALB (`Service.js` `downstreamTypes = ["alb"]`), while ALB has no dedicated case and falls into the generic forwarding branch that pushes to **any** connection with **no backpressure check**. So an `alb ⇄ sqs` pair bounces a request `ALB→SQS→ALB→SQS…` forever — it's never handed to `finishRequest`/`failRequest`/`removeRequest`, leaking it from `STATE.requests`, growing the queue unbounded, and charging upkeep for zero throughput. **Fix:** removed the `alb → sqs` rule; `sqs → alb` (the real forwarding direction) stays.

### 2. Campaign burst callbacks leak across Retry / Next
`burstPattern` schedules up to `burstSize` `setTimeout` spawns spaced 20ms apart. The bail-out guard only checked `this.active`/`ended`, but **Retry** and **Next** call `startCampaignLevel → loadLevel` directly (which resets `ended = false`) without `exit()`. Stale callbacks from the previous attempt then passed the guard and injected phantom requests into the freshly-loaded level, polluting its scoring before the player even pressed Play. **Fix:** monotonic session id captured at schedule time; a callback bails if the session changed.

### 3. Drag-drop onto an occupied tile makes a service unremovable
The drag path never applied the overlap guard `createService` uses. Dropping node B onto node A's tile left them sharing a position; the raycaster only ever returns the front mesh, so the other service became permanently unselectable/undeletable/un-upgradeable while still charging upkeep. **Fix:** reject the drop (revert to the drag-start tile) when the target tile is occupied.

### 4. `clearAllServices` leaked connection GPU resources
Every other connection-removal path disposes `geometry`/`material`; "Clear All" only removed the mesh from the scene. **Fix:** dispose them too.

### 5. Held keys never cleared on window blur
A `keyup` missed during an alt-tab left the key stuck in `keysPressed`, panning the camera forever. **Fix:** `window blur` handler clears all held keys.

### 6. Dragging the Internet node never moved its ring
`if (draggedNode.mesh)` — but `internetNode.mesh` is always set, so the `else` branch (the only one that also moves the ring) was dead code; the cyan ring stayed frozen at spawn. **Fix:** branch on node identity.

### 7. `_persistWin` could poison best time with `NaN`
A `completed[]` entry missing `bestTimeSec` (hand-edited/future schema) made `Math.min(undefined, elapsed) = NaN`, permanently displaying "NaNs". **Fix:** `Number.isFinite` guard.

## Verification
In-browser: `alb → sqs` now rejected while `sqs → alb` still connects; `clearAllServices` runs without error; campaign `_session` increments on each level load (stale callbacks invalidated); `_persistWin` returns a finite best time (42.5) and correct max stars from a malformed entry. No new console errors. No build step — served raw as before.