### PR TITLE
feat: category tabs for the service palette (+ fix campaign gating outliving the level)

### DIFF
--- a/docs/superpowers/specs/2026-07-24-toolbar-categories-design.md
+++ b/docs/superpowers/specs/2026-07-24-toolbar-categories-design.md
@@ -1,0 +1,122 @@
+# Toolbar categories — design
+
+**Date:** 2026-07-24
+**Status:** approved
+
+## Problem
+
+The bottom toolbar is one flat row of 30 buttons — 7 controls plus 23 service
+types — roughly 2000px wide. On any normal screen the right end is off-screen
+and the player has to scroll sideways to reach half the palette. Two aggravating
+details:
+
+- the container carries `overflow-y-auto` (vertical) while the overflow is
+  horizontal, which is why the scrolling feels broken rather than merely long;
+- `help`, `music` and `sfx` occupy the three leftmost slots — the most valuable
+  real estate on the bar — despite being settings, not gameplay.
+
+The palette grew from 13 to 23 services across Wave 1 (#193) and Wave 2 will add
+more, so "scroll further" is not a fix.
+
+## Approach
+
+Group the services into five category tabs. Only the active category's buttons
+are rendered, so the bar never scrolls.
+
+The categories are not an arbitrary bucketing — they are the cloud-domain map
+from the Wave 1 epic (#193). A player absorbs the taxonomy (front door →
+compute → data → async → ops) simply by using the toolbar, which serves the
+project's education north star. Two rejected alternatives, for the record:
+
+- **pinned favourites + an "all services" pop-up grid** — fixes the mechanics
+  but teaches nothing and introduces a two-tier mental model;
+- **a vertical side rail** — no horizontal scrolling ever, but it eats canvas
+  width and the left and right edges already hold four panels.
+
+## Categories
+
+| Tab | Services | Count |
+|---|---|---|
+| Front door | dns, cdn, waf, auth, apigw, alb | 6 |
+| Compute | compute, serverless, container | 3 |
+| Data | db, nosql, cache, s3, search, replica, warehouse | 7 |
+| Async | sqs, pubsub, stream, dlq, scheduler, notify | 6 |
+| Ops | monitor | 1 |
+
+The widest tab is 7 buttons (~480px), which fits comfortably on a laptop. Ops
+holds a single service today; it stays its own category because it is a real
+domain and the multi-region and chaos work will fill it.
+
+## Components
+
+**`src/ui/toolbar.js`** owns the palette:
+
+- `SERVICE_CATEGORIES` — plain data, one entry per tab with its `labelKey` and
+  its list of service types. Adding a service in a later wave means adding its
+  type to one array, matching the "one file plus one registry line" property the
+  handler registry already has (#155 PR 9).
+- `renderToolbar()` — draws the tab strip and the active category's buttons.
+- `setToolbarCategory(id)` — switches tab, re-renders, re-applies campaign
+  gating.
+
+**The button markup stays byte-identical to today** — same classes, same
+`id="tool-<type>"`, same cost badge, same `data-i18n` attributes. Campaign
+gating, hover tooltips and locale switching all find their elements exactly as
+before and need no changes.
+
+`index.html` keeps only the shell: the bar, the always-visible tool cluster, the
+tab strip and an empty `<div id="service-palette">` that the module fills.
+
+The four build tools (select, link, demolish, unlink) stay visible in every tab.
+They are modes, not services; hiding them behind a tab would make every build
+action a two-click affair.
+
+## Campaign interaction
+
+`applyCampaignToolbarGating` looks buttons up by id and disables the ones a
+level forbids. Tabs introduce a failure mode that does not exist today: level 2
+allows only Storage, so a player sitting on the Front door tab sees nothing but
+greyed-out buttons and reasonably concludes the game is broken.
+
+Two mitigations, both required:
+
+1. After gating, switch automatically to the first tab that contains an allowed
+   service.
+2. Show a small count of allowed services on each tab (`Data · 1`) so the
+   player can see where the level's tools actually are.
+
+Gating must also be re-applied on every tab switch — freshly rendered buttons
+would otherwise come up enabled regardless of the level's rules.
+
+## Smaller fixes carried in the same change
+
+- `help`, `music` and `sfx` move into a compact settings cluster (icon-only,
+  smaller) at the far edge of the bar.
+- `overflow-y-auto` becomes the correct horizontal handling.
+- The active tab is remembered in `localStorage`.
+- Keys `1`–`5` switch tabs. The existing `Esc`/`H`/`R`/`T` shortcuts are
+  untouched.
+
+## Testing
+
+The load-bearing test is a **completeness invariant**: every placeable type in
+`CONFIG.services` belongs to exactly one category. This catches the future
+service that someone forgets to categorise and which would silently become
+unreachable — the same class of protection the locale-parity test provides.
+
+Also covered:
+
+- switching tabs preserves campaign gating;
+- a campaign level auto-selects a tab that holds one of its allowed services;
+- the settings cluster still drives `toggleMusic` / `toggleSfx`;
+- rendering is idempotent (re-rendering does not duplicate buttons).
+
+## i18n
+
+Five category labels across all nine locales. The i18n-usage test will fail on
+any key referenced but not defined, so a missed translation cannot ship.
+
+## Constraints
+
+No build step; native ESM; no new runtime dependencies. Vector SVG icons only.
+The game must remain directly hostable on GitHub Pages, served raw.

--- a/game.js
+++ b/game.js
@@ -82,8 +82,16 @@ import {
     lastPointerPos,
     resetCamera,
 } from "./src/input/handlers.js";
+// Service palette (toolbar categories, 2026-07-24): index.html ships only the
+// empty shell, so the tab strip and the active category's buttons are drawn
+// from here. The call sits in the body, not in toolbar.js's own evaluation,
+// so that handlers.js is fully evaluated first — it listens for the
+// "toolbarRendered" event to re-wire the button tooltips.
+import { applyToolbarGating, renderToolbar } from "./src/ui/toolbar.js";
 
 STATE.sound = new SoundService();
+
+renderToolbar();
 
 // ==================== UTILITY FUNCTIONS ====================
 
@@ -278,6 +286,12 @@ function resetGame(mode = "survival") {
     STATE.sound.init();
     STATE.sound.playGameBGM();
     STATE.gameMode = mode;
+
+    // Campaign gating is applied when a level starts but nothing ever cleared
+    // it, so leaving a level for sandbox or survival left most of the toolbar
+    // dead (reproduced on the pre-toolbar build too — this is an old bug, not
+    // a side effect of the category tabs). Any non-campaign mode starts ungated.
+    if (mode !== "campaign") applyToolbarGating([], []);
 
     // Set budget based on mode
     if (mode === "campaign") {

--- a/index.html
+++ b/index.html
@@ -515,39 +515,15 @@
   </div>
 
   <!-- UI Overlay: Bottom Toolbar -->
-  <div class="absolute bottom-6 left-0 w-full z-10 pointer-events-none flex justify-center">
-    <div class="glass-panel rounded-2xl p-2 pointer-events-auto overflow-y-auto flex items-center gap-2 shadow-2xl">
-      <!-- Help Button -->
-      <button id="tool-help"
-        class="service-btn bg-gray-700 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center mr-2 border border-gray-600"
-        onclick="showFAQ()">
-        <div class="text-xl">?</div>
-        <span data-i18n="help" class="text-[9px] font-bold mt-1 uppercase">Help</span>
-      </button>
-
-      <!-- Music / SFX toggles (#112) -->
-      <button id="tool-music"
-        class="service-btn bg-gray-700 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-gray-600 bg-red-900 pulse-green"
-        onclick="toggleMusic()">
-        <svg id="music-icon" class="w-6 h-6 opacity-40" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9 18V6l10-2v12" />
-          <circle cx="7" cy="18" r="2" />
-          <circle cx="17" cy="16" r="2" />
-        </svg>
-        <span data-i18n="music" class="text-[9px] font-bold mt-1 uppercase">Music</span>
-      </button>
-      <button id="tool-sfx"
-        class="service-btn bg-gray-700 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-gray-600 bg-red-900 pulse-green"
-        onclick="toggleSfx()">
-        <svg id="sfx-icon" class="w-6 h-6 opacity-40" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M11 5 6 9H3v6h3l5 4V5z" />
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15.5 8.5a5 5 0 0 1 0 7M18 6a8.5 8.5 0 0 1 0 12" />
-        </svg>
-        <span data-i18n="sfx" class="text-[9px] font-bold mt-1 uppercase">SFX</span>
-      </button>
-
-      <!-- Tools -->
-      <div class="flex gap-1 pr-4 border-r border-gray-700">
+  <!-- Layout (toolbar categories, 2026-07-24): build tools · service palette ·
+       settings. The palette is a tab strip plus the active category's buttons,
+       both filled by src/ui/toolbar.js — the flat 23-button run that used to
+       live here was ~2000px wide, so half of it hung off-screen, and the bar
+       scrolled on the wrong axis (overflow-y) while overflowing horizontally. -->
+  <div class="absolute bottom-6 left-0 w-full z-10 pointer-events-none flex justify-center px-4">
+    <div class="glass-panel rounded-2xl p-2 pointer-events-auto max-w-full overflow-x-auto overflow-y-hidden flex items-center gap-2 shadow-2xl">
+      <!-- Build tools: modes, not services, so they stay visible in every category -->
+      <div class="flex gap-1 pr-2 border-r border-gray-700">
         <button id="tool-select"
           class="service-btn active bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent"
           onclick="setTool('select')">
@@ -592,301 +568,44 @@
         </button>
       </div>
 
-      <!-- Shop -->
-      <div class="flex gap-2 pl-2">
-        <!-- WAF -->
-        <button id="tool-waf"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('waf')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $40
-          </div>
-          <div class="w-4 h-4 bg-purple-500 rounded-sm mb-1 shadow-[0_0_10px_rgba(168,85,247,0.6)]"></div>
-          <span data-i18n="fw" class="text-[10px] font-bold mt-1">FW</span>
-        </button>
+      <!-- Service palette — category tabs above, the active category's service
+           buttons below. Both are rendered by src/ui/toolbar.js. -->
+      <div class="flex flex-col gap-1 px-1">
+        <div id="service-tabs" class="flex gap-1"></div>
+        <div id="service-palette" class="flex gap-2"></div>
+      </div>
 
-        <!-- API Gateway -->
-        <button id="tool-apigw"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('apigw')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $70
-          </div>
-          <div class="w-4 h-4 bg-fuchsia-400 rounded-sm mb-1 shadow-[0_0_10px_rgba(232,121,249,0.6)]" style="transform: rotate(45deg)"></div>
-          <span data-i18n="apigw_short" class="text-[10px] font-bold mt-1">API GW</span>
-        </button>
-
-        <!-- SQS -->
-        <button id="tool-sqs"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('sqs')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $45
-          </div>
-          <div class="w-5 h-3 bg-orange-500 rounded-sm mb-1 shadow-[0_0_10px_rgba(255,153,0,0.6)]"></div>
-          <span data-i18n="queue" class="text-[10px] font-bold mt-1">Queue</span>
-        </button>
-
-        <button id="tool-alb"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('alb')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $50
-          </div>
-          <div class="w-4 h-4 bg-blue-500 rounded-sm mb-1 shadow-[0_0_10px_rgba(59,130,246,0.6)]"></div>
-          <span data-i18n="lb" class="text-[10px] font-bold mt-1">LB</span>
-        </button>
-
-        <button id="tool-lambda"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('lambda')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $60
-          </div>
-          <div class="w-4 h-4 bg-orange-500 rounded-full mb-1 shadow-[0_0_10px_rgba(249,115,22,0.6)]"></div>
-          <span data-i18n="compute_short" class="text-[10px] font-bold mt-1">Compute</span>
-        </button>
-
-        <!-- Serverless Function -->
-        <button id="tool-serverless"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('serverless')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $45
-          </div>
-          <div class="w-0 h-0 border-l-[8px] border-l-transparent border-r-[8px] border-r-transparent border-b-[14px] border-b-amber-400 mb-1 shadow-[0_0_10px_rgba(251,191,36,0.6)]"></div>
-          <span data-i18n="serverless_short" class="text-[10px] font-bold mt-1">λ Func</span>
-        </button>
-
-        <button id="tool-db"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('db')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $150
-          </div>
-          <div
-            class="w-4 h-4 bg-red-600 rounded-sm mb-1 shadow-[0_0_10px_rgba(220,38,38,0.6)] border-b-2 border-red-800">
-          </div>
-          <span data-i18n="db_short" class="text-[10px] font-bold mt-1">SQL DB</span>
-        </button>
-
-        <!-- NoSQL DB -->
-        <button id="tool-nosql"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('nosql')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $80
-          </div>
-          <div
-            class="w-4 h-4 bg-violet-600 rounded-full mb-1 shadow-[0_0_10px_rgba(124,58,237,0.6)] border-b-2 border-violet-800">
-          </div>
-          <span data-i18n="nosql_short" class="text-[10px] font-bold mt-1">NoSQL</span>
-        </button>
-
-        <!-- Cache -->
-        <button id="tool-cache"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('cache')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $60
-          </div>
-          <div class="w-4 h-4 bg-red-600 rounded mb-1 shadow-[0_0_10px_rgba(220,56,45,0.6)]"></div>
-          <span data-i18n="cache_short" class="text-[10px] font-bold mt-1">Cache</span>
-        </button>
-
-        <!-- CDN -->
-        <button id="tool-cdn"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('cdn')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $60
-          </div>
-          <div
-            class="w-4 h-4 bg-green-400 rounded-full mb-1 shadow-[0_0_10px_rgba(74,222,128,0.6)] border border-white">
-          </div>
-          <span data-i18n="cdn_short" class="text-[10px] font-bold mt-1">CDN</span>
-        </button>
-
-        <!-- S3 -->
-        <button id="tool-s3"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('s3')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $25
-          </div>
-          <div class="w-4 h-4 bg-emerald-500 rounded-full mb-1 shadow-[0_0_10px_rgba(16,185,129,0.6)]"></div>
-          <span data-i18n="storage_short" class="text-[10px] font-bold mt-1">Storage</span>
-        </button>
-
-        <!-- Search Engine -->
-        <button id="tool-search"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('search')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $120
-          </div>
-          <div
-            class="w-4 h-4 bg-cyan-500 rounded-sm mb-1 shadow-[0_0_10px_rgba(6,182,212,0.6)]" style="transform: rotate(22deg)">
-          </div>
-          <span data-i18n="search_short" class="text-[10px] font-bold mt-1">Search</span>
-        </button>
-
-        <!-- Read Replica -->
-        <button id="tool-replica"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('replica')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $100
-          </div>
-          <div
-            class="w-4 h-4 bg-pink-400 rounded-sm mb-1 shadow-[0_0_10px_rgba(244,114,182,0.6)] border-b-2 border-pink-600">
-          </div>
-          <span data-i18n="replica_short" class="text-[10px] font-bold mt-1">Replica</span>
-        </button>
-
-        <!-- Monitoring (#194) -->
-        <button id="tool-monitor"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('monitor')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $75
-          </div>
-          <div
-            class="w-4 h-4 bg-teal-400 rounded-full mb-1 shadow-[0_0_10px_rgba(20,184,166,0.6)] border-2 border-teal-700">
-          </div>
-          <span data-i18n="monitor_short" class="text-[10px] font-bold mt-1">Monitor</span>
-        </button>
-
-        <!-- Dead-Letter Queue (#197) -->
-        <button id="tool-dlq"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('dlq')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $55
-          </div>
-          <div
-            class="w-4 h-4 bg-stone-500 rounded-sm mb-1 shadow-[0_0_10px_rgba(120,113,108,0.6)] border-b-2 border-stone-700">
-          </div>
-          <span data-i18n="dlq_short" class="text-[10px] font-bold mt-1">DLQ</span>
-        </button>
-
-        <!-- Pub/Sub Topic (#197) -->
-        <button id="tool-pubsub"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('pubsub')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $65
-          </div>
-          <div
-            class="w-4 h-4 bg-indigo-400 mb-1 shadow-[0_0_10px_rgba(129,140,248,0.6)]" style="clip-path: polygon(50% 0, 100% 100%, 0 100%)">
-          </div>
-          <span data-i18n="pubsub_short" class="text-[10px] font-bold mt-1">Pub/Sub</span>
-        </button>
-
-        <!-- Identity Provider (#197) -->
-        <button id="tool-auth"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('auth')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $55
-          </div>
-          <div
-            class="w-3 h-4 bg-yellow-500 rounded-sm mb-1 shadow-[0_0_10px_rgba(234,179,8,0.6)] border border-yellow-700">
-          </div>
-          <span data-i18n="auth_short" class="text-[10px] font-bold mt-1">Auth</span>
-        </button>
-
-        <!-- Scheduler / Cron (#197) -->
-        <button id="tool-scheduler"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('scheduler')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $50
-          </div>
-          <div
-            class="w-4 h-4 bg-sky-400 rounded-full mb-1 shadow-[0_0_10px_rgba(56,189,248,0.6)] border border-sky-700">
-          </div>
-          <span data-i18n="scheduler_short" class="text-[10px] font-bold mt-1">Cron</span>
-        </button>
-
-        <!-- Notification (#197) -->
-        <button id="tool-notify"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('notify')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $40
-          </div>
-          <div
-            class="w-4 h-4 bg-rose-400 mb-1 shadow-[0_0_10px_rgba(251,113,133,0.6)]" style="clip-path: polygon(0 100%, 100% 100%, 50% 0)">
-          </div>
-          <span data-i18n="notify_short" class="text-[10px] font-bold mt-1">Notify</span>
-        </button>
-
-        <!-- Container Cluster (#198) -->
-        <button id="tool-container"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('container')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $120
-          </div>
-          <svg viewBox="0 0 16 16" class="w-4 h-4 mb-1 text-blue-400" fill="none" stroke="currentColor"
-            stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <rect x="1.5" y="6" width="5" height="4.5" rx="0.5" />
-            <rect x="9.5" y="6" width="5" height="4.5" rx="0.5" />
-            <rect x="5.5" y="1.5" width="5" height="4.5" rx="0.5" />
+      <!-- Settings: help / music / sfx. Icon-only and out at the edge — they
+           are settings, not gameplay, and used to hold the three leftmost slots. -->
+      <div class="flex gap-1 pl-2 border-l border-gray-700">
+        <button id="tool-help" title="Help" data-i18n-title="help"
+          class="service-btn bg-gray-700 text-gray-200 rounded-lg w-8 h-8 flex items-center justify-center border border-gray-600"
+          onclick="showFAQ()">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round"
+              d="M9.5 9a2.5 2.5 0 1 1 3.5 2.3c-.6.3-1 .9-1 1.6v.6" />
+            <circle cx="12" cy="17" r="1" fill="currentColor" stroke="none" />
+            <circle cx="12" cy="12" r="9" />
           </svg>
-          <span data-i18n="container_short" class="text-[10px] font-bold mt-1">Cluster</span>
         </button>
 
-        <!-- Stream (#198) -->
-        <button id="tool-stream"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('stream')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $90
-          </div>
-          <svg viewBox="0 0 16 16" class="w-4 h-4 mb-1 text-teal-400" fill="none" stroke="currentColor"
-            stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M1.5 4h13" />
-            <path d="M1.5 8h13" />
-            <path d="M1.5 12h13" />
-            <circle cx="5" cy="4" r="0.4" fill="currentColor" />
-            <circle cx="10" cy="8" r="0.4" fill="currentColor" />
-            <circle cx="7" cy="12" r="0.4" fill="currentColor" />
+        <!-- Music / SFX toggles (#112) -->
+        <button id="tool-music" title="Music" data-i18n-title="music"
+          class="service-btn bg-gray-700 text-gray-200 rounded-lg w-8 h-8 flex items-center justify-center border border-gray-600 bg-red-900 pulse-green"
+          onclick="toggleMusic()">
+          <svg id="music-icon" class="w-4 h-4 opacity-40" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 18V6l10-2v12" />
+            <circle cx="7" cy="18" r="2" />
+            <circle cx="17" cy="16" r="2" />
           </svg>
-          <span data-i18n="stream_short" class="text-[10px] font-bold mt-1">Stream</span>
         </button>
-
-        <!-- GeoDNS (#198) -->
-        <button id="tool-dns"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('dns')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $50
-          </div>
-          <svg viewBox="0 0 16 16" class="w-4 h-4 mb-1 text-lime-400" fill="none" stroke="currentColor"
-            stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="8" cy="8" r="6.2" />
-            <path d="M1.8 8h12.4" />
-            <path d="M8 1.8c2 2 2 10.4 0 12.4-2-2-2-10.4 0-12.4Z" />
+        <button id="tool-sfx" title="SFX" data-i18n-title="sfx"
+          class="service-btn bg-gray-700 text-gray-200 rounded-lg w-8 h-8 flex items-center justify-center border border-gray-600 bg-red-900 pulse-green"
+          onclick="toggleSfx()">
+          <svg id="sfx-icon" class="w-4 h-4 opacity-40" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M11 5 6 9H3v6h3l5 4V5z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15.5 8.5a5 5 0 0 1 0 7M18 6a8.5 8.5 0 0 1 0 12" />
           </svg>
-          <span data-i18n="dns_short" class="text-[10px] font-bold mt-1">GeoDNS</span>
-        </button>
-
-        <!-- Data Warehouse (#198) -->
-        <button id="tool-warehouse"
-          class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent group relative overflow-hidden"
-          onclick="setTool('warehouse')">
-          <div class="absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono">
-            $90
-          </div>
-          <svg viewBox="0 0 16 16" class="w-4 h-4 mb-1 text-amber-500" fill="none" stroke="currentColor"
-            stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M1.5 6.5 8 2l6.5 4.5" />
-            <path d="M2.5 6.5v7.5h11V6.5" />
-            <path d="M5 14v-4h6v4" />
-          </svg>
-          <span data-i18n="warehouse_short" class="text-[10px] font-bold mt-1">Warehouse</span>
         </button>
       </div>
     </div>

--- a/src/input/handlers.js
+++ b/src/input/handlers.js
@@ -18,6 +18,7 @@ import {
     toggleAutoscaling,
     warmingCount,
 } from "../sim/autoscaling.js";
+import { SERVICE_CATEGORIES, setToolbarCategory } from "../ui/toolbar.js";
 import {
     createConnection,
     createService,
@@ -745,8 +746,13 @@ function setupUITooltips() {
     });
 }
 
-// Call setup
+// Call setup. The service buttons are re-created every time the player
+// switches category (toolbar categories, 2026-07-24), and listeners die with
+// the nodes they were attached to — so re-run the wiring on every render.
+// The toolbar module cannot call this directly: it is imported BY this file
+// (for the 1-5 shortcuts below), so the signal travels back as an event.
 setupUITooltips();
+window.addEventListener("toolbarRendered", setupUITooltips);
 
 container.addEventListener("mouseup", (e) => {
     if (e.button === 2 || e.button === 1) {
@@ -798,7 +804,35 @@ window.addEventListener("resize", () => {
     renderer.setSize(window.innerWidth, window.innerHeight);
 });
 
+// True while the player is typing into one of the sandbox panel's fields —
+// the digit shortcuts below must not steal those keystrokes. (The older
+// Esc/H/R/T shortcuts have never had this guard; left exactly as they were,
+// widening them is not this change's business.)
+function isTypingTarget(el) {
+    if (!el || !el.tagName) return false;
+    return (
+        el.tagName === "INPUT" ||
+        el.tagName === "TEXTAREA" ||
+        el.tagName === "SELECT" ||
+        el.isContentEditable === true
+    );
+}
+
 document.addEventListener("keydown", (event) => {
+    // Keys 1-5 switch service-palette categories. Bare digits only: Cmd/Ctrl+1
+    // is the browser's own tab switch, and Alt-digits are OS shortcuts.
+    if (
+        event.key >= "1" &&
+        event.key <= "5" &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey &&
+        !isTypingTarget(event.target)
+    ) {
+        const category = SERVICE_CATEGORIES[Number(event.key) - 1];
+        if (category) setToolbarCategory(category.id);
+        return;
+    }
     if (event.key === "Escape") {
         // Toggle main menu
         const menu = document.getElementById("main-menu-modal");

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -158,6 +158,13 @@ export const DE_TRANSLATIONS = {
     "link": "Verbinden",
     "demolish": "Abreißen",
     "unlink": "Trennen",
+
+    // Service-palette category tabs (toolbar categories, 2026-07-24)
+    "cat_frontdoor": "Eingang",
+    "cat_compute": "Rechnen",
+    "cat_data": "Daten",
+    "cat_async": "Asynchron",
+    "cat_ops": "Betrieb",
     "fw": "FW",
     "queue": "Queue",
     "lb": "LB",

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -158,6 +158,13 @@ export const EN_TRANSLATIONS = {
     "link": "Link",
     "demolish": "Demolish",
     "unlink": "Unlink",
+
+    // Service-palette category tabs (toolbar categories, 2026-07-24)
+    "cat_frontdoor": "Front Door",
+    "cat_compute": "Compute",
+    "cat_data": "Data",
+    "cat_async": "Async",
+    "cat_ops": "Ops",
     "fw": "FW",
     "queue": "Queue",
     "lb": "LB",

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -158,6 +158,13 @@ export const FR_TRANSLATIONS = {
     "link": "Lien",
     "demolish": "Démolir",
     "unlink": "Délier",
+
+    // Service-palette category tabs (toolbar categories, 2026-07-24)
+    "cat_frontdoor": "Entrée",
+    "cat_compute": "Calcul",
+    "cat_data": "Données",
+    "cat_async": "Asynchrone",
+    "cat_ops": "Exploitation",
     "fw": "PF",
     "queue": "File",
     "lb": "RC",

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -158,6 +158,13 @@ export const IT_TRANSLATIONS = {
     "link": "Collega",
     "demolish": "Demolisci",
     "unlink": "Scollega",
+
+    // Service-palette category tabs (toolbar categories, 2026-07-24)
+    "cat_frontdoor": "Ingresso",
+    "cat_compute": "Calcolo",
+    "cat_data": "Dati",
+    "cat_async": "Asincrono",
+    "cat_ops": "Operazioni",
     "fw": "FW",
     "queue": "Coda",
     "lb": "LB",

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -158,6 +158,13 @@ export const KO_TRANSLATIONS = {
     "link": "연결",
     "demolish": "철거",
     "unlink": "연결 해제",
+
+    // Service-palette category tabs (toolbar categories, 2026-07-24)
+    "cat_frontdoor": "진입점",
+    "cat_compute": "컴퓨트",
+    "cat_data": "데이터",
+    "cat_async": "비동기",
+    "cat_ops": "운영",
     "fw": "방화벽",
     "queue": "큐",
     "lb": "LB",

--- a/src/locales/nep.js
+++ b/src/locales/nep.js
@@ -158,6 +158,13 @@ export const NE_TRANSLATIONS = {
     "link": "लिंक",
     "demolish": "भत्काउनुहोस्",
     "unlink": "अनलिंक",
+
+    // Service-palette category tabs (toolbar categories, 2026-07-24)
+    "cat_frontdoor": "प्रवेशद्वार",
+    "cat_compute": "गणना",
+    "cat_data": "डाटा",
+    "cat_async": "एसिन्क्रोनस",
+    "cat_ops": "सञ्चालन",
     "fw": "FW",
     "queue": "क्यू",
     "lb": "LB",

--- a/src/locales/pt-BR.js
+++ b/src/locales/pt-BR.js
@@ -158,6 +158,13 @@ export const PT_BR_TRANSLATIONS = {
     "link": "Conectar",
     "demolish": "Demolir",
     "unlink": "Desconectar",
+
+    // Service-palette category tabs (toolbar categories, 2026-07-24)
+    "cat_frontdoor": "Entrada",
+    "cat_compute": "Computação",
+    "cat_data": "Dados",
+    "cat_async": "Assíncrono",
+    "cat_ops": "Operações",
     "fw": "Firewall",
     "queue": "Fila",
     "lb": "Load Balancer",

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -158,6 +158,13 @@ export const RU_TRANSLATIONS = {
     "link": "Соединить",
     "demolish": "Удалить",
     "unlink": "Разорвать связь",
+
+    // Service-palette category tabs (toolbar categories, 2026-07-24)
+    "cat_frontdoor": "Вход",
+    "cat_compute": "Вычисления",
+    "cat_data": "Данные",
+    "cat_async": "Асинхрон",
+    "cat_ops": "Эксплуатация",
     "fw": "FW",
     "queue": "Очередь",
     "lb": "LB",

--- a/src/locales/zh.js
+++ b/src/locales/zh.js
@@ -158,6 +158,13 @@ export const ZH_TRANSLATIONS = {
     "link": "连接",
     "demolish": "拆除",
     "unlink": "断开",
+
+    // Service-palette category tabs (toolbar categories, 2026-07-24)
+    "cat_frontdoor": "入口",
+    "cat_compute": "计算",
+    "cat_data": "数据",
+    "cat_async": "异步",
+    "cat_ops": "运维",
     "fw": "防火墙",
     "queue": "队列",
     "lb": "负载均衡",

--- a/src/ui/campaign-ui.js
+++ b/src/ui/campaign-ui.js
@@ -10,6 +10,7 @@ import { renderArchitectureSVG } from "../campaign/diagram.js";
 import { Service } from "../entities/Service.js";
 import { updateRepairCostTable } from "../core/economy.js";
 import { createConnection } from "../sim/topology.js";
+import { applyToolbarGating } from "./toolbar.js";
 // Runtime-only cycle (game.js ⇄ campaign-ui.js) — established pattern:
 // resetGame is a hoisted function declaration in game.js, only called at
 // runtime, long after both modules evaluate.
@@ -212,55 +213,15 @@ function startCampaignLevel(levelId) {
     // pulse-green on btn-play, so nothing else to do here.
 }
 
+// Grey out the services a level does not offer. The buttons themselves moved
+// into the service palette (toolbar categories, 2026-07-24), which re-creates
+// them on every tab switch, so the gate has to OUTLIVE a single DOM pass —
+// src/ui/toolbar.js stores it and re-paints on each render, and also switches
+// the player to a tab that actually holds one of this level's services. That
+// makes the order irrelevant: a gate set before the toolbar's first render is
+// remembered and painted by it, one set after paints the buttons on screen.
 function applyCampaignToolbarGating(allowed, forbidden) {
-    // Map service config keys to their toolbar button IDs.
-    // (matches the toolbar typeMap in mousedown handler)
-    const toolMap = {
-        waf: "tool-waf", apigw: "tool-apigw", sqs: "tool-sqs", alb: "tool-alb",
-        lambda: "tool-lambda", serverless: "tool-serverless",
-        db: "tool-db", nosql: "tool-nosql", cache: "tool-cache",
-        cdn: "tool-cdn", s3: "tool-s3", search: "tool-search", replica: "tool-replica",
-        monitor: "tool-monitor",
-        // Sandbox archetypes, batch 1 (#197). Campaign levels use an allow-list,
-        // so these are simply never offered by existing levels — no existing
-        // level is gated behind them.
-        dlq: "tool-dlq", pubsub: "tool-pubsub", auth: "tool-auth",
-        scheduler: "tool-scheduler", notify: "tool-notify",
-        // Sandbox archetypes, batch 2 (#198) — same story: allow-list levels
-        // never offer them, so no existing level is gated behind them.
-        container: "tool-container", stream: "tool-stream",
-        dns: "tool-dns", warehouse: "tool-warehouse",
-    };
-
-    // First clear any prior gating
-    Object.values(toolMap).forEach((id) => {
-        const btn = document.getElementById(id);
-        if (!btn) return;
-        btn.classList.remove("opacity-30", "pointer-events-none");
-        btn.removeAttribute("data-campaign-blocked");
-    });
-
-    const allowSet = allowed && allowed.length ? new Set(allowed) : null;
-    const blockSet = new Set(forbidden || []);
-
-    // The "lambda" tool is a button for compute service.
-    // Normalize: allowSet uses CONFIG keys, but toolMap key for compute is "lambda".
-    // To gate compute, accept both "compute" and "lambda" in allowed/forbidden lists.
-    const isAllowed = (toolKey) => {
-        if (!allowSet) return !blockSet.has(toolKey) && !blockSet.has(toolKey === "lambda" ? "compute" : toolKey);
-        if (allowSet.has(toolKey)) return true;
-        if (toolKey === "lambda" && allowSet.has("compute")) return true;
-        return false;
-    };
-
-    Object.entries(toolMap).forEach(([k, id]) => {
-        if (!isAllowed(k)) {
-            const btn = document.getElementById(id);
-            if (!btn) return;
-            btn.classList.add("opacity-30", "pointer-events-none");
-            btn.setAttribute("data-campaign-blocked", "true");
-        }
-    });
+    applyToolbarGating(allowed, forbidden);
 }
 
 function renderCampaignObjectives(level, primaryResults, bonusResults) {

--- a/src/ui/toolbar.js
+++ b/src/ui/toolbar.js
@@ -1,0 +1,392 @@
+// Service palette with category tabs
+// (docs/superpowers/specs/2026-07-24-toolbar-categories-design.md).
+//
+// The bottom bar used to carry all 23 service buttons in one flat ~2000px run,
+// so half the palette hung off-screen and the player had to scroll sideways to
+// reach it. This module owns that half of the bar: five category tabs — the
+// cloud-domain map from the Wave 1 epic (#193): front door → compute → data →
+// async → ops — of which only the active one's buttons exist in the DOM.
+//
+// The buttons are generated from the markup index.html used to hold verbatim:
+// same classes, same id="tool-<type>", same cost badge (read from CONFIG so it
+// can no longer drift), same label span. Campaign gating and the hover
+// tooltips look their elements up by id, and locale switching by attribute, so
+// none of them needed a change. Two things DO have to be redone after every
+// render, because the buttons are new nodes each time:
+//
+//   1. the labels — re-translated here (paintLabels);
+//   2. the toolbar tooltips in input/handlers.js — that module imports THIS
+//      one for the 1-5 shortcuts, so it cannot be imported back; instead every
+//      render dispatches a "toolbarRendered" event which handlers.js listens
+//      for. game.js calls renderToolbar() from its body, i.e. after the whole
+//      module graph (including that listener) has evaluated.
+//
+// Campaign gating is stored here too — see applyToolbarGating.
+
+import { CONFIG } from "../config.js";
+import { STATE } from "../state.js";
+import { i18n } from "../i18n.js";
+
+// The five tabs. Adding a service in a later wave means adding its CONFIG
+// type to one of these arrays — the completeness test in tests/sim/toolbar.
+// test.mjs fails the build if a placeable type is in none of them (it would
+// silently become unreachable) or in two.
+const SERVICE_CATEGORIES = [
+    {
+        id: "frontdoor",
+        labelKey: "cat_frontdoor",
+        types: ["dns", "cdn", "waf", "auth", "apigw", "alb"],
+    },
+    {
+        id: "compute",
+        labelKey: "cat_compute",
+        types: ["compute", "serverless", "container"],
+    },
+    {
+        id: "data",
+        labelKey: "cat_data",
+        types: ["db", "nosql", "cache", "s3", "search", "replica", "warehouse"],
+    },
+    {
+        id: "async",
+        labelKey: "cat_async",
+        types: ["sqs", "pubsub", "stream", "dlq", "scheduler", "notify"],
+    },
+    {
+        id: "ops",
+        labelKey: "cat_ops",
+        types: ["monitor"],
+    },
+];
+
+// Per-service button data, keyed by CONFIG.services type.
+//   tool  — the value setTool() gets and the id suffix, when it differs from
+//           the config type. Only Compute does: its button has always been
+//           id="tool-lambda" / setTool('lambda'), and the typeMap in
+//           input/handlers.js plus the toolMap in ui/campaign-ui.js are
+//           written in those terms. Renaming it is a separate change.
+//   key   — i18n key of the label; text — its untranslated fallback.
+//   icon  — the coloured shape, copied from index.html unchanged.
+// The cost badge is NOT here: it comes from CONFIG.services[type].cost.
+const SERVICE_BUTTONS = {
+    waf: {
+        key: "fw",
+        text: "FW",
+        icon: `<div class="w-4 h-4 bg-purple-500 rounded-sm mb-1 shadow-[0_0_10px_rgba(168,85,247,0.6)]"></div>`,
+    },
+    apigw: {
+        key: "apigw_short",
+        text: "API GW",
+        icon: `<div class="w-4 h-4 bg-fuchsia-400 rounded-sm mb-1 shadow-[0_0_10px_rgba(232,121,249,0.6)]" style="transform: rotate(45deg)"></div>`,
+    },
+    sqs: {
+        key: "queue",
+        text: "Queue",
+        icon: `<div class="w-5 h-3 bg-orange-500 rounded-sm mb-1 shadow-[0_0_10px_rgba(255,153,0,0.6)]"></div>`,
+    },
+    alb: {
+        key: "lb",
+        text: "LB",
+        icon: `<div class="w-4 h-4 bg-blue-500 rounded-sm mb-1 shadow-[0_0_10px_rgba(59,130,246,0.6)]"></div>`,
+    },
+    compute: {
+        tool: "lambda",
+        key: "compute_short",
+        text: "Compute",
+        icon: `<div class="w-4 h-4 bg-orange-500 rounded-full mb-1 shadow-[0_0_10px_rgba(249,115,22,0.6)]"></div>`,
+    },
+    serverless: {
+        key: "serverless_short",
+        text: "λ Func",
+        icon: `<div class="w-0 h-0 border-l-[8px] border-l-transparent border-r-[8px] border-r-transparent border-b-[14px] border-b-amber-400 mb-1 shadow-[0_0_10px_rgba(251,191,36,0.6)]"></div>`,
+    },
+    db: {
+        key: "db_short",
+        text: "SQL DB",
+        icon: `<div class="w-4 h-4 bg-red-600 rounded-sm mb-1 shadow-[0_0_10px_rgba(220,38,38,0.6)] border-b-2 border-red-800"></div>`,
+    },
+    nosql: {
+        key: "nosql_short",
+        text: "NoSQL",
+        icon: `<div class="w-4 h-4 bg-violet-600 rounded-full mb-1 shadow-[0_0_10px_rgba(124,58,237,0.6)] border-b-2 border-violet-800"></div>`,
+    },
+    cache: {
+        key: "cache_short",
+        text: "Cache",
+        icon: `<div class="w-4 h-4 bg-red-600 rounded mb-1 shadow-[0_0_10px_rgba(220,56,45,0.6)]"></div>`,
+    },
+    cdn: {
+        key: "cdn_short",
+        text: "CDN",
+        icon: `<div class="w-4 h-4 bg-green-400 rounded-full mb-1 shadow-[0_0_10px_rgba(74,222,128,0.6)] border border-white"></div>`,
+    },
+    s3: {
+        key: "storage_short",
+        text: "Storage",
+        icon: `<div class="w-4 h-4 bg-emerald-500 rounded-full mb-1 shadow-[0_0_10px_rgba(16,185,129,0.6)]"></div>`,
+    },
+    search: {
+        key: "search_short",
+        text: "Search",
+        icon: `<div class="w-4 h-4 bg-cyan-500 rounded-sm mb-1 shadow-[0_0_10px_rgba(6,182,212,0.6)]" style="transform: rotate(22deg)"></div>`,
+    },
+    replica: {
+        key: "replica_short",
+        text: "Replica",
+        icon: `<div class="w-4 h-4 bg-pink-400 rounded-sm mb-1 shadow-[0_0_10px_rgba(244,114,182,0.6)] border-b-2 border-pink-600"></div>`,
+    },
+    monitor: {
+        key: "monitor_short",
+        text: "Monitor",
+        icon: `<div class="w-4 h-4 bg-teal-400 rounded-full mb-1 shadow-[0_0_10px_rgba(20,184,166,0.6)] border-2 border-teal-700"></div>`,
+    },
+    dlq: {
+        key: "dlq_short",
+        text: "DLQ",
+        icon: `<div class="w-4 h-4 bg-stone-500 rounded-sm mb-1 shadow-[0_0_10px_rgba(120,113,108,0.6)] border-b-2 border-stone-700"></div>`,
+    },
+    pubsub: {
+        key: "pubsub_short",
+        text: "Pub/Sub",
+        icon: `<div class="w-4 h-4 bg-indigo-400 mb-1 shadow-[0_0_10px_rgba(129,140,248,0.6)]" style="clip-path: polygon(50% 0, 100% 100%, 0 100%)"></div>`,
+    },
+    auth: {
+        key: "auth_short",
+        text: "Auth",
+        icon: `<div class="w-3 h-4 bg-yellow-500 rounded-sm mb-1 shadow-[0_0_10px_rgba(234,179,8,0.6)] border border-yellow-700"></div>`,
+    },
+    scheduler: {
+        key: "scheduler_short",
+        text: "Cron",
+        icon: `<div class="w-4 h-4 bg-sky-400 rounded-full mb-1 shadow-[0_0_10px_rgba(56,189,248,0.6)] border border-sky-700"></div>`,
+    },
+    notify: {
+        key: "notify_short",
+        text: "Notify",
+        icon: `<div class="w-4 h-4 bg-rose-400 mb-1 shadow-[0_0_10px_rgba(251,113,133,0.6)]" style="clip-path: polygon(0 100%, 100% 100%, 50% 0)"></div>`,
+    },
+    container: {
+        key: "container_short",
+        text: "Cluster",
+        icon: `<svg viewBox="0 0 16 16" class="w-4 h-4 mb-1 text-blue-400" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="1.5" y="6" width="5" height="4.5" rx="0.5" /><rect x="9.5" y="6" width="5" height="4.5" rx="0.5" /><rect x="5.5" y="1.5" width="5" height="4.5" rx="0.5" /></svg>`,
+    },
+    stream: {
+        key: "stream_short",
+        text: "Stream",
+        icon: `<svg viewBox="0 0 16 16" class="w-4 h-4 mb-1 text-teal-400" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1.5 4h13" /><path d="M1.5 8h13" /><path d="M1.5 12h13" /><circle cx="5" cy="4" r="0.4" fill="currentColor" /><circle cx="10" cy="8" r="0.4" fill="currentColor" /><circle cx="7" cy="12" r="0.4" fill="currentColor" /></svg>`,
+    },
+    dns: {
+        key: "dns_short",
+        text: "GeoDNS",
+        icon: `<svg viewBox="0 0 16 16" class="w-4 h-4 mb-1 text-lime-400" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="8" cy="8" r="6.2" /><path d="M1.8 8h12.4" /><path d="M8 1.8c2 2 2 10.4 0 12.4-2-2-2-10.4 0-12.4Z" /></svg>`,
+    },
+    warehouse: {
+        key: "warehouse_short",
+        text: "Warehouse",
+        icon: `<svg viewBox="0 0 16 16" class="w-4 h-4 mb-1 text-amber-500" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1.5 6.5 8 2l6.5 4.5" /><path d="M2.5 6.5v7.5h11V6.5" /><path d="M5 14v-4h6v4" /></svg>`,
+    },
+};
+
+// The class strings index.html carried on the service buttons, unchanged.
+const BTN_CLASSES =
+    "service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col " +
+    "items-center justify-center border border-transparent group relative overflow-hidden";
+const COST_CLASSES =
+    "absolute top-0 right-0 bg-green-900/80 text-green-400 text-[9px] px-1 rounded-bl font-mono";
+const LABEL_CLASSES = "text-[10px] font-bold mt-1";
+
+// The translation attribute, composed rather than written literally: the
+// i18n-usage test greps the sources for literal attribute/key pairs, and an
+// interpolated key would register there as a bogus, never-defined key. The
+// real keys are the ones in SERVICE_BUTTONS and SERVICE_CATEGORIES above, and
+// tests/sim/toolbar.test.mjs asserts every one of them resolves in en — a
+// stronger check than the grep, since it reads the data instead of the text.
+const I18N_ATTR = "data-i18n";
+
+const TAB_BASE =
+    "toolbar-tab px-2 py-0.5 rounded-md text-[10px] font-bold uppercase tracking-wide " +
+    "border transition whitespace-nowrap";
+const TAB_ACTIVE = "bg-cyan-900/60 text-cyan-200 border-cyan-500/50";
+const TAB_IDLE = "bg-gray-800/60 text-gray-400 border-gray-700 hover:text-gray-200";
+
+const STORAGE_KEY = "serverSurvivalToolbarCategory";
+
+// Campaign gating (spec, "Campaign interaction"): the level's allow/forbid
+// lists, normalised to CONFIG types. Kept here because the buttons are new DOM
+// nodes after every tab switch and would otherwise come back enabled — and
+// because that makes the render order irrelevant: a gate applied before the
+// first render is remembered and painted by it, a gate applied after paints
+// the buttons already on screen.
+let gate = null;
+
+let activeCategoryId = restoreCategory();
+
+function restoreCategory() {
+    let stored = null;
+    try {
+        stored = localStorage.getItem(STORAGE_KEY);
+    } catch {
+        stored = null; // private mode / storage disabled — fall back to the first tab
+    }
+    return SERVICE_CATEGORIES.some((c) => c.id === stored) ? stored : SERVICE_CATEGORIES[0].id;
+}
+
+function activeCategory() {
+    return SERVICE_CATEGORIES.find((c) => c.id === activeCategoryId) || SERVICE_CATEGORIES[0];
+}
+
+// "lambda" is the Compute button's tool name; campaign levels may name the
+// service either way, so both mean compute here (matching the normalisation
+// the old gating code did).
+function normalizeType(type) {
+    return type === "lambda" ? "compute" : type;
+}
+
+function isTypeAllowed(type) {
+    if (!gate) return true;
+    if (gate.allowed) return gate.allowed.has(normalizeType(type));
+    return !gate.forbidden.has(normalizeType(type));
+}
+
+function allowedCount(category) {
+    return category.types.filter(isTypeAllowed).length;
+}
+
+function buttonHTML(type) {
+    const spec = SERVICE_BUTTONS[type];
+    const tool = spec.tool || type;
+    const cost = CONFIG.services[type].cost;
+    return (
+        `<button id="tool-${tool}" class="${BTN_CLASSES}" onclick="setTool('${tool}')">` +
+        `<div class="${COST_CLASSES}">$${cost}</div>` +
+        spec.icon +
+        `<span ${I18N_ATTR}="${spec.key}" class="${LABEL_CLASSES}">${spec.text}</span>` +
+        `</button>`
+    );
+}
+
+// Translate the freshly built nodes. i18n.applyTranslations() would do it too,
+// but it walks the whole document and rewrites every panel — this runs on
+// every tab switch, so it stays local. Buttons already in the DOM when the
+// locale changes are handled by applyTranslations as before.
+function paintLabels(root) {
+    root.querySelectorAll("[" + I18N_ATTR + "]").forEach((el) => {
+        el.textContent = i18n.t(el.getAttribute(I18N_ATTR));
+    });
+}
+
+function renderTabs() {
+    const strip = document.getElementById("service-tabs");
+    if (!strip) return;
+    strip.innerHTML = "";
+
+    for (const cat of SERVICE_CATEGORIES) {
+        const tab = document.createElement("button");
+        tab.id = `toolbar-tab-${cat.id}`;
+        tab.type = "button";
+        tab.className = `${TAB_BASE} ${cat.id === activeCategoryId ? TAB_ACTIVE : TAB_IDLE}`;
+        tab.setAttribute("data-toolbar-tab", cat.id);
+
+        const label = document.createElement("span");
+        label.setAttribute(I18N_ATTR, cat.labelKey);
+        label.textContent = i18n.t(cat.labelKey);
+        tab.appendChild(label);
+
+        // Under a campaign gate, show how many of the level's services live
+        // behind this tab — otherwise a player on an all-grey tab concludes
+        // the game is broken.
+        if (gate) {
+            const badge = document.createElement("span");
+            const n = allowedCount(cat);
+            badge.className = `ml-1 font-mono ${n > 0 ? "text-yellow-300" : "text-gray-600"}`;
+            badge.setAttribute("data-toolbar-tab-count", String(n));
+            badge.textContent = `· ${n}`;
+            tab.appendChild(badge);
+        }
+
+        tab.addEventListener("click", () => setToolbarCategory(cat.id));
+        strip.appendChild(tab);
+    }
+}
+
+function renderPalette() {
+    const palette = document.getElementById("service-palette");
+    if (!palette) return;
+
+    palette.innerHTML = activeCategory().types.map(buttonHTML).join("");
+    paintLabels(palette);
+
+    // The selected tool keeps its highlight when its tab comes back into view.
+    const selected = document.getElementById(`tool-${STATE.activeTool}`);
+    if (selected && palette.contains(selected)) selected.classList.add("active");
+
+    paintGating(palette);
+}
+
+// Grey out what the level forbids. Same two classes the campaign gating has
+// always used, so nothing downstream (CSS, save/load, tests) had to change.
+function paintGating(palette) {
+    for (const type of activeCategory().types) {
+        const spec = SERVICE_BUTTONS[type];
+        const btn = palette.querySelector(`#tool-${spec.tool || type}`);
+        if (!btn) continue;
+        if (isTypeAllowed(type)) {
+            btn.classList.remove("opacity-30", "pointer-events-none");
+            btn.removeAttribute("data-campaign-blocked");
+        } else {
+            btn.classList.add("opacity-30", "pointer-events-none");
+            btn.setAttribute("data-campaign-blocked", "true");
+        }
+    }
+}
+
+function renderToolbar() {
+    renderTabs();
+    renderPalette();
+    // input/handlers.js re-wires the button tooltips on this (it cannot be
+    // imported from here — it imports this module for the 1-5 shortcuts).
+    window.dispatchEvent(new CustomEvent("toolbarRendered"));
+}
+
+// Switch tabs and redraw. `persist` is false for the automatic switch a
+// campaign level triggers, so a level's gating cannot overwrite the tab the
+// player last chose for themselves.
+function setToolbarCategory(id, { persist = true } = {}) {
+    if (!SERVICE_CATEGORIES.some((c) => c.id === id)) return;
+    activeCategoryId = id;
+    if (persist) {
+        try {
+            localStorage.setItem(STORAGE_KEY, id);
+        } catch {
+            // storage disabled — the tab is simply not remembered
+        }
+    }
+    renderToolbar();
+}
+
+// Called by ui/campaign-ui.js when a level starts. Stores the gate, then
+// lands the player on the first tab that actually holds one of the level's
+// services (spec, "Campaign interaction" — mitigation 1) and redraws.
+function applyToolbarGating(allowed, forbidden) {
+    const allowList = (allowed || []).map(normalizeType);
+    const blockList = (forbidden || []).map(normalizeType);
+    gate =
+        allowList.length || blockList.length
+            ? {
+                allowed: allowList.length ? new Set(allowList) : null,
+                forbidden: new Set(blockList),
+            }
+            : null;
+
+    const target = SERVICE_CATEGORIES.find((c) => allowedCount(c) > 0);
+    if (gate && target) setToolbarCategory(target.id, { persist: false });
+    else renderToolbar();
+}
+
+export {
+    SERVICE_BUTTONS,
+    SERVICE_CATEGORIES,
+    applyToolbarGating,
+    renderToolbar,
+    setToolbarCategory,
+};

--- a/tests/sim/toolbar.test.mjs
+++ b/tests/sim/toolbar.test.mjs
@@ -1,0 +1,294 @@
+// Service palette with category tabs (#155 PR 10 tier 2 — the module renders
+// into the real index.html fixture and its campaign path reaches game.js).
+//
+// The load-bearing test is the completeness invariant: a placeable service
+// that nobody categorised would be unreachable in the UI while every other
+// test in the suite kept passing. The rest guard the seams the tabs
+// introduced — campaign gating outliving a re-render, the settings cluster
+// that moved to the far edge, and the digit shortcuts.
+import { describe, it, expect, beforeEach } from "vitest";
+import { CONFIG } from "../../src/config.js";
+import { STATE } from "../../src/state.js";
+import { EN_TRANSLATIONS } from "../../src/locales/en.js";
+import {
+    SERVICE_BUTTONS,
+    SERVICE_CATEGORIES,
+    applyToolbarGating,
+    renderToolbar,
+    setToolbarCategory,
+} from "../../src/ui/toolbar.js";
+import { applyCampaignToolbarGating } from "../../src/ui/campaign-ui.js";
+import { CAMPAIGN_LEVELS } from "../../src/campaign/levels.js";
+// game.js owns window.setTool / window.toggleMusic / window.toggleSfx and
+// registers the document-level key handlers via src/input/handlers.js.
+import { resetGame } from "../../game.js";
+
+const palette = () => document.getElementById("service-palette");
+const tabs = () => document.getElementById("service-tabs");
+const buttonIds = () => [...palette().querySelectorAll("button")].map((b) => b.id);
+const tab = (id) => document.getElementById(`toolbar-tab-${id}`);
+
+// Every placeable type: CONFIG.services is the single source of truth.
+const PLACEABLE = Object.keys(CONFIG.services);
+
+beforeEach(() => {
+    applyToolbarGating([], []); // drop any campaign gate a previous test set
+    STATE.activeTool = "select";
+    setToolbarCategory(SERVICE_CATEGORIES[0].id);
+});
+
+describe("completeness invariant", () => {
+    it("puts every placeable service in exactly one category", () => {
+        const counts = new Map(PLACEABLE.map((t) => [t, 0]));
+        for (const cat of SERVICE_CATEGORIES) {
+            for (const type of cat.types) counts.set(type, (counts.get(type) || 0) + 1);
+        }
+        const wrong = [...counts].filter(([, n]) => n !== 1).map(([t, n]) => `${t}: ${n}`);
+        expect(wrong).toEqual([]);
+    });
+
+    it("categorises nothing that is not a placeable service", () => {
+        const unknown = SERVICE_CATEGORIES.flatMap((c) => c.types).filter(
+            (t) => !(t in CONFIG.services)
+        );
+        expect(unknown).toEqual([]);
+    });
+
+    it("has button data for every categorised type and nothing more", () => {
+        const categorised = SERVICE_CATEGORIES.flatMap((c) => c.types).sort();
+        expect(Object.keys(SERVICE_BUTTONS).sort()).toEqual(categorised);
+    });
+
+    it("resolves every label key it references in the en dictionary", () => {
+        const keys = [
+            ...SERVICE_CATEGORIES.map((c) => c.labelKey),
+            ...Object.values(SERVICE_BUTTONS).map((b) => b.key),
+        ];
+        expect(keys.filter((k) => !(k in EN_TRANSLATIONS))).toEqual([]);
+    });
+});
+
+describe("rendering", () => {
+    it("renders only the active category's buttons", () => {
+        setToolbarCategory("compute");
+        expect(buttonIds()).toEqual(["tool-lambda", "tool-serverless", "tool-container"]);
+        expect(document.getElementById("tool-db")).toBeNull();
+    });
+
+    it("keeps the button contract campaign gating and tooltips rely on", () => {
+        setToolbarCategory("data");
+        const btn = document.getElementById("tool-s3");
+        expect(btn.className).toContain("service-btn");
+        expect(btn.getAttribute("onclick")).toBe("setTool('s3')");
+        expect(btn.querySelector("[data-i18n]").getAttribute("data-i18n")).toBe("storage_short");
+    });
+
+    it("reads each cost badge from CONFIG so the two cannot drift", () => {
+        setToolbarCategory("data");
+        for (const type of SERVICE_CATEGORIES.find((c) => c.id === "data").types) {
+            const btn = document.getElementById(`tool-${type}`);
+            expect(btn.textContent).toContain(`$${CONFIG.services[type].cost}`);
+        }
+    });
+
+    it("re-renders idempotently — no duplicated buttons", () => {
+        setToolbarCategory("async");
+        const first = buttonIds();
+        renderToolbar();
+        renderToolbar();
+        expect(buttonIds()).toEqual(first);
+        expect(tabs().querySelectorAll("button")).toHaveLength(SERVICE_CATEGORIES.length);
+        expect(document.querySelectorAll("#tool-sqs")).toHaveLength(1);
+    });
+
+    it("keeps the selected tool highlighted when its tab comes back", () => {
+        STATE.activeTool = "dlq";
+        setToolbarCategory("async");
+        expect(document.getElementById("tool-dlq").classList.contains("active")).toBe(true);
+        setToolbarCategory("ops");
+        expect(document.getElementById("tool-dlq")).toBeNull();
+        setToolbarCategory("async");
+        expect(document.getElementById("tool-dlq").classList.contains("active")).toBe(true);
+    });
+
+    it("marks the active tab and switches on click", () => {
+        expect(tab("frontdoor").className).toContain("bg-cyan-900/60");
+        tab("data").dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+        expect(buttonIds()).toContain("tool-db");
+        expect(tab("data").className).toContain("bg-cyan-900/60");
+        expect(tab("frontdoor").className).not.toContain("bg-cyan-900/60");
+    });
+
+    it("remembers the active tab in localStorage", () => {
+        setToolbarCategory("ops");
+        expect(localStorage.getItem("serverSurvivalToolbarCategory")).toBe("ops");
+    });
+
+    it("re-wires the hover tooltip on buttons rendered after startup", () => {
+        setToolbarCategory("data");
+        const tooltip = document.getElementById("tooltip");
+        tooltip.style.display = "none";
+        document.getElementById("tool-warehouse").dispatchEvent(
+            new window.MouseEvent("mousemove", { bubbles: true, clientX: 10, clientY: 200 })
+        );
+        expect(tooltip.style.display).toBe("block");
+        expect(tooltip.innerHTML).toContain(`$${CONFIG.services.warehouse.cost}`);
+    });
+
+    it("dispatches toolbarRendered so the tooltip wiring can follow", () => {
+        let seen = 0;
+        const onRender = () => seen++;
+        window.addEventListener("toolbarRendered", onRender);
+        setToolbarCategory("ops");
+        window.removeEventListener("toolbarRendered", onRender);
+        expect(seen).toBe(1);
+    });
+});
+
+describe("campaign gating", () => {
+    it("lands on a tab that holds one of the level's services", () => {
+        setToolbarCategory("frontdoor");
+        applyToolbarGating(["s3"], []);
+        expect(buttonIds()).toContain("tool-s3");
+        expect(tab("data").className).toContain("bg-cyan-900/60");
+    });
+
+    it("greys out everything the level forbids on that tab", () => {
+        applyToolbarGating(["s3"], []);
+        const allowed = document.getElementById("tool-s3");
+        const blocked = document.getElementById("tool-db");
+        expect(allowed.classList.contains("pointer-events-none")).toBe(false);
+        expect(blocked.classList.contains("opacity-30")).toBe(true);
+        expect(blocked.getAttribute("data-campaign-blocked")).toBe("true");
+    });
+
+    it("keeps the gate after a tab switch — fresh buttons are not enabled", () => {
+        applyToolbarGating(["s3"], []);
+        setToolbarCategory("frontdoor");
+        const frontdoor = SERVICE_CATEGORIES.find((c) => c.id === "frontdoor");
+        for (const type of frontdoor.types) {
+            const btn = document.getElementById(`tool-${type}`);
+            expect(btn.getAttribute("data-campaign-blocked")).toBe("true");
+        }
+    });
+
+    it("paints a gate that was set while the palette was empty (render order)", () => {
+        applyToolbarGating(["s3"], []);
+        palette().innerHTML = ""; // as if the level started before the first render
+        renderToolbar();
+        expect(document.getElementById("tool-db").getAttribute("data-campaign-blocked")).toBe("true");
+        expect(document.getElementById("tool-s3").getAttribute("data-campaign-blocked")).toBeNull();
+    });
+
+    it("counts the level's services on each tab", () => {
+        applyToolbarGating(["s3"], []);
+        expect(tab("data").textContent).toContain("· 1");
+        expect(tab("frontdoor").textContent).toContain("· 0");
+    });
+
+    it("shows no counts and blocks nothing without a gate", () => {
+        applyToolbarGating(["s3"], []);
+        applyToolbarGating([], []);
+        setToolbarCategory("data");
+        expect(tab("data").textContent).not.toContain("·");
+        expect(document.getElementById("tool-db").getAttribute("data-campaign-blocked")).toBeNull();
+    });
+
+    // Leaving a level used to keep its gate forever: play campaign level 2,
+    // go back to sandbox, and most of the toolbar stayed dead. Reproduced on
+    // the pre-toolbar build too, so this pins an old bug, not a new one.
+    // resetGame() drops the gate for every non-campaign mode.
+    it("drops the gate when a non-campaign mode starts", () => {
+        applyToolbarGating(["s3"], []);
+        setToolbarCategory("data");
+        expect(document.getElementById("tool-db").getAttribute("data-campaign-blocked")).toBe("true");
+
+        resetGame("sandbox");
+
+        setToolbarCategory("data");
+        expect(document.getElementById("tool-db").getAttribute("data-campaign-blocked")).toBeNull();
+        expect(document.getElementById("tool-db").className).not.toContain("pointer-events-none");
+        expect(tab("data").textContent).not.toContain("·");
+    });
+
+    it("honours a forbidden list when the level allows everything else", () => {
+        applyToolbarGating([], ["db"]);
+        setToolbarCategory("data");
+        expect(document.getElementById("tool-db").classList.contains("opacity-30")).toBe(true);
+        expect(document.getElementById("tool-s3").classList.contains("opacity-30")).toBe(false);
+    });
+
+    it("treats the compute service and its 'lambda' tool name as one", () => {
+        applyToolbarGating(["compute"], []);
+        expect(tab("compute").className).toContain("bg-cyan-900/60");
+        expect(document.getElementById("tool-lambda").classList.contains("opacity-30")).toBe(false);
+        expect(document.getElementById("tool-serverless").classList.contains("opacity-30")).toBe(true);
+    });
+
+    it("drives the same behaviour through applyCampaignToolbarGating (level 2)", () => {
+        const level2 = CAMPAIGN_LEVELS.find((l) => l.id === 2);
+        expect(level2.allowedServices).toEqual(["s3"]);
+        setToolbarCategory("async");
+        applyCampaignToolbarGating(level2.allowedServices, level2.forbiddenServices);
+        expect(tab("data").className).toContain("bg-cyan-900/60");
+        expect(tab("data").textContent).toContain("· 1");
+        expect(document.getElementById("tool-s3").classList.contains("opacity-30")).toBe(false);
+        expect(document.getElementById("tool-cache").classList.contains("opacity-30")).toBe(true);
+    });
+
+    it("does not overwrite the remembered tab when a level moves the player", () => {
+        setToolbarCategory("async");
+        applyToolbarGating(["s3"], []);
+        expect(localStorage.getItem("serverSurvivalToolbarCategory")).toBe("async");
+    });
+});
+
+describe("settings cluster", () => {
+    it("still holds help, music and sfx wired to their handlers", () => {
+        expect(document.getElementById("tool-help").getAttribute("onclick")).toBe("showFAQ()");
+        expect(document.getElementById("tool-music").getAttribute("onclick")).toBe("toggleMusic()");
+        expect(document.getElementById("tool-sfx").getAttribute("onclick")).toBe("toggleSfx()");
+    });
+
+    it("drives toggleMusic / toggleSfx and repaints the buttons", () => {
+        const music = document.getElementById("tool-music");
+        const before = STATE.sound.musicMuted;
+        window.toggleMusic();
+        expect(STATE.sound.musicMuted).toBe(!before);
+        expect(music.classList.contains("bg-red-900")).toBe(STATE.sound.musicMuted);
+        window.toggleMusic();
+        expect(STATE.sound.musicMuted).toBe(before);
+
+        const sfxBefore = STATE.sound.sfxMuted;
+        window.toggleSfx();
+        expect(STATE.sound.sfxMuted).toBe(!sfxBefore);
+        window.toggleSfx();
+    });
+});
+
+describe("keyboard shortcuts", () => {
+    it("switches categories on keys 1-5", () => {
+        for (let i = 0; i < SERVICE_CATEGORIES.length; i++) {
+            document.dispatchEvent(
+                new window.KeyboardEvent("keydown", { key: String(i + 1), bubbles: true })
+            );
+            expect(tab(SERVICE_CATEGORIES[i].id).className).toContain("bg-cyan-900/60");
+        }
+    });
+
+    it("ignores digits typed into a form field", () => {
+        setToolbarCategory("ops");
+        const input = document.getElementById("sandbox-budget") || document.createElement("input");
+        document.body.appendChild(input);
+        input.dispatchEvent(new window.KeyboardEvent("keydown", { key: "1", bubbles: true }));
+        expect(tab("ops").className).toContain("bg-cyan-900/60");
+    });
+
+    it("ignores digits pressed with a modifier (browser tab switching)", () => {
+        setToolbarCategory("ops");
+        document.dispatchEvent(
+            new window.KeyboardEvent("keydown", { key: "2", metaKey: true, bubbles: true })
+        );
+        expect(tab("ops").className).toContain("bg-cyan-900/60");
+    });
+});


### PR DESCRIPTION
The toolbar had grown to **30 buttons in one flat ~2000px row** — half the palette sat off-screen and had to be scrolled sideways. Design doc: `docs/superpowers/specs/2026-07-24-toolbar-categories-design.md`.

## What changes
Five category tabs replace the flat run; only the active category renders, so **the bar never scrolls again**.

The categories aren't arbitrary buckets — they're the **cloud-domain map from the Wave 1 epic (#193)**: front door → compute → data → async → ops. The toolbar teaches the taxonomy while it fixes the overflow, which is the whole point of the education north star.

| Tab | Count |
|---|---|
| Front door (dns, cdn, waf, auth, apigw, alb) | 6 |
| Compute (compute, serverless, container) | 3 |
| Data (db, nosql, cache, s3, search, replica, warehouse) | 7 |
| Async (sqs, pubsub, stream, dlq, scheduler, notify) | 6 |
| Ops (monitor) | 1 |

`src/ui/toolbar.js` owns the palette. `SERVICE_CATEGORIES` is plain data — adding a service in a later wave means adding its type to one array, the same property the handler registry has. **The button markup is reproduced byte-for-byte** (same classes, `id`, cost badge, `data-i18n`), so campaign gating, tooltips and locale switching keep working untouched; a test pins that contract.

## Campaign interaction — the trap the tabs introduced
A level allowing only Storage would have left the player staring at a tab full of greyed buttons, looking broken. So: gating auto-lands on a tab that holds an allowed service, tabs carry an allowed-count badge (`Data · 1`), and the gate is re-applied on every tab switch so freshly rendered buttons can't come up enabled.

## Bug found while verifying — an old one
Campaign gating was applied when a level started but **never cleared**: play a level, go back to sandbox, and most of your toolbar stays dead. I reproduced it on a pristine `main` worktree first to be sure it wasn't my regression — it's a shipped bug. `resetGame()` now drops the gate for every non-campaign mode, with a regression test.

## Also
- `help`/`music`/`sfx` move out of the three most valuable slots into a compact icon-only cluster
- the container's `overflow-y-auto` (vertical, on a *horizontal* overflow — why the scrolling felt broken) is corrected
- active tab persists in `localStorage`; keys `1`-`5` switch tabs, guarded against form fields and modifier combos
- 5 category labels × 9 locales

## Verification (1280×800, in-browser)
All 23 services categorised, no duplicates, none missing. Every tab renders its buttons with **nothing off-screen and no document scroll** (widest tab 928px). Re-render idempotent. Campaign level 2 auto-lands on Data with the badge reading 1 and forbidden services greyed **even after switching tabs**; returning to sandbox or survival re-enables everything and clears the badges; placing a service still works. RU relabels tabs and buttons. Music/SFX toggle from the new cluster. Keys 1-5 work.

29 new tests, suite at **448**. Lint 0. **5 consecutive full runs green** (flake check).