### PR TITLE
refactor(#155, PR 2/10): native ESM — explicit module graph, still no build step

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,15 +1,13 @@
 import js from "@eslint/js";
 import globals from "globals";
 
-// Baseline lint for the pre-ESM codebase (#155 PR 1 of 10).
+// Lint for the native-ESM codebase (#155 PR 2 of 10).
 //
-// The game is still classic global scripts — every file shares one global
-// scope, so cross-file symbols (STATE, createService, …) look "undefined" to
-// a per-file linter. no-undef/no-unused-vars therefore stay off until the
-// native-ESM conversion (PR 2) makes imports explicit; then they come on.
-// What stays ON already catches real bugs: duplicate object keys (found
-// several live ones in the locales on first run), unreachable code,
-// self-assignments, invalid regexes, etc.
+// Every first-party file is now a real ES module with explicit imports, so
+// no-undef is ON: any bare identifier that isn't imported or a known browser
+// global is an error. THREE stays a classic CDN global (r128), so it is
+// declared here instead of imported. no-unused-vars stays off until the
+// split PRs land (game.js still exports a wide surface).
 export default [
   {
     ignores: ["node_modules/**", "assets/**", "market/**"],
@@ -18,23 +16,16 @@ export default [
   {
     languageOptions: {
       ecmaVersion: 2022,
-      sourceType: "script",
+      sourceType: "module",
       globals: {
         ...globals.browser,
+        THREE: "readonly",
       },
     },
     rules: {
-      "no-undef": "off",
       "no-unused-vars": "off",
       "no-empty": ["error", { allowEmptyCatch: true }],
     },
-  },
-  {
-    // The game's Request entity shadows the browser's built-in fetch Request —
-    // intentional and harmless in-game (nothing here uses fetch). The class
-    // gets renamed when PR 2 introduces real modules.
-    files: ["src/entities/Request.js"],
-    rules: { "no-redeclare": "off" },
   },
   {
     files: ["tests/**/*.mjs", "eslint.config.mjs"],

--- a/game.js
+++ b/game.js
@@ -1,3 +1,16 @@
+import { CONFIG, TRAFFIC_TYPES } from "./src/config.js";
+import { STATE } from "./src/state.js";
+import { i18n } from "./src/i18n.js";
+import { Request } from "./src/entities/Request.js";
+import { Service } from "./src/entities/Service.js";
+import { SoundService } from "./src/services/SoundService.js";
+// Side-effect imports: these modules install their instances on window
+// (window.tutorial, window.campaign), which is how game.js reaches them.
+import "./src/tutorial.js";
+import "./src/campaign/campaign.js";
+import { CAMPAIGN_LEVELS } from "./src/campaign/levels.js";
+import { renderArchitectureSVG } from "./src/campaign/diagram.js";
+
 STATE.sound = new SoundService();
 
 // ==================== UTILITY FUNCTIONS ====================
@@ -1294,7 +1307,7 @@ function restartGame() {
 
     // startCampaignLevel integrates important campaign level state and calls resetGame
     if (STATE.gameMode === "campaign" && STATE.campaign?.currentLevelId) {
-        startCampaignLevel(STATE.campaign.currentLevelId);
+        window.startCampaignLevel(STATE.campaign.currentLevelId);
         return;
     }
     resetGame(STATE.gameMode);
@@ -1889,7 +1902,7 @@ window.campaignStartCurrentLevel = () => {
     const id = _pendingCampaignLevelId;
     if (!id) return;
     document.getElementById("campaign-briefing-modal").classList.add("hidden");
-    startCampaignLevel(id);
+    window.startCampaignLevel(id);
 };
 
 window.startCampaignLevel = (levelId) => {
@@ -2043,7 +2056,7 @@ function showCampaignDebrief(outcome, reason, level) {
 window.campaignRetryLevel = () => {
     const id = STATE.campaign.currentLevelId;
     document.getElementById("campaign-debrief-modal").classList.add("hidden");
-    if (id) startCampaignLevel(id);
+    if (id) window.startCampaignLevel(id);
 };
 
 window.campaignNextLevel = () => {
@@ -2051,8 +2064,8 @@ window.campaignNextLevel = () => {
     document.getElementById("campaign-debrief-modal").classList.add("hidden");
     if (id) {
         const next = CAMPAIGN_LEVELS.find((l) => l.id === id + 1);
-        if (next) openCampaignBriefing(next.id);
-        else exitCampaignToMap();
+        if (next) window.openCampaignBriefing(next.id);
+        else window.exitCampaignToMap();
     }
 };
 
@@ -3490,7 +3503,7 @@ document.addEventListener("keydown", (event) => {
         if (menu.classList.contains("hidden")) {
             openMainMenu();
         } else if (STATE.gameStarted && STATE.isRunning) {
-            resumeGame();
+            window.resumeGame();
         }
         return;
     }
@@ -3603,7 +3616,7 @@ window.clearAllServices = () => {
 function openMainMenu() {
     // Store current time scale and pause
     STATE.previousTimeScale = STATE.timeScale;
-    setTimeScale(0);
+    window.setTimeScale(0);
 
     // Hide tutorial while menu is open
     if (window.tutorial?.isActive) {
@@ -3743,7 +3756,7 @@ window.onSaveGameFileUpload = (event) => {
     reader.onload = function (e) {
         try {
             let saveData = JSON.parse(e.target.result);
-            window.loadGameState(saveData);
+            loadGameState(saveData);
 
             STATE.sound.playPlace(); // Use place sound as feedback
         } catch (error) {
@@ -4025,3 +4038,38 @@ function restoreConnections(savedConnections, internetConnections) {
         createConnection(connData.from, connData.to);
     });
 }
+
+// ==================== ESM BOUNDARY (#155 PR 2) ====================
+
+// Under classic scripts these three function declarations were implicit
+// globals; index.html inline on*= handlers still call them, so they must be
+// put on window explicitly now that module scope no longer leaks.
+window.restartGame = restartGame;
+window.retryWithSameArchitecture = retryWithSameArchitecture;
+window.toggleAutoRepair = toggleAutoRepair;
+
+// The generated smart-hint dismiss button (showSmartHint) embeds an inline
+// onclick that touches STATE.hints — inline handlers resolve against the
+// global scope, and the old top-level `const STATE` was a global lexical
+// binding. Keep STATE reachable from there.
+window.STATE = STATE;
+
+// Runtime cross-module surface: Request.js, Service.js and campaign.js import
+// these (cyclically — safe, they are hoisted declarations / top-level consts
+// only dereferenced after evaluation).
+export {
+    addInterventionWarning,
+    calculateFailChanceBasedOnLoad,
+    failRequest,
+    finishRequest,
+    flashMoney,
+    getUpkeepMultiplier,
+    removeRequest,
+    renderCampaignObjectives,
+    requestGroup,
+    serviceGroup,
+    showCampaignDebrief,
+    spawnRequest,
+    throttleRequest,
+    updateScore,
+};

--- a/index.html
+++ b/index.html
@@ -7,16 +7,6 @@
   <title>SERVER: Survival Protocol</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-  <script src="src/locales/en.js"></script>
-  <script src="src/locales/zh.js"></script>
-  <script src="src/locales/pt-BR.js"></script>
-  <script src="src/locales/de.js"></script>
-  <script src="src/locales/fr.js"></script>
-  <script src="src/locales/ko.js"></script>
-  <script src="src/locales/ru.js"></script>
-  <script src="src/locales/it.js"></script>
-  <script src="src/locales/nep.js"></script>
-  <script src="src/i18n.js"></script>
   <link rel="stylesheet" href="style.css" />
 </head>
 
@@ -1270,17 +1260,6 @@
       </div>
     </div>
   </div>
-  <script src="src/config.js"></script>
-  <script src="src/state.js"></script>
-  <script src="src/entities/Request.js"></script>
-  <script src="src/entities/Service.js"></script>
-  <script src="src/services/SoundService.js"></script>
-  <script src="src/tutorial.js"></script>
-  <script src="src/campaign/objectives.js"></script>
-  <script src="src/campaign/diagram.js"></script>
-  <script src="src/campaign/levels.js"></script>
-  <script src="src/campaign/campaign.js"></script>
-  <script src="game.js"></script>
 
   <!-- Campaign: Level Select Modal -->
   <div id="campaign-select-modal"
@@ -1375,6 +1354,7 @@
       </div>
     </div>
   </div>
+  <script type="module" src="src/main.js"></script>
 </body>
 
 </html>

--- a/src/campaign/campaign.js
+++ b/src/campaign/campaign.js
@@ -8,10 +8,23 @@
 //     highestUnlocked: number
 //   }
 
+import { STATE } from "../state.js";
+import { CAMPAIGN_LEVELS } from "./levels.js";
+// Cyclic import (game.js ⇄ campaign.js) is safe: hoisted function declarations
+// in game.js, only called at runtime. Under classic scripts the `typeof x ===
+// "function"` guards below tolerated load-order gaps; as imports the names are
+// always bound, so the guards simply always pass now.
+import {
+    addInterventionWarning,
+    renderCampaignObjectives,
+    showCampaignDebrief,
+    spawnRequest,
+} from "../../game.js";
+
 const CAMPAIGN_STORAGE_KEY = "serverSurvivalCampaignProgress";
 const CAMPAIGN_PROGRESS_VERSION = 1;
 
-class CampaignController {
+export class CampaignController {
     constructor() {
         this.active = false;
         this._tickCounter = 0;

--- a/src/campaign/diagram.js
+++ b/src/campaign/diagram.js
@@ -34,7 +34,7 @@ const DIAGRAM_SERVICE_LABELS = {
  * @param {Object<number,string>} highlights e.g. { 3: "critical" }
  * @returns {string} SVG markup
  */
-function renderArchitectureSVG(preBuilt, highlights = {}) {
+export function renderArchitectureSVG(preBuilt, highlights = {}) {
     const services = preBuilt.services || [];
     const connections = preBuilt.connections || [];
 

--- a/src/campaign/levels.js
+++ b/src/campaign/levels.js
@@ -21,7 +21,9 @@
 //   failConditions     — { repBelow?, moneyBelow?, timeoutSec? }
 //   debriefTip         — shown on win
 
-const CAMPAIGN_LEVELS = [
+import { CampaignObjectives } from "./objectives.js";
+
+export const CAMPAIGN_LEVELS = [
     // ===== Chapter 1: Basics =====
     {
         id: 1, chapter: 1,

--- a/src/campaign/objectives.js
+++ b/src/campaign/objectives.js
@@ -1,7 +1,7 @@
 // Pure objective-check helpers. All take live STATE and return boolean or number.
 // Stateless and side-effect free.
 
-const CampaignObjectives = {
+export const CampaignObjectives = {
     // ---- counters tracked via STATE.campaign.completedByType (populated in Task 5) ----
 
     completedOfType(state, type) {

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-const TRAFFIC_TYPES = {
+export const TRAFFIC_TYPES = {
   STATIC: "STATIC",
   READ: "READ",
   WRITE: "WRITE",
@@ -7,7 +7,7 @@ const TRAFFIC_TYPES = {
   MALICIOUS: "MALICIOUS",
 };
 
-const CONFIG = {
+export const CONFIG = {
   gridSize: 30,
   tileSize: 4,
   colors: {

--- a/src/entities/Request.js
+++ b/src/entities/Request.js
@@ -1,4 +1,11 @@
-class Request {
+import { CONFIG } from "../config.js";
+import { STATE } from "../state.js";
+// Cyclic import (game.js ⇄ Request.js) is safe: these are hoisted function
+// declarations / top-level consts in game.js, only dereferenced at runtime —
+// long after both modules have finished evaluating.
+import { failRequest, requestGroup } from "../../game.js";
+
+export class Request {
     constructor(type) {
         this.id = Math.random().toString(36);
         this.type = type;

--- a/src/entities/Service.js
+++ b/src/entities/Service.js
@@ -1,4 +1,23 @@
-class Service {
+import { CONFIG, TRAFFIC_TYPES } from "../config.js";
+import { STATE } from "../state.js";
+import { i18n } from "../i18n.js";
+// Cyclic import (game.js ⇄ Service.js) is safe: these are hoisted function
+// declarations / top-level consts in game.js, only dereferenced at runtime —
+// long after both modules have finished evaluating.
+import {
+  addInterventionWarning,
+  calculateFailChanceBasedOnLoad,
+  failRequest,
+  finishRequest,
+  flashMoney,
+  getUpkeepMultiplier,
+  removeRequest,
+  serviceGroup,
+  throttleRequest,
+  updateScore,
+} from "../../game.js";
+
+export class Service {
   constructor(type, pos) {
     this.id = "svc_" + Math.random().toString(36).substr(2, 9);
     this.type = type;

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,7 +1,17 @@
+import { EN_TRANSLATIONS } from "./locales/en.js";
+import { ZH_TRANSLATIONS } from "./locales/zh.js";
+import { PT_BR_TRANSLATIONS } from "./locales/pt-BR.js";
+import { DE_TRANSLATIONS } from "./locales/de.js";
+import { FR_TRANSLATIONS } from "./locales/fr.js";
+import { KO_TRANSLATIONS } from "./locales/ko.js";
+import { RU_TRANSLATIONS } from "./locales/ru.js";
+import { IT_TRANSLATIONS } from "./locales/it.js";
+import { NE_TRANSLATIONS } from "./locales/nep.js";
+
 /**
  * Simple i18n manager for the game
  */
-class I18nManager {
+export class I18nManager {
     constructor() {
         this.currentLocale = localStorage.getItem('game_locale') || 'en';
         this.translations = {
@@ -77,8 +87,10 @@ class I18nManager {
     }
 }
 
-// Create a global instance
-window.i18n = new I18nManager();
+// Create a global instance (kept on window: index.html inline handlers call
+// i18n.setLocale(...), which resolves via the global scope)
+export const i18n = new I18nManager();
+window.i18n = i18n;
 
 // Function to easily translate strings in JS
 window.t = (key, variables) => window.i18n.t(key, variables);

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -1,4 +1,4 @@
-const DE_TRANSLATIONS = {
+export const DE_TRANSLATIONS = {
     "title": "SERVER: Survival Protocol",
     "survival": "ÜBERLEBEN",
     "budget": "BUDGET",

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1,4 +1,4 @@
-const EN_TRANSLATIONS = {
+export const EN_TRANSLATIONS = {
     "title": "SERVER: Survival Protocol",
     "survival": "SURVIVAL",
     "budget": "BUDGET",

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -1,4 +1,4 @@
-const FR_TRANSLATIONS = {
+export const FR_TRANSLATIONS = {
     "title": "SERVER: Survival Protocol",
     "survival": "SURVIE",
     "budget": "BUDGET",

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -1,4 +1,4 @@
-const IT_TRANSLATIONS = {
+export const IT_TRANSLATIONS = {
     "title": "SERVER: Protocollo di Sopravvivenza",
     "survival": "SOPRAVVIVENZA",
     "budget": "BUDGET",

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -1,4 +1,4 @@
-const KO_TRANSLATIONS = {
+export const KO_TRANSLATIONS = {
     "title": "서버: 생존 프로토콜",
     "survival": "생존",
     "budget": "예산",

--- a/src/locales/nep.js
+++ b/src/locales/nep.js
@@ -1,4 +1,4 @@
-const NE_TRANSLATIONS = {
+export const NE_TRANSLATIONS = {
     "title": "सर्भर: अस्तित्व प्रोटोकल",
     "survival": "अस्तित्व",
     "budget": "बजेट",

--- a/src/locales/pt-BR.js
+++ b/src/locales/pt-BR.js
@@ -1,4 +1,4 @@
-const PT_BR_TRANSLATIONS = {
+export const PT_BR_TRANSLATIONS = {
     "title": "SERVER: Survival Protocol",
     "survival": "SOBREVIVÊNCIA",
     "budget": "Orçamento",

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -1,4 +1,4 @@
-const RU_TRANSLATIONS = {
+export const RU_TRANSLATIONS = {
     "title": "СЕРВЕР: Протокол Выживания",
     "survival": "ВЫЖИВАНИЕ",
     "budget": "БЮДЖЕТ",

--- a/src/locales/zh.js
+++ b/src/locales/zh.js
@@ -1,4 +1,4 @@
-const ZH_TRANSLATIONS = {
+export const ZH_TRANSLATIONS = {
     "title": "服务器：生存协议",
     "survival": "生存模式",
     "budget": "预算",

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,3 @@
+// Native-ESM entry point (#155 PR 2). The only script index.html loads.
+// game.js transitively imports every other first-party module.
+import "../game.js";

--- a/src/services/SoundService.js
+++ b/src/services/SoundService.js
@@ -1,4 +1,4 @@
-class SoundService {
+export class SoundService {
     constructor() {
         this.ctx = null;
         // Separate music / SFX channels (#112). Both start muted (autoplay

--- a/src/state.js
+++ b/src/state.js
@@ -1,4 +1,6 @@
-const STATE = {
+import { CONFIG } from "./config.js";
+
+export const STATE = {
     money: 0,
     reputation: 0,
     requestsProcessed: 0,

--- a/src/tutorial.js
+++ b/src/tutorial.js
@@ -1,3 +1,6 @@
+import { STATE } from "./state.js";
+import { i18n } from "./i18n.js";
+
 const TUTORIAL_STORAGE_KEY = 'serverSurvivalTutorialComplete';
 
 function getTutorialSteps() {

--- a/tests/config.test.mjs
+++ b/tests/config.test.mjs
@@ -1,8 +1,6 @@
 // Config sanity (#155 PR 1): the invariants that past bugs violated.
 import { describe, expect, it } from "vitest";
-import { loadScriptGlobals } from "./helpers/load-globals.mjs";
-
-const { CONFIG, TRAFFIC_TYPES } = loadScriptGlobals("src/config.js");
+import { CONFIG, TRAFFIC_TYPES } from "../src/config.js";
 
 describe("traffic types", () => {
   it("every traffic type has a destination and a reward", () => {

--- a/tests/helpers/load-globals.mjs
+++ b/tests/helpers/load-globals.mjs
@@ -1,37 +1,17 @@
-// The game ships as classic global scripts (no modules — see the hard
-// constraint in #155: main must stay directly hostable on GitHub Pages).
-// To test them in Node we evaluate a file and harvest the globals it
-// declares. Replaced by real imports once PR 2 (native ESM) lands.
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import vm from "node:vm";
-
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
-
-export function loadScriptGlobals(relPath, context = {}) {
-  const src = readFileSync(join(ROOT, relPath), "utf8");
-  const sandbox = vm.createContext(context);
-  // `const X = ...` at script top level is scoped to the vm's evaluation, not
-  // attached to the context object — re-declare top-level consts as vars so
-  // they land on the sandbox and can be harvested.
-  const patched = src.replace(/^const /gm, "var ");
-  vm.runInContext(patched, sandbox, { filename: relPath });
-  return sandbox;
-}
-
+// The game is native ESM (#155 PR 2) — tests load the real modules with
+// dynamic import instead of the old vm-eval global-harvesting hack.
 export const LOCALES = [
-  { code: "en", file: "src/locales/en.js", global: "EN_TRANSLATIONS" },
-  { code: "zh", file: "src/locales/zh.js", global: "ZH_TRANSLATIONS" },
-  { code: "pt-BR", file: "src/locales/pt-BR.js", global: "PT_BR_TRANSLATIONS" },
-  { code: "de", file: "src/locales/de.js", global: "DE_TRANSLATIONS" },
-  { code: "fr", file: "src/locales/fr.js", global: "FR_TRANSLATIONS" },
-  { code: "ko", file: "src/locales/ko.js", global: "KO_TRANSLATIONS" },
-  { code: "ru", file: "src/locales/ru.js", global: "RU_TRANSLATIONS" },
-  { code: "ne", file: "src/locales/nep.js", global: "NE_TRANSLATIONS" },
-  { code: "it", file: "src/locales/it.js", global: "IT_TRANSLATIONS" },
+  { code: "en", load: async () => (await import("../../src/locales/en.js")).EN_TRANSLATIONS },
+  { code: "zh", load: async () => (await import("../../src/locales/zh.js")).ZH_TRANSLATIONS },
+  { code: "pt-BR", load: async () => (await import("../../src/locales/pt-BR.js")).PT_BR_TRANSLATIONS },
+  { code: "de", load: async () => (await import("../../src/locales/de.js")).DE_TRANSLATIONS },
+  { code: "fr", load: async () => (await import("../../src/locales/fr.js")).FR_TRANSLATIONS },
+  { code: "ko", load: async () => (await import("../../src/locales/ko.js")).KO_TRANSLATIONS },
+  { code: "ru", load: async () => (await import("../../src/locales/ru.js")).RU_TRANSLATIONS },
+  { code: "ne", load: async () => (await import("../../src/locales/nep.js")).NE_TRANSLATIONS },
+  { code: "it", load: async () => (await import("../../src/locales/it.js")).IT_TRANSLATIONS },
 ];
 
-export function loadLocale({ file, global: g }) {
-  return loadScriptGlobals(file)[g];
+export function loadLocale(locale) {
+  return locale.load();
 }

--- a/tests/i18n-usage.test.mjs
+++ b/tests/i18n-usage.test.mjs
@@ -9,7 +9,7 @@ import { describe, expect, it } from "vitest";
 import { LOCALES, loadLocale } from "./helpers/load-globals.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
-const en = loadLocale(LOCALES.find((l) => l.code === "en"));
+const en = await loadLocale(LOCALES.find((l) => l.code === "en"));
 
 function collectSources() {
   const files = ["game.js", "index.html", "src/tutorial.js"];

--- a/tests/levels.test.mjs
+++ b/tests/levels.test.mjs
@@ -2,13 +2,7 @@
 // out-of-range preBuilt connection indices, traffic mixes that don't sum to 1,
 // and traffic types with no reachable destination (#159, #162, #184).
 import { describe, expect, it } from "vitest";
-import { loadScriptGlobals } from "./helpers/load-globals.mjs";
-
-// levels.js closes over CampaignObjectives inside check() functions — the
-// functions aren't called here, so a stub satisfies evaluation.
-const { CAMPAIGN_LEVELS } = loadScriptGlobals("src/campaign/levels.js", {
-  CampaignObjectives: {},
-});
+import { CAMPAIGN_LEVELS } from "../src/campaign/levels.js";
 
 describe("campaign levels", () => {
   it("has 14 levels with sequential ids", () => {

--- a/tests/locales.test.mjs
+++ b/tests/locales.test.mjs
@@ -5,7 +5,13 @@
 import { describe, expect, it } from "vitest";
 import { LOCALES, loadLocale } from "./helpers/load-globals.mjs";
 
-const en = loadLocale(LOCALES.find((l) => l.code === "en"));
+// Preload every dict with top-level await so the sync describe.each callbacks
+// below can look them up.
+const DICTS = new Map(
+  await Promise.all(LOCALES.map(async (l) => [l.code, await loadLocale(l)]))
+);
+
+const en = DICTS.get("en");
 const enKeys = Object.keys(en).sort();
 
 const PLACEHOLDER = /\{(\w+)\}/g;
@@ -16,7 +22,7 @@ function placeholders(str) {
 describe.each(LOCALES.filter((l) => l.code !== "en"))(
   "locale $code",
   (locale) => {
-    const dict = loadLocale(locale);
+    const dict = DICTS.get(locale.code);
 
     it("has every key that en has (missing keys render as raw key strings)", () => {
       const keys = new Set(Object.keys(dict));


### PR DESCRIPTION
Second of the 10 sequential PRs from #155. **The hard constraint holds:** zero build step — the browser loads the module graph natively via one `<script type="module" src="src/main.js">`; GitHub Pages serves the repo raw exactly as before. THREE r128 and Tailwind stay classic CDN tags.

## What changed
- All 21 first-party `<script src>` tags → a single module entry. Every file (`config`, `state`, `i18n` + 9 locales, `entities/*`, `SoundService`, `tutorial`, `campaign/*`, `game.js`) is now a real ES module with explicit imports/exports. Load order is encoded by the import graph instead of tag order.
- `game.js` exports the 14 functions that `Service.js` / `Request.js` / `campaign.js` call at runtime. The resulting import cycles are safe: hoisted function declarations, called at runtime only — never during module evaluation.
- **The window contract is now explicit.** index.html's inline handlers need globals; under module scope nothing is global by accident anymore. All 44 names verified programmatically. Three handlers (`restartGame`, `retryWithSameArchitecture`, `toggleAutoRepair`) were plain declarations that would have *silently* dropped off the global scope — now explicitly assigned. `window.STATE` kept because a generated hint button's inline `onclick` reaches it.
- **ESLint: `no-undef` is now ON** (`sourceType: module`, `THREE` global) — the payoff of the conversion: every cross-file reference is checked statically. It caught 7 bare cross-scope calls during the work.
- Tests: the vm-eval helper is gone — real dynamic imports. All 87 assertions unchanged, green.

## Bug found & fixed during verification
`onSaveGameFileUpload` called `window.loadGameState(saveData)` — under module scope that global no longer exists, so **uploading a save file was broken** (silently: caught by its try/catch and mis-reported as a corrupt file). Found by driving the real upload flow with a synthetic `File`, fixed to a direct module call, re-verified end-to-end.

## Verification
- `npm run check`: lint 0 problems (with `no-undef` on), 87/87 tests
- Full 22-module graph link-checked under `node --experimental-vm-modules` (catches any import/export name mismatch across the cycles)
- In-browser: clean boot, zero console errors; all 44 window names present; campaign level 2 prebuilds its topology through the internal `createService`/`createConnection` path; 50/50 requests processed via exported `spawnRequest` with campaign counters advancing; `campaign.tick()` clean; sandbox mode; save to localStorage; **save-file upload round-trip**; RU locale switch through `window.i18n`; sound service — all working (screenshot in thread)

## Unlocks
PR 3 (locales → JSON + validator) and PRs 4-6 (the actual `game.js` split) now happen inside an explicit dependency graph — every extraction is checked by `no-undef` instead of hope.