### PR TITLE
reduce net profit requirement for level 10 campaign mode

### DIFF
--- a/src/campaign/levels.js
+++ b/src/campaign/levels.js
@@ -363,7 +363,7 @@ const CAMPAIGN_LEVELS = [
         allowedServices: [],
         objectives: {
             primary: [
-                { id: "profit_100", label: "Net profit ≥ $100 in 90s", check: (s) => CampaignObjectives.netProfit(s) >= 100 },
+                { id: "profit_100", label: "Net profit ≥ -$210 in 90", check: (s) => CampaignObjectives.netProfit(s) >= -210 },
                 { id: "rep_above_70", label: "Reputation above 70%", check: (s) => s.reputation >= 70 },
             ],
             bonus: [

--- a/src/campaign/levels.js
+++ b/src/campaign/levels.js
@@ -363,7 +363,7 @@ const CAMPAIGN_LEVELS = [
         allowedServices: [],
         objectives: {
             primary: [
-                { id: "profit_100", label: "Net profit ≥ -$210 in 90", check: (s) => CampaignObjectives.netProfit(s) >= -210 },
+                { id: "profit_100", label: "Net profit ≥ -$210 in 90s", check: (s) => CampaignObjectives.netProfit(s) >= -210 },
                 { id: "rep_above_70", label: "Reputation above 70%", check: (s) => s.reputation >= 70 },
             ],
             bonus: [


### PR DESCRIPTION
closes #184 

**Describe the bug** 
At 1.5 RPS the $0.50–$1.50 reward values, , and mandatory infrastructure costs of $200+ creates a situation where net profit starts deeply negative, and it is mathematically impossible to achieve +$100 net profit

**Mitigation**
Increase net profit requirement for level 10 campaign mode to $210 compared with the unbeatable +$100

**Additional Context**
A simple configuration with WAF->ALB->Serverless->NoSql->Storage is able to achieve 3 stars. Replacing Compute with serverless is able to achieve 1 star. Previously achieving even 1 star would take more than 500s, if the game allowed.