### PR TITLE
Campaign restart brings back initial campaign state

### DIFF
--- a/game.js
+++ b/game.js
@@ -1277,6 +1277,12 @@ function resetGame(mode = "survival") {
 
 function restartGame() {
     document.getElementById("modal").classList.add("hidden");
+
+    // startCampaignLevel integrates important campaign level state and calls resetGame
+    if (STATE.gameMode === "campaign" && STATE.campaign?.currentLevelId) {
+        startCampaignLevel(STATE.campaign.currentLevelId);
+        return;
+    }
     resetGame(STATE.gameMode);
 }
 


### PR DESCRIPTION
closes #186 

**Describe the bug**

Wheneve the restart button is pressed in campaign mode. The initial state is totally wiped clean and everything starts from 0. Including budget, load, initial assets, etc.

**Additional context**

restartGame() called resetGame(STATE.gameMode) directly . resetGame("campaign") intentionally sets money=0 as a placeholder, with the per-level budget **expected** to be applied afterward by startCampaignLevel. 

But since the flow skipped startCampaignLevel and only called restartGame, the level budget was never set, leaving the player with $0, a stale traffic mix, no pre-built architecture, and no toolbar gating.

**Fix**

Gate restartGame() so campaign restarts route through startCampaignLevel(STATE.campaign.currentLevelId), which re-propagates state and calls resetGame() internally. Survival and sandbox paths are unchanged.