### PR TITLE
Survival mode UX fixes

### DIFF
--- a/game.js
+++ b/game.js
@@ -1690,6 +1690,14 @@ window.togglePanel = (contentId, iconId) => {
     }
 };
 
+window.toggleFailureModal = () => {
+    const card = document.getElementById("modal-card");
+    const restore = document.getElementById("modal-restore");
+    if (!card || !restore) return;
+    const minimized = card.classList.toggle("hidden");
+    restore.classList.toggle("hidden", !minimized);
+};
+
 window.startGame = () => {
     document.getElementById("main-menu-modal").classList.add("hidden");
     resetGame();
@@ -2826,6 +2834,9 @@ container.addEventListener("mousemove", (e) => {
             STATE.failures.WRITE=0;
             STATE.failures.UPLOAD=0;
             STATE.failures.SEARCH=0;
+            // when click on clear button, update ui immediately
+            document.getElementById('failures-panel').classList.add('hidden');
+            document.getElementById('failures-total').textContent = `0 ${i18n.t('total')}`;
         })
 
 // Helper function for showing tooltips
@@ -3291,6 +3302,10 @@ function animate(time) {
             </div>
         `;
         document.getElementById("modal").classList.remove("hidden");
+        // show the results card , now has an id
+        document.getElementById("modal-card").classList.remove("hidden");
+        // hide the "show results" floating button , new element
+        document.getElementById("modal-restore").classList.add("hidden");
         STATE.sound.playGameOver();
     }
 
@@ -3799,7 +3814,7 @@ function loadGameState(saveData = null) {
             STATE.maliciousSpikeTimer = 0;
             STATE.maliciousSpikeActive = false;
             STATE.normalTrafficDist = null;
-            STATE.autoRepairEnabled = false;
+            STATE.autoRepairEnabled = saveData.autoRepairEnabled || false;
         }
 
         // Restore finances from the save (fall back to zeroed defaults for older
@@ -3833,6 +3848,20 @@ function loadGameState(saveData = null) {
             : defaultFinances;
 
         restoreServices(saveData.services);
+
+        const autoRepairBtn = document.getElementById("auto-repair-toggle");
+        if (autoRepairBtn) {
+            if (STATE.autoRepairEnabled) {
+                autoRepairBtn.textContent = i18n.t('upkeep_on');
+                autoRepairBtn.classList.remove("text-gray-400");
+                autoRepairBtn.classList.add("text-green-400");
+            } else {
+                autoRepairBtn.textContent = i18n.t('upkeep_off');
+                autoRepairBtn.classList.remove("text-green-400");
+                autoRepairBtn.classList.add("text-gray-400");
+            }
+        }
+        updateRepairCostTable();
 
         restoreConnections(
             saveData.connections,

--- a/index.html
+++ b/index.html
@@ -741,8 +741,12 @@
 
   <!-- End/Next Level Modal -->
   <div id="modal"
-    class="hidden fixed inset-0 bg-black bg-opacity-90 z-50 flex items-center justify-center backdrop-blur-sm">
-    <div class="glass-panel p-8 rounded-2xl text-center max-w-md border border-gray-600">
+    class="hidden fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
+    <div id="modal-card" class="relative glass-panel p-8 rounded-2xl text-center max-w-md border border-gray-600 pointer-events-auto">
+      <button onclick="toggleFailureModal()" title="Minimize" data-i18n-title="minimize"
+        class="absolute top-3 right-3 w-6 h-6 flex items-center justify-center bg-gray-800 hover:bg-gray-700 rounded border border-gray-600 text-gray-400 transition">
+        <span class="text-[10px]">─</span>
+      </button>
       <h2 id="modal-title" data-i18n="system_failure" class="text-4xl font-bold mb-4 text-white font-mono tracking-tighter">
         SYSTEM FAILURE
       </h2>
@@ -763,6 +767,11 @@
         </button>
       </div>
     </div>
+    <button id="modal-restore" onclick="toggleFailureModal()"
+      data-i18n="show_results"
+      class="hidden absolute bottom-6 right-6 pointer-events-auto glass-panel px-4 py-2 rounded-lg border border-red-500/50 text-red-400 text-sm font-mono hover:text-white transition">
+      ⚠ Show Results
+    </button>
   </div>
 
   <!-- Main Menu Modal -->

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -286,6 +286,8 @@ const DE_TRANSLATIONS = {
     "infra_collapsed": "Infrastruktur zusammengebrochen.",
     "retry_same": "Gleiches Setup erneut versuchen",
     "start_fresh": "Neu beginnen",
+    "minimize": "Minimieren",
+    "show_results": "⚠ Ergebnisse anzeigen",
     "resume_game": "Spiel fortsetzen",
     "start_survival": "Überleben starten",
     "sandbox_mode": "Sandbox-Modus",

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -285,6 +285,8 @@ const EN_TRANSLATIONS = {
     "infra_collapsed": "Infrastructure collapsed.",
     "retry_same": "Retry Same Setup",
     "start_fresh": "Start Fresh",
+    "minimize": "Minimize",
+    "show_results": "⚠ Show Results",
     "resume_game": "Resume Game",
     "start_survival": "Start Survival",
     "sandbox_mode": "Sandbox Mode",

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -286,6 +286,8 @@ const FR_TRANSLATIONS = {
     "infra_collapsed": "Infrastructure effondrée.",
     "retry_same": "Réessayer la même configuration",
     "start_fresh": "Recommencer",
+    "minimize": "Réduire",
+    "show_results": "⚠ Voir les résultats",
     "resume_game": "Reprendre la partie",
     "start_survival": "Démarrer la survie",
     "sandbox_mode": "Mode Sandbox",

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -285,6 +285,8 @@ const IT_TRANSLATIONS = {
     "infra_collapsed": "Infrastruttura collassata.",
     "retry_same": "Riprova Stessa Configurazione",
     "start_fresh": "Ricomincia da Capo",
+    "minimize": "Riduci",
+    "show_results": "⚠ Mostra risultati",
     "resume_game": "Riprendi Gioco",
     "start_survival": "Inizia Sopravvivenza",
     "sandbox_mode": "Modalità Sandbox",

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -264,6 +264,8 @@ const KO_TRANSLATIONS = {
     "infra_collapsed": "인프라가 붕괴되었습니다.",
     "retry_same": "같은 설정으로 재시도",
     "start_fresh": "새로 시작",
+    "minimize": "최소화",
+    "show_results": "⚠ 결과 보기",
     "resume_game": "게임 재개",
     "start_survival": "생존 모드 시작",
     "sandbox_mode": "샌드박스 모드",

--- a/src/locales/nep.js
+++ b/src/locales/nep.js
@@ -286,6 +286,8 @@ const NE_TRANSLATIONS = {
     "infra_collapsed": "इन्फ्रास्ट्रक्चर पतन भयो।",
     "retry_same": "उही सेटअप पुनः प्रयास गर्नुहोस्",
     "start_fresh": "ताजा सुरु गर्नुहोस्",
+    "minimize": "सानो बनाउनुहोस्",
+    "show_results": "⚠ नतिजा हेर्नुहोस्",
     "resume_game": "खेल जारी राख्नुहोस्",
     "start_survival": "अस्तित्व सुरु गर्नुहोस्",
     "sandbox_mode": "स्यान्डबक्स मोड",

--- a/src/locales/pt-BR.js
+++ b/src/locales/pt-BR.js
@@ -317,6 +317,8 @@ const PT_BR_TRANSLATIONS = {
     "infra_collapsed": "Infraestrutura colapsada.",
     "retry_same": "Tentar mesma arquitetura",
     "start_fresh": "Começar do zero",
+    "minimize": "Minimizar",
+    "show_results": "⚠ Mostrar resultados",
     "resume_game": "Continuar jogo",
     "start_survival": "Iniciar no Modo Sobrevivência",
     "sandbox_mode": "Entrar no Modo Sandbox",

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -286,6 +286,8 @@ const RU_TRANSLATIONS = {
     "infra_collapsed": "Инфраструктура рухнула.",
     "retry_same": "Повторить с тем же сетапом",
     "start_fresh": "Начать заново",
+    "minimize": "Свернуть",
+    "show_results": "⚠ Показать результаты",
     "resume_game": "Продолжить игру",
     "start_survival": "Начать режим выживания",
     "sandbox_mode": "Режим песочницы",

--- a/src/locales/zh.js
+++ b/src/locales/zh.js
@@ -316,6 +316,8 @@ const ZH_TRANSLATIONS = {
     "infra_collapsed": "基础设施已瘫痪。",
     "retry_same": "重试当前架构",
     "start_fresh": "重新开始",
+    "minimize": "最小化",
+    "show_results": "⚠ 显示结果",
     "resume_game": "继续游戏",
     "start_survival": "开始生存模式",
     "sandbox_mode": "进入沙盒模式",


### PR DESCRIPTION
closes #188

**Summary**

**Change 1 : Inspect the board on game over + minimizable failure card**
- Basically when i fail a survival game at high RPS, it happens so quickly , i am not able to figure out what caused the failure in the first place. Need a way to see the snapshot of the failure-moment state which i can hover over to see the load on various resources
- Removed the opaque dark/blur overlay on the game-over #modal so the frozen board stays visible. The modal is now pass-through (pointer-events-none) with only the result card interactive (pointer-events-auto), letting you hover services to read their load/queue/health at the moment of failure.
- Added a minimize button (─) to the failure card and a floating "⚠ Show Results" restore pill, via new window.toggleFailureModal(). Collapsing the card fully clears the board for inspection; the card always reopens expanded on a fresh failure.

**Change 2: Failures list "Clear" updates immediately**
- So whenever i pressed the clear button for failures. It wasnt instant. Only when a new failure occurred, it started from 0. Otherwise the clear button looked like it was broken.
- Clicking Clear previously only zeroed STATE.failures; the panel didn't refresh until the next failure (the render block is gated on totalFailures > 0). It now hides the panel and resets the total to 0 right away.

**Change 3: Restore auto-repair state on Continue (load saved game)**
- Tried several times continuing saved game to reach higher RPS. But each time I had to enable auto repair. Which doesnt make sense. Its better to load it from previous state.
- loadGameState hardcoded STATE.autoRepairEnabled = false, discarding the saved value. It now restores the flag from the save and syncs the Auto-Repair toggle button (ON/OFF text + color).

**i18n**
- Added minimize and show_results keys across all 9 locales (en, de, fr, it, ko, nep, pt-BR, ru, zh).