### PR TITLE
feat: teach the replica read-only rule with a smart hint (#190)

### DIFF
--- a/game.js
+++ b/game.js
@@ -891,9 +891,22 @@ function checkSmartHints() {
     .filter(s => s.type === "compute")
     .some(s => s.totalLoad > 0.8);
 
+  // Misconfiguration: a Compute routes READs through a Replica but has no
+  // master DB path left for WRITE/SEARCH traffic (#190). Players replace the
+  // direct DB link with the Replica and then watch WRITEs die with no clue why
+  // — Replicas are read-only by design, so teach that instead of failing silently.
+  const replicaNoMaster = STATE.services.some(s =>
+    s.type === "compute" &&
+    s.connections.some(id => STATE.services.find(x => x.id === id)?.type === "replica") &&
+    !s.connections.some(id => ["db", "nosql"].includes(STATE.services.find(x => x.id === id)?.type))
+  );
+
   let hint = null;
 
-  if (dbOverloaded && !hasSearch && STATE.trafficDistribution.SEARCH > 0.05 &&
+  if (replicaNoMaster && (STATE.failures.WRITE || 0) + (STATE.failures.SEARCH || 0) > 3 &&
+      !STATE.hints.dismissedHints.has("replica_write")) {
+    hint = { key: "hint_replica_write", id: "replica_write" };
+  } else if (dbOverloaded && !hasSearch && STATE.trafficDistribution.SEARCH > 0.05 &&
       !STATE.hints.dismissedHints.has("search")) {
     hint = { key: "hint_search_overload", id: "search" };
   } else if (dbOverloaded && !hasReplica && STATE.trafficDistribution.READ > 0.1 &&

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -475,6 +475,7 @@ const DE_TRANSLATIONS = {
     // Smart Hints
     "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
     "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",
+    "hint_replica_write": "💡 Replikate sind schreibgeschützt! Halte Compute mit der Master-DB verbunden — WRITE-Traffic hat sonst kein Ziel.",
     "hint_no_waf": "💡 Malicious traffic is getting through! Add a Firewall to block attacks.",
     "hint_no_cache": "💡 Many requests are cacheable. A Memory Cache would reduce DB load!",
     "hint_compute_overload": "💡 Your Compute nodes are overwhelmed. Add a Message Queue to buffer requests.",

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -474,6 +474,7 @@ const EN_TRANSLATIONS = {
     // Smart Hints
     "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
     "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",
+    "hint_replica_write": "💡 Replicas are read-only! Keep Compute connected to the master DB — WRITE traffic has nowhere to go.",
     "hint_no_waf": "💡 Malicious traffic is getting through! Add a Firewall to block attacks.",
     "hint_no_cache": "💡 Many requests are cacheable. A Memory Cache would reduce DB load!",
     "hint_compute_overload": "💡 Your Compute nodes are overwhelmed. Add a Message Queue to buffer requests.",

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -475,6 +475,7 @@ const FR_TRANSLATIONS = {
     // Smart Hints
     "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
     "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",
+    "hint_replica_write": "💡 Les réplicas sont en lecture seule ! Gardez Compute connecté à la BD principale — le trafic WRITE n'a nulle part où aller.",
     "hint_no_waf": "💡 Malicious traffic is getting through! Add a Firewall to block attacks.",
     "hint_no_cache": "💡 Many requests are cacheable. A Memory Cache would reduce DB load!",
     "hint_compute_overload": "💡 Your Compute nodes are overwhelmed. Add a Message Queue to buffer requests.",

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -470,6 +470,7 @@ const IT_TRANSLATIONS = {
     "hint_serverless_expensive": "💡 La tua Funzione Serverless sta accumulando costi per richiesta con questa frequenza di RPS. Prendi in considerazione l'aggiunta di un nodo Compute per un rendimento costante più economico.",
     "hint_search_overload": "💡 Il tuo DB è sovraccarico di query di RICERCA. Prendi in considerazione l'aggiunta di un Motore di Ricerca!",
     "hint_read_overload": "💡 Troppe LETTURE colpiscono il tuo DB. Una Read Replica può alleviare il traffico di lettura!",
+    "hint_replica_write": "💡 Le repliche sono di sola lettura! Mantieni Compute collegato al DB principale — il traffico WRITE non ha dove andare.",
     "hint_no_waf": "💡 Il traffico malevolo sta passando! Aggiungi un Firewall per bloccare gli attacchi.",
     "hint_no_cache": "💡 Molte richieste sono memorizzabili in cache. Una Memory Cache ridurrebbe il carico sul DB!",
     "hint_compute_overload": "💡 I tuoi nodi Compute sono sovraccarichi. Aggiungi una Coda di Messaggi per bufferizzare le richieste.",

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -428,6 +428,7 @@ const KO_TRANSLATIONS = {
     // Smart Hints
     "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
     "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",
+    "hint_replica_write": "💡 복제본은 읽기 전용입니다! Compute를 마스터 DB에 연결해 두세요 — WRITE 트래픽이 갈 곳이 없습니다.",
     "hint_no_waf": "💡 Malicious traffic is getting through! Add a Firewall to block attacks.",
     "hint_no_cache": "💡 Many requests are cacheable. A Memory Cache would reduce DB load!",
     "hint_compute_overload": "💡 Your Compute nodes are overwhelmed. Add a Message Queue to buffer requests.",

--- a/src/locales/nep.js
+++ b/src/locales/nep.js
@@ -475,6 +475,7 @@ const NE_TRANSLATIONS = {
     // Smart Hints
     "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
     "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",
+    "hint_replica_write": "💡 Replica पढ्नका लागि मात्र हो! Compute लाई मास्टर DB सँग जोडिराख्नुहोस् — WRITE ट्राफिक जाने ठाउँ छैन।",
     "hint_no_waf": "💡 Malicious traffic is getting through! Add a Firewall to block attacks.",
     "hint_no_cache": "💡 Many requests are cacheable. A Memory Cache would reduce DB load!",
     "hint_compute_overload": "💡 Your Compute nodes are overwhelmed. Add a Message Queue to buffer requests.",

--- a/src/locales/pt-BR.js
+++ b/src/locales/pt-BR.js
@@ -484,6 +484,7 @@ const PT_BR_TRANSLATIONS = {
     // Smart Hints
     "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
     "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",
+    "hint_replica_write": "💡 Réplicas são somente leitura! Mantenha o Compute conectado ao BD principal — o tráfego WRITE não tem para onde ir.",
     "hint_no_waf": "💡 Malicious traffic is getting through! Add a Firewall to block attacks.",
     "hint_no_cache": "💡 Many requests are cacheable. A Memory Cache would reduce DB load!",
     "hint_compute_overload": "💡 Your Compute nodes are overwhelmed. Add a Message Queue to buffer requests.",

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -471,6 +471,7 @@ const RU_TRANSLATIONS = {
     "hint_serverless_expensive": "💡 Ваш Serverless накапливает плату за запросы при таком RPS. Добавьте Compute для более дешёвой постоянной нагрузки.",
     "hint_search_overload": "💡 Ваша БД перегружена SEARCH-запросами. Добавьте Search Engine!",
     "hint_read_overload": "💡 Слишком много READ-запросов бьёт по БД. Read Replica разгрузит трафик чтения!",
+    "hint_replica_write": "💡 Реплики только для чтения! Держите Compute подключённым к мастер-БД — WRITE-трафику некуда идти.",
     "hint_no_waf": "💡 Вредоносный трафик проходит! Добавьте Firewall, чтобы блокировать атаки.",
     "hint_no_cache": "💡 Многие запросы кэшируемы. Cache снизит нагрузку на БД!",
     "hint_compute_overload": "💡 Ваши узлы Compute перегружены. Добавьте Queue, чтобы буферизовать запросы.",

--- a/src/locales/zh.js
+++ b/src/locales/zh.js
@@ -483,6 +483,7 @@ const ZH_TRANSLATIONS = {
     // Smart Hints
     "hint_search_overload": "💡 Your DB is overloaded with SEARCH queries. Consider adding a Search Engine!",
     "hint_read_overload": "💡 Too many READs hitting your DB. A Read Replica can offload read traffic!",
+    "hint_replica_write": "💡 只读副本不能写入！请保持 Compute 与主数据库相连——WRITE 流量无处可去。",
     "hint_no_waf": "💡 Malicious traffic is getting through! Add a Firewall to block attacks.",
     "hint_no_cache": "💡 Many requests are cacheable. A Memory Cache would reduce DB load!",
     "hint_compute_overload": "💡 Your Compute nodes are overwhelmed. Add a Message Queue to buffer requests.",


### PR DESCRIPTION
Resolves #190.

## Investigation
Reproduced the reported topology live (`Internet → WAF → ALB → Compute → Replica → DB`) driving the real service update loop:

| Scenario | Spawned | Processed | READ failed |
|---|---|---|---|
| Replica path, pure READ | 60 | **60** | 0 |
| Replica path, pure READ, high RPS | 200 | **200** | 0 |
| Replica + direct DB, mixed traffic | 200 | **200** | 0 |
| Cache→Replica cascade, READ | 200 | **200** | 0 |

**The replica processes READs correctly in every case.** What the reporter actually hit (reproduced): replacing the direct `Compute → DB` link with the Replica path. In mixed traffic that kills **WRITE and SEARCH** (57 + 17 failures in my run) — they have no route, because **replicas are read-only by design**. The red wall of failures near the DB looks like "replica doesn't process", but READs are all fine.

## The real bug: silence
The simulation is right; the feedback is missing. The player gets zero explanation of *why* requests die — which is exactly the gap that turns a teaching moment into a bug report.

## Fix
New smart hint (highest priority, since it's an active failure): fires when a Compute routes through a Replica but has **no master DB/NoSQL path** and WRITE/SEARCH failures accumulate:

> 💡 Replicas are read-only! Keep Compute connected to the master DB — WRITE traffic has nowhere to go.

Silent on correct builds (verified). Key added to all 9 locales. This is Wave-1-flavored (#193): the game teaching *why*, not just failing.

## Verification
In-browser through `resetGame('survival')` + real loop: misconfigured build → hint fires after >3 WRITE/SEARCH failures with Dismiss button; adding the direct DB link → no hint. RU locale renders correctly.