### PR TITLE
fix: restore ALB → Queue link, block the reverse edge instead (#191)

### DIFF
--- a/game.js
+++ b/game.js
@@ -2083,6 +2083,11 @@ function createConnection(fromId, toId) {
     const from = getEntity(fromId),
         to = getEntity(toId);
     if (!from || !to || from.connections.includes(toId)) return;
+    // Reject the reverse edge of an existing link. ALB⇄SQS is the only pair valid
+    // in both directions, and having both at once loops requests forever (SQS
+    // pushes to ALB, ALB's generic forwarding pushes back) — they never reach
+    // finishRequest/failRequest and leak. Either single direction stays legal.
+    if (to.connections && to.connections.includes(fromId)) return;
 
     let valid = false;
     const t1 = from.type,
@@ -2092,6 +2097,7 @@ function createConnection(fromId, toId) {
     else if (t1 === "waf" && t2 === "alb") valid = true;
     else if (t1 === "waf" && t2 === "sqs") valid = true;
     else if (t1 === "sqs" && t2 === "alb") valid = true;
+    else if (t1 === "alb" && t2 === "sqs") valid = true;
     else if (t1 === "sqs" && t2 === "compute") valid = true;
     else if (t1 === "alb" && t2 === "compute") valid = true;
     else if (t1 === "compute" && t2 === "cache") valid = true;


### PR DESCRIPTION
Fixes #191 — a regression I introduced in #183.

## What went wrong
In #183 I found that an `ALB ⇄ SQS` pair loops requests forever (SQS pushes to ALB, ALB's generic forwarding pushes back; nothing ever reaches `finishRequest`/`failRequest`, so requests leak). I "fixed" it by deleting the `alb → sqs` validity rule.

That was the wrong cut. **`alb → sqs` is legitimate and documented** — the in-game manual promises both directions, and `ALB → Queue → Compute` is a real buffering pattern the engine explicitly supports: when SQS has no downstream ALB it parks the request back in `processing` (`Service.js:567-571`) *precisely so a Compute node can pull it*. Deleting the rule broke that topology for players, which is exactly what @ashaltu reported.

## The actual fix
The loop requires **both** edges simultaneously. Either single direction is fine. So instead of banning a direction, reject the **reverse edge of an existing link**:

```js
if (to.connections && to.connections.includes(fromId)) return;
```

`ALB ⇄ SQS` is the only pair valid in both directions, so this guard changes nothing else. The `alb → sqs` rule is restored.

## Verification
Driven in-browser through the real service update loop at ~2 RPS (not a synthetic harness — my first attempt at one was misleading, which is how the original bad call slipped through):

| Topology | Spawned | Processed | Failed | In flight |
|---|---|---|---|---|
| `ALB → Compute` (baseline) | 60 | **60** | 0 | 0 |
| `ALB → Queue → Compute` (#191) | 60 | **60** | 0 | 0 |

The #191 topology now delivers traffic identically to the baseline. The reverse edge is still rejected in **both** creation orders (`alb→sqs` then `sqs→alb`, and vice versa), so the loop cannot be formed.