### PR TITLE
feat: educational failure badges — every dropped request says why (#156)

### DIFF
--- a/game.js
+++ b/game.js
@@ -39,6 +39,15 @@ import { upkeepInstanceFactor } from "./src/sim/autoscaling.js";
 import { resetResilience } from "./src/sim/circuit-breaker.js";
 import { metricsTick, resetMetrics } from "./src/core/metrics.js";
 import { renderMetricsPanel } from "./src/ui/metrics-panel.js";
+// Educational failure badges (#156): the floating "why did this fail" labels.
+// game.js owns their scene group (badgeGroup, below), ticks them once per
+// frame next to metricsTick, and clears them on reset.
+import {
+    clearFailureBadges,
+    syncFailureBadgeButton,
+    tickFailureBadges,
+    toggleFailureBadges,
+} from "./src/ui/failure-badges.js";
 import {
     campaignNextLevel,
     campaignRetryLevel,
@@ -243,9 +252,13 @@ scene.add(gridHelper);
 const serviceGroup = new THREE.Group();
 const connectionGroup = new THREE.Group();
 const requestGroup = new THREE.Group();
+// Failure badges (#156) get their own group: a badge must outlive the node
+// that dropped the request, and sprite scale must not inherit a node's.
+const badgeGroup = new THREE.Group();
 scene.add(serviceGroup);
 scene.add(connectionGroup);
 scene.add(requestGroup);
+scene.add(badgeGroup);
 
 const internetGeo = new THREE.BoxGeometry(6, 1, 10);
 const internetMat = new THREE.MeshStandardMaterial({
@@ -352,6 +365,9 @@ function resetGame(mode = "survival") {
     STATE.autoRepairEnabled = false;
     resetMetrics();
     resetResilience();
+    // Dispose the floating failure labels (#156) — a badge anchored to a
+    // node from the previous run is both meaningless and a texture leak.
+    clearFailureBadges();
     STATE.hints = {
       lastHintTime: 0,
       dismissedHints: new Set(),
@@ -790,6 +806,7 @@ window.toggleSfx = () => {
 
 // Reflect persisted prefs on load
 syncSoundButtons();
+syncFailureBadgeButton();
 
 // The wheel-zoom, upgrade-indicator, keyboard-navigation, and mouse
 // drag/pan/connect/place listeners (with their state) moved to
@@ -951,6 +968,10 @@ function animate(time) {
     // it only rebuilds rows on service-set changes and redraws on new samples.
     metricsTick(dt);
     renderMetricsPanel();
+
+    // Failure badges (#156): age and fade the floating labels. Same
+    // game-scaled dt as everything else, so they freeze with the board.
+    tickFailureBadges(dt);
 
     // Live tooltip refresh (#173): while the pointer sits still over a service,
     // replay the last mousemove at ~4 Hz so the tooltip's load/queue/rate stats
@@ -1430,6 +1451,8 @@ window.resumeGame = () => {
 window.restartGame = restartGame;
 window.retryWithSameArchitecture = retryWithSameArchitecture;
 window.toggleAutoRepair = toggleAutoRepair;
+// #156: the failure-badge toggle in the toolbar's settings cluster.
+window.toggleFailureBadges = toggleFailureBadges;
 
 // #155 PR 6: the campaign-UI and save/load handlers now live in
 // src/ui/campaign-ui.js and src/persistence/save-load.js; index.html inline
@@ -1467,6 +1490,7 @@ window.STATE = STATE;
 // declarations / top-level consts only dereferenced after evaluation).
 export {
     animate,
+    badgeGroup,
     camera,
     cameraTarget,
     connectionGroup,

--- a/index.html
+++ b/index.html
@@ -607,6 +607,19 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M15.5 8.5a5 5 0 0 1 0 7M18 6a8.5 8.5 0 0 1 0 12" />
           </svg>
         </button>
+
+        <!-- Failure-reason badges toggle (#156). Default ON — the labels are
+             the teaching half of every failure — with the preference persisted
+             in localStorage exactly like the sound channels above. -->
+        <button id="tool-badges" title="Failure reasons" data-i18n-title="failure_badges"
+          class="service-btn bg-gray-700 text-gray-200 rounded-lg w-8 h-8 flex items-center justify-center border border-gray-600"
+          onclick="toggleFailureBadges()">
+          <svg id="badges-icon" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 5h16v10H9l-4 4V5z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 7.5v3" />
+            <circle cx="12" cy="12.8" r="0.7" fill="currentColor" stroke="none" />
+          </svg>
+        </button>
       </div>
     </div>
   </div>

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -14,7 +14,14 @@ import { Request } from "../entities/Request.js";
 import { recordServiceError, recordServiceSuccess } from "./metrics.js";
 // Resilience (#196): routing skips tripped nodes exactly like disabled ones.
 // The breaker's counters are NOT fed from here — see the note on failRequest.
-import { isRoutable } from "../sim/circuit-breaker.js";
+// hasTrippedDownstream is the fail-fast attribution for the badges (#156).
+import { hasTrippedDownstream, isRoutable } from "../sim/circuit-breaker.js";
+// Educational failure badges (#156). The `reason` argument threaded through
+// failRequest / failOrPark / throttleRequest is pure attribution: it is read
+// only here, only to draw a label, and never influences control flow. See the
+// contract note in core/failure-reasons.js.
+import { FAIL_REASONS } from "./failure-reasons.js";
+import { spawnFailureBadge } from "../ui/failure-badges.js";
 // Dead-Letter Queue (#197): a final failure at a node wired to a DLQ is parked
 // there instead of dropped. Runtime-only cycle (actions.js ⇄ dlq.js) — hoisted
 // declarations, dereferenced long after both modules evaluate.
@@ -108,7 +115,7 @@ function spawnRequest() {
 function routeRequestToEntry(req, type) {
     const conns = STATE.internetNode.connections;
     if (conns.length === 0) {
-        failRequest(req);
+        failRequest(req, FAIL_REASONS.NO_ROUTE);
         return;
     }
     const entryNodes = conns.map((id) =>
@@ -148,7 +155,7 @@ function routeRequestToEntry(req, type) {
     }
 
     if (target) req.flyTo(target);
-    else failRequest(req);
+    else failRequest(req, FAIL_REASONS.NO_ROUTE);
 }
 
 function updateScore(req, outcome) {
@@ -244,7 +251,12 @@ function finishRequest(req, viaServiceType, service) {
     removeRequest(req);
 }
 
-function failRequest(req) {
+// `reason` (optional second param, #156) is a FAIL_REASONS value describing WHY
+// this request died, purely so the badge over the node can teach it. It is
+// read once, at the very end, to spawn a label — it touches no counter, no
+// score and no branch, so passing one can never change which requests fail.
+// Defaults to null (no badge) for callers with nothing to say.
+function failRequest(req, reason = null) {
     // Observability (#194): attribute the failure to the service the request
     // was headed to / sitting on. Entry-routing failures with no target (no
     // Internet connections at all) stay unattributed by design. `failed` marks
@@ -268,7 +280,25 @@ function failRequest(req) {
     updateScore(req, failType);
     STATE.sound.playFail();
     req.mesh.material.color.setHex(CONFIG.colors.requestFail);
+    // A MALICIOUS request that reaches here got through — whatever routing
+    // verdict actually dropped it, the lesson is the breach, which is also
+    // exactly what updateScore just charged the player for.
+    spawnFailureBadge(
+        req,
+        req.type === TRAFFIC_TYPES.MALICIOUS ? FAIL_REASONS.BREACH : reason
+    );
     setTimeout(() => removeRequest(req), 500);
+}
+
+// Fail-fast attribution (#156). A node that found no candidate downstream
+// normally means the player forgot a wire — but if the only downstream is
+// there and merely TRIPPED, the request is being shed by the circuit breaker,
+// which is a completely different lesson. Resolving it here (rather than at
+// every routing site) keeps the handlers' one-liners intact, and it is pure
+// relabelling: NO_ROUTE and CIRCUIT_OPEN both fail the request identically.
+function routingReason(service, reason) {
+    if (reason !== FAIL_REASONS.NO_ROUTE) return reason;
+    return hasTrippedDownstream(service) ? FAIL_REASONS.CIRCUIT_OPEN : reason;
 }
 
 // Dead-Letter Queue interception (#197). The single choke point every "this
@@ -280,9 +310,9 @@ function failRequest(req) {
 // service context (entry routing with no Internet link, queue overflow in
 // Request.update) keep calling failRequest directly: there is no node to hang a
 // DLQ off. MALICIOUS is never parked (see parkInDLQ).
-function failOrPark(req, service) {
+function failOrPark(req, service, reason = null) {
     if (parkInDLQ(req, service)) return;
-    failRequest(req);
+    failRequest(req, routingReason(service, reason));
 }
 
 // Notification silent failure (#197). A Notification node's overload drops are
@@ -301,7 +331,7 @@ function notifySilentFail(req, service) {
     removeRequest(req);
 }
 
-function throttleRequest(req) {
+function throttleRequest(req, reason = null) {
     // Throttling is load shedding working as designed, not a service error:
     // it feeds neither the metrics error rate nor the breaker window. The flag
     // keeps Service.update() from scoring it as a breaker success either.
@@ -309,6 +339,9 @@ function throttleRequest(req) {
     updateScore(req, "THROTTLED");
     STATE.sound.playFail();
     req.mesh.material.color.setHex(CONFIG.colors.apigw); // Pink flash for throttled
+    // Soft fail (#156): the badge paints this one amber, not red — the
+    // gateway did its job, the player just hit the rate limit.
+    spawnFailureBadge(req, reason);
     setTimeout(() => removeRequest(req), 500);
 }
 

--- a/src/core/failure-reasons.js
+++ b/src/core/failure-reasons.js
@@ -1,0 +1,58 @@
+// Failure taxonomy (#156, educational failure badges). One symbolic constant
+// per reason a request can die, whose VALUE is the i18n key of the short label
+// the floating badge shows. Two rules keep this honest:
+//
+//   1. It is pure data with no imports, so every layer (core/actions.js, the
+//      handler registry, Request/Service, retry/stream/circuit-breaker, and
+//      ui/failure-badges.js) can share it without a new cycle.
+//   2. A reason is ATTRIBUTION ONLY. It rides along the existing fail path as
+//      an extra argument and never decides anything — adding one must not
+//      change which requests fail, in what order, or how they are scored.
+//      That is what makes the whole feature provably free of gameplay drift
+//      (see tests/sim/failure-badges.test.mjs, "reason argument is inert").
+//
+// The wording is a teaching line, not an error message: a player who reads
+// "Read-only replica" learns why a WRITE cannot land there. Keep them SHORT —
+// they are drawn as a floating label over the node, not a sentence.
+//
+// Two reasons are DERIVED rather than passed by a call site, because the site
+// that fails the request does not know them:
+//   BREACH        — any MALICIOUS request that reaches failRequest is a breach
+//                   (that is exactly what updateScore already scores it as),
+//                   whichever routing verdict actually dropped it.
+//   CIRCUIT_OPEN  — a NO_ROUTE at a node whose downstream is only unreachable
+//                   because its breaker tripped is fail-fast, not a wiring
+//                   mistake. Resolved in failOrPark(); see routingReason().
+
+export const FAIL_REASONS = {
+    // Capacity / health
+    QUEUE_FULL: "fail_queue_full",
+    OVERLOADED: "fail_overloaded",
+    RETRY_FAILED: "fail_retry_failed",
+
+    // Topology dead ends
+    NO_ROUTE: "fail_no_route",
+    NO_ORIGIN: "fail_no_origin",
+    NO_SUBSCRIBER: "fail_no_subscriber",
+    NO_MASTER: "fail_no_master",
+
+    // Wrong destination for this traffic — the OLTP/OLAP and read-replica
+    // lessons, worded per site so each one teaches its own rule.
+    READ_ONLY_REPLICA: "fail_read_only_replica",
+    ANALYTICS_STORE: "fail_analytics_store",
+    WRONG_STORE: "fail_wrong_store",
+    NOT_INDEXED: "fail_not_indexed",
+    SEARCH_ONLY: "fail_search_only",
+
+    // Wave 1 mechanics
+    CIRCUIT_OPEN: "fail_circuit_open",
+    PARTITION_STALLED: "fail_partition_stalled",
+
+    // Security / load shedding
+    BREACH: "fail_breach",
+    THROTTLED: "fail_throttled",
+};
+
+// Reasons the badge paints amber instead of red: the request was shed on
+// purpose (rate limiting working as designed), not dropped by a broken board.
+export const SOFT_REASONS = new Set([FAIL_REASONS.THROTTLED]);

--- a/src/entities/Request.js
+++ b/src/entities/Request.js
@@ -4,6 +4,7 @@ import { STATE } from "../state.js";
 // hoisted function declarations / top-level consts, only dereferenced at
 // runtime — long after all modules have finished evaluating.
 import { failRequest } from "../core/actions.js";
+import { FAIL_REASONS } from "../core/failure-reasons.js";
 // Retry backoff (#196) is ticked here, inside the existing flight model, so a
 // pending retry freezes with the game and dies with a reset — see the note in
 // src/sim/retry.js.
@@ -102,7 +103,7 @@ export class Request {
                     // is failing" signals the breaker listens to — the target
                     // is so backed up it cannot even accept the request.
                     recordBreakerFailure(this.target);
-                    failRequest(this);
+                    failRequest(this, FAIL_REASONS.QUEUE_FULL);
                 }
             } else {
                 const dest = this.target.position.clone();

--- a/src/entities/Service.js
+++ b/src/entities/Service.js
@@ -14,6 +14,10 @@ import {
   updateScore,
 } from "../core/actions.js";
 import { addInterventionWarning } from "../core/events.js";
+// Failure taxonomy (#156): the load/health roll is the "Overloaded" lesson —
+// unless the request had already burned its retry, which teaches a different
+// one. Attribution only; see the contract in core/failure-reasons.js.
+import { FAIL_REASONS } from "../core/failure-reasons.js";
 // Per-type job processing lives in the handler registry (#155 PR 9):
 // one file per service type + the shared fallback. See the control-flow
 // contract in src/sim/handlers/index.js.
@@ -618,8 +622,16 @@ export class Service {
             notifySilentFail(job.req, this);
           } else if (!retryRequest(job.req, this)) {
             // Final failure: park it in a wired DLQ (#197) if one exists,
-            // otherwise drop it normally.
-            failOrPark(job.req, this);
+            // otherwise drop it normally. A request that already spent a retry
+            // and died anyway is a "Retry failed", not a plain overload —
+            // labelling only, both paths fail it identically (#156).
+            failOrPark(
+              job.req,
+              this,
+              job.req.retries > 0
+                ? FAIL_REASONS.RETRY_FAILED
+                : FAIL_REASONS.OVERLOADED
+            );
           }
           continue;
         }

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -563,4 +563,24 @@ export const DE_TRANSLATIONS = {
     "warehouse_desc_long": "Ein Analysespeicher mit dem umgekehrten Profil einer Datenbank: Er schließt WRITE- und UPLOAD-Traffic ab — langsam und günstig bei hohem Volumen — lässt aber jedes Echtzeit-READ oder SEARCH scheitern, denn ein Warehouse ist OLAP, nicht OLTP. Man lädt es, man bedient keine Nutzer-Reads daraus. Speise es mit einer Analyse-Kopie aus einem Pub/Sub-Fan-out, einem geplanten Batch-Load vom Scheduler oder einem Stream. Diese Read-Ablehnung plus günstige, hohe Kapazität ist die OLTP-vs-OLAP-Lektion. Reale Entsprechungen: Amazon Redshift · Azure Synapse · Google BigQuery.",
     "warehouse_flow": "Fluss: Pub/Sub / Scheduler / Stream → Data Warehouse (Analyse-Terminal)",
     "warehouse_desc_short": "Günstiger Analysespeicher ($90)",
+
+    // Educational failure badges (#156). Short floating labels drawn over the
+    // node that dropped a request — keep them SHORT, they are sprite text.
+    "failure_badges": "Fehlergründe",
+    "fail_queue_full": "Warteschlange voll",
+    "fail_overloaded": "Überlastet",
+    "fail_retry_failed": "Wiederholung fehlgeschlagen",
+    "fail_no_route": "Keine Route",
+    "fail_no_origin": "Kein Origin",
+    "fail_no_subscriber": "Kein Abonnent",
+    "fail_no_master": "Kein Master",
+    "fail_read_only_replica": "Nur-Lese-Replik",
+    "fail_analytics_store": "Analytics-Speicher, nicht für Reads",
+    "fail_wrong_store": "Falscher Speichertyp",
+    "fail_not_indexed": "Kein Suchindex",
+    "fail_search_only": "Nur Suchindex",
+    "fail_circuit_open": "Sicherung offen",
+    "fail_partition_stalled": "Partition blockiert",
+    "fail_breach": "Einbruch!",
+    "fail_throttled": "Gedrosselt",
 };

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -563,4 +563,24 @@ export const EN_TRANSLATIONS = {
     "warehouse_desc_long": "An analytics store with the inverse profile of a database: it completes WRITE and UPLOAD traffic — slowly and cheaply at high volume — but fails any realtime READ or SEARCH that reaches it, because a warehouse is OLAP, not OLTP. You load it, you do not serve user reads from it. Feed it an analytics copy from a Pub/Sub fan-out, a scheduled batch load from the Scheduler, or a Stream. That read-rejection plus cheap-high-capacity is the OLTP-vs-OLAP lesson. Real-world equivalents: Amazon Redshift · Azure Synapse · Google BigQuery.",
     "warehouse_flow": "Flow: Pub/Sub / Scheduler / Stream → Data Warehouse (analytics terminal)",
     "warehouse_desc_short": "Cheap analytics store ($90)",
+
+    // Educational failure badges (#156). Short floating labels drawn over the
+    // node that dropped a request — keep them SHORT, they are sprite text.
+    "failure_badges": "Failure reasons",
+    "fail_queue_full": "Queue full",
+    "fail_overloaded": "Overloaded",
+    "fail_retry_failed": "Retry failed",
+    "fail_no_route": "No route",
+    "fail_no_origin": "No origin",
+    "fail_no_subscriber": "No subscriber",
+    "fail_no_master": "No master",
+    "fail_read_only_replica": "Read-only replica",
+    "fail_analytics_store": "Analytics store, not for reads",
+    "fail_wrong_store": "Wrong store type",
+    "fail_not_indexed": "No search index",
+    "fail_search_only": "Search index only",
+    "fail_circuit_open": "Circuit open",
+    "fail_partition_stalled": "Partition stalled",
+    "fail_breach": "Breach!",
+    "fail_throttled": "Throttled",
 };

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -563,4 +563,24 @@ export const FR_TRANSLATIONS = {
     "warehouse_desc_long": "Un magasin analytique au profil inverse d'une base de données : il termine le trafic WRITE et UPLOAD — lentement et à bas coût à grand volume — mais fait échouer tout READ ou SEARCH en temps réel qui l'atteint, car un entrepôt est OLAP, pas OLTP. On le charge, on n'y sert pas de lectures utilisateur. Alimentez-le d'une copie analytique depuis un fan-out Pub/Sub, d'un chargement par lots planifié depuis le Scheduler, ou d'un Stream. Ce rejet des lectures plus la capacité élevée et bon marché est la leçon OLTP vs OLAP. Équivalents réels : Amazon Redshift · Azure Synapse · Google BigQuery.",
     "warehouse_flow": "Flux : Pub/Sub / Scheduler / Stream → Entrepôt de données (terminal analytique)",
     "warehouse_desc_short": "Magasin analytique bon marché ($90)",
+
+    // Educational failure badges (#156). Short floating labels drawn over the
+    // node that dropped a request — keep them SHORT, they are sprite text.
+    "failure_badges": "Raisons d'échec",
+    "fail_queue_full": "File pleine",
+    "fail_overloaded": "Surchargé",
+    "fail_retry_failed": "Nouvelle tentative échouée",
+    "fail_no_route": "Aucune route",
+    "fail_no_origin": "Aucune origine",
+    "fail_no_subscriber": "Aucun abonné",
+    "fail_no_master": "Aucun maître",
+    "fail_read_only_replica": "Réplica en lecture seule",
+    "fail_analytics_store": "Entrepôt analytique, pas pour les lectures",
+    "fail_wrong_store": "Mauvais type de stockage",
+    "fail_not_indexed": "Aucun index de recherche",
+    "fail_search_only": "Index de recherche uniquement",
+    "fail_circuit_open": "Disjoncteur ouvert",
+    "fail_partition_stalled": "Partition bloquée",
+    "fail_breach": "Intrusion !",
+    "fail_throttled": "Limité",
 };

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -563,4 +563,24 @@ export const IT_TRANSLATIONS = {
     "warehouse_desc_long": "Un archivio analitico con il profilo opposto di un database: completa il traffico WRITE e UPLOAD — lentamente e a basso costo su grandi volumi — ma fa fallire qualsiasi READ o SEARCH in tempo reale che lo raggiunge, perché un warehouse è OLAP, non OLTP. Lo carichi, non ci servi letture degli utenti. Alimentalo con una copia analitica da un fan-out Pub/Sub, un carico batch pianificato dallo Scheduler, o uno Stream. Questo rifiuto delle letture più la capacità elevata ed economica è la lezione OLTP vs OLAP. Equivalenti reali: Amazon Redshift · Azure Synapse · Google BigQuery.",
     "warehouse_flow": "Flusso: Pub/Sub / Scheduler / Stream → Data Warehouse (terminale analitico)",
     "warehouse_desc_short": "Archivio analitico economico ($90)",
+
+    // Educational failure badges (#156). Short floating labels drawn over the
+    // node that dropped a request — keep them SHORT, they are sprite text.
+    "failure_badges": "Motivi di errore",
+    "fail_queue_full": "Coda piena",
+    "fail_overloaded": "Sovraccarico",
+    "fail_retry_failed": "Nuovo tentativo fallito",
+    "fail_no_route": "Nessuna rotta",
+    "fail_no_origin": "Nessuna origine",
+    "fail_no_subscriber": "Nessun sottoscrittore",
+    "fail_no_master": "Nessun master",
+    "fail_read_only_replica": "Replica in sola lettura",
+    "fail_analytics_store": "Archivio analitico, non per letture",
+    "fail_wrong_store": "Tipo di archivio errato",
+    "fail_not_indexed": "Nessun indice di ricerca",
+    "fail_search_only": "Solo indice di ricerca",
+    "fail_circuit_open": "Interruttore aperto",
+    "fail_partition_stalled": "Partizione bloccata",
+    "fail_breach": "Violazione!",
+    "fail_throttled": "Limitato",
 };

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -563,4 +563,24 @@ export const KO_TRANSLATIONS = {
     "warehouse_desc_long": "데이터베이스와 반대 프로파일의 분석 저장소: WRITE와 UPLOAD 트래픽을 완료하지만 — 대용량에서 느리고 저렴하게 — 도달하는 실시간 READ나 SEARCH는 실패시킵니다. 웨어하우스는 OLTP가 아니라 OLAP이기 때문입니다. 적재하는 곳이지, 사용자 읽기를 서비스하는 곳이 아닙니다. Pub/Sub 팬아웃의 분석 사본, 스케줄러의 예약 배치 적재, 또는 스트림으로 공급하세요. 이 읽기 거부와 저렴한 고용량이 OLTP 대 OLAP 교훈입니다. 실제 대응: Amazon Redshift · Azure Synapse · Google BigQuery.",
     "warehouse_flow": "흐름: Pub/Sub / 스케줄러 / 스트림 → 데이터 웨어하우스(분석 종점)",
     "warehouse_desc_short": "저렴한 분석 저장소 ($90)",
+
+    // Educational failure badges (#156). Short floating labels drawn over the
+    // node that dropped a request — keep them SHORT, they are sprite text.
+    "failure_badges": "실패 원인",
+    "fail_queue_full": "큐 가득 참",
+    "fail_overloaded": "과부하",
+    "fail_retry_failed": "재시도 실패",
+    "fail_no_route": "경로 없음",
+    "fail_no_origin": "오리진 없음",
+    "fail_no_subscriber": "구독자 없음",
+    "fail_no_master": "마스터 없음",
+    "fail_read_only_replica": "읽기 전용 복제본",
+    "fail_analytics_store": "분석 저장소, 읽기 불가",
+    "fail_wrong_store": "저장소 유형 불일치",
+    "fail_not_indexed": "검색 색인 없음",
+    "fail_search_only": "검색 색인 전용",
+    "fail_circuit_open": "차단기 열림",
+    "fail_partition_stalled": "파티션 정체",
+    "fail_breach": "침해!",
+    "fail_throttled": "속도 제한",
 };

--- a/src/locales/nep.js
+++ b/src/locales/nep.js
@@ -563,4 +563,24 @@ export const NE_TRANSLATIONS = {
     "warehouse_desc_long": "डाटाबेसको उल्टो प्रोफाइल भएको विश्लेषण भण्डार: यो WRITE र UPLOAD ट्राफिक पूरा गर्छ — ठूलो परिमाणमा ढिलो र सस्तो — तर यसमा पुग्ने कुनै पनि वास्तविक-समय READ वा SEARCH असफल पार्छ, किनकि वेयरहाउस OLAP हो, OLTP होइन। तपाईं यसमा लोड गर्नुहुन्छ, यसबाट प्रयोगकर्ता पढाइ सेवा गर्नुहुन्न। यसलाई Pub/Sub फ्यान-आउटको विश्लेषण प्रतिलिपि, Scheduler को अनुसूचित ब्याच लोड, वा Stream ले खुवाउनुहोस्। यो पढाइ अस्वीकार र सस्तो-उच्च क्षमता नै OLTP बनाम OLAP को पाठ हो। वास्तविक समकक्ष: Amazon Redshift · Azure Synapse · Google BigQuery।",
     "warehouse_flow": "प्रवाह: Pub/Sub / Scheduler / Stream → डाटा वेयरहाउस (विश्लेषण टर्मिनल)",
     "warehouse_desc_short": "सस्तो विश्लेषण भण्डार ($90)",
+
+    // Educational failure badges (#156). Short floating labels drawn over the
+    // node that dropped a request — keep them SHORT, they are sprite text.
+    "failure_badges": "असफलताका कारण",
+    "fail_queue_full": "लाम भरियो",
+    "fail_overloaded": "अत्यधिक भार",
+    "fail_retry_failed": "पुनःप्रयास असफल",
+    "fail_no_route": "मार्ग छैन",
+    "fail_no_origin": "मूल स्रोत छैन",
+    "fail_no_subscriber": "सदस्य छैन",
+    "fail_no_master": "मास्टर छैन",
+    "fail_read_only_replica": "पढ्न मात्र मिल्ने प्रतिलिपि",
+    "fail_analytics_store": "विश्लेषण भण्डार, पढाइका लागि होइन",
+    "fail_wrong_store": "गलत भण्डार प्रकार",
+    "fail_not_indexed": "खोज अनुक्रमणिका छैन",
+    "fail_search_only": "खोज अनुक्रमणिका मात्र",
+    "fail_circuit_open": "ब्रेकर खुला",
+    "fail_partition_stalled": "पार्टिसन अवरुद्ध",
+    "fail_breach": "उल्लङ्घन!",
+    "fail_throttled": "सीमित",
 };

--- a/src/locales/pt-BR.js
+++ b/src/locales/pt-BR.js
@@ -563,4 +563,24 @@ export const PT_BR_TRANSLATIONS = {
     "warehouse_desc_long": "Um armazenamento analítico com o perfil inverso de um banco de dados: conclui tráfego WRITE e UPLOAD — lenta e baratamente em grande volume — mas falha qualquer READ ou SEARCH em tempo real que o alcance, porque um warehouse é OLAP, não OLTP. Você o carrega, não serve leituras de usuários dele. Alimente-o com uma cópia analítica de um fan-out Pub/Sub, uma carga em lote agendada pelo Scheduler, ou um Stream. Essa rejeição de leituras mais a capacidade alta e barata é a lição OLTP vs OLAP. Equivalentes reais: Amazon Redshift · Azure Synapse · Google BigQuery.",
     "warehouse_flow": "Fluxo: Pub/Sub / Scheduler / Stream → Data Warehouse (terminal analítico)",
     "warehouse_desc_short": "Armazenamento analítico barato ($90)",
+
+    // Educational failure badges (#156). Short floating labels drawn over the
+    // node that dropped a request — keep them SHORT, they are sprite text.
+    "failure_badges": "Motivos de falha",
+    "fail_queue_full": "Fila cheia",
+    "fail_overloaded": "Sobrecarregado",
+    "fail_retry_failed": "Nova tentativa falhou",
+    "fail_no_route": "Sem rota",
+    "fail_no_origin": "Sem origem",
+    "fail_no_subscriber": "Sem assinante",
+    "fail_no_master": "Sem master",
+    "fail_read_only_replica": "Réplica somente leitura",
+    "fail_analytics_store": "Repositório analítico, não para leituras",
+    "fail_wrong_store": "Tipo de armazenamento errado",
+    "fail_not_indexed": "Sem índice de busca",
+    "fail_search_only": "Somente índice de busca",
+    "fail_circuit_open": "Disjuntor aberto",
+    "fail_partition_stalled": "Partição travada",
+    "fail_breach": "Invasão!",
+    "fail_throttled": "Limitado",
 };

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -563,4 +563,24 @@ export const RU_TRANSLATIONS = {
     "warehouse_desc_long": "Аналитическое хранилище с профилем, обратным базе данных: оно завершает трафик WRITE и UPLOAD — медленно и дёшево на больших объёмах, — но проваливает любой READ или SEARCH в реальном времени, дошедший до него, ведь хранилище — это OLAP, а не OLTP. В него загружают, из него не обслуживают пользовательские чтения. Питайте его аналитической копией из веерной рассылки Pub/Sub, плановой пакетной загрузкой от Scheduler или из Стрима. Этот отказ в чтении плюс дешёвая высокая ёмкость и есть урок OLTP против OLAP. Реальные аналоги: Amazon Redshift · Azure Synapse · Google BigQuery.",
     "warehouse_flow": "Поток: Pub/Sub / Scheduler / Стрим → Хранилище данных (аналитический терминал)",
     "warehouse_desc_short": "Дешёвое аналитическое хранилище ($90)",
+
+    // Educational failure badges (#156). Short floating labels drawn over the
+    // node that dropped a request — keep them SHORT, they are sprite text.
+    "failure_badges": "Причины отказов",
+    "fail_queue_full": "Очередь переполнена",
+    "fail_overloaded": "Перегрузка",
+    "fail_retry_failed": "Повтор не помог",
+    "fail_no_route": "Нет маршрута",
+    "fail_no_origin": "Нет источника",
+    "fail_no_subscriber": "Нет подписчиков",
+    "fail_no_master": "Нет мастера",
+    "fail_read_only_replica": "Реплика только для чтения",
+    "fail_analytics_store": "Аналитика, не для чтений",
+    "fail_wrong_store": "Неподходящее хранилище",
+    "fail_not_indexed": "Нет поискового индекса",
+    "fail_search_only": "Только поиск",
+    "fail_circuit_open": "Предохранитель разомкнут",
+    "fail_partition_stalled": "Партиция застряла",
+    "fail_breach": "Взлом!",
+    "fail_throttled": "Ограничено",
 };

--- a/src/locales/zh.js
+++ b/src/locales/zh.js
@@ -563,4 +563,24 @@ export const ZH_TRANSLATIONS = {
     "warehouse_desc_long": "一种与数据库画像相反的分析存储：它完成 WRITE 和 UPLOAD 流量——在大批量下缓慢而廉价——但会让任何到达它的实时 READ 或 SEARCH 失败，因为数据仓库是 OLAP，而非 OLTP。你向它加载数据，而不从中服务用户读取。用 Pub/Sub 扇出的分析副本、Scheduler 的定时批量加载或 Stream 来喂养它。这种拒绝读取加上廉价高容量，就是 OLTP 与 OLAP 的教训。现实对应：Amazon Redshift · Azure Synapse · Google BigQuery。",
     "warehouse_flow": "流向：Pub/Sub / Scheduler / Stream → 数据仓库（分析终点）",
     "warehouse_desc_short": "廉价分析存储（$90）",
+
+    // Educational failure badges (#156). Short floating labels drawn over the
+    // node that dropped a request — keep them SHORT, they are sprite text.
+    "failure_badges": "失败原因",
+    "fail_queue_full": "队列已满",
+    "fail_overloaded": "过载",
+    "fail_retry_failed": "重试失败",
+    "fail_no_route": "无路由",
+    "fail_no_origin": "无源站",
+    "fail_no_subscriber": "无订阅者",
+    "fail_no_master": "无主库",
+    "fail_read_only_replica": "只读副本",
+    "fail_analytics_store": "分析存储，不供读取",
+    "fail_wrong_store": "存储类型不匹配",
+    "fail_not_indexed": "无搜索索引",
+    "fail_search_only": "仅限搜索索引",
+    "fail_circuit_open": "熔断器断开",
+    "fail_partition_stalled": "分区阻塞",
+    "fail_breach": "被攻破！",
+    "fail_throttled": "被限流",
 };

--- a/src/sim/circuit-breaker.js
+++ b/src/sim/circuit-breaker.js
@@ -70,6 +70,22 @@ function isBreakerOpen(service) {
     return service?.breakerState === "open";
 }
 
+// Fail-fast attribution for the failure badges (#156). True when `service` is
+// wired to a downstream that is ONLINE but skipped purely because its breaker
+// is not accepting traffic — i.e. the request in front of us is being shed by
+// the breaker rather than falling off an unwired board. Read-only: it decides
+// nothing, it only lets core/actions.js relabel a NO_ROUTE as "Circuit open".
+function hasTrippedDownstream(service) {
+    if (!service || !service.connections) return false;
+    return STATE.services.some(
+        (s) =>
+            service.connections.includes(s.id) &&
+            !s.isDisabled &&
+            (s.breakerState === "open" ||
+                (s.breakerState === "half-open" && s.breakerProbes <= 0))
+    );
+}
+
 function errorRate(service) {
     const events = service.breakerEvents;
     if (!events || events.length === 0) return 0;
@@ -171,6 +187,7 @@ function resetResilience() {
 
 export {
     errorRate,
+    hasTrippedDownstream,
     initBreaker,
     isBreakerOpen,
     isRoutable,

--- a/src/sim/handlers/apigw.js
+++ b/src/sim/handlers/apigw.js
@@ -6,6 +6,7 @@
 
 import { STATE } from "../../state.js";
 import { failOrPark, throttleRequest } from "../../core/actions.js";
+import { FAIL_REASONS } from "../../core/failure-reasons.js";
 import { isRoutable } from "../circuit-breaker.js";
 
 export function process(service, job) {
@@ -14,7 +15,7 @@ export function process(service, job) {
 
   if (service.rateCounter > rateLimit) {
     // Rate limited - soft fail
-    throttleRequest(job.req);
+    throttleRequest(job.req, FAIL_REASONS.THROTTLED);
     return "next";
   }
 
@@ -30,7 +31,7 @@ export function process(service, job) {
     service.rrIndex++;
     job.req.flyTo(target);
   } else {
-    failOrPark(job.req, service);
+    failOrPark(job.req, service, FAIL_REASONS.NO_ROUTE);
   }
   return "next";
 }

--- a/src/sim/handlers/cache.js
+++ b/src/sim/handlers/cache.js
@@ -5,6 +5,7 @@
 
 import { STATE } from "../../state.js";
 import { failOrPark, finishRequest } from "../../core/actions.js";
+import { FAIL_REASONS } from "../../core/failure-reasons.js";
 
 export function process(service, job) {
   if (job.req.isCacheable) {
@@ -37,7 +38,7 @@ export function process(service, job) {
     }
     const sqlTarget = service.findConnectedService("db");
     if (sqlTarget) { job.req.flyTo(sqlTarget); return "next"; }
-    failOrPark(job.req, service);
+    failOrPark(job.req, service, FAIL_REASONS.NO_ROUTE);
   } else {
     // Storage-family destinations are interchangeable on a miss (#88):
     // STATIC's destination is "cdn" but a Cache wired to S3 should still
@@ -49,7 +50,7 @@ export function process(service, job) {
     if (target) {
       job.req.flyTo(target);
     } else {
-      failOrPark(job.req, service);
+      failOrPark(job.req, service, FAIL_REASONS.NO_ROUTE);
     }
   }
   return "next";

--- a/src/sim/handlers/cdn.js
+++ b/src/sim/handlers/cdn.js
@@ -4,6 +4,7 @@
 
 import { STATE } from "../../state.js";
 import { failRequest, finishRequest } from "../../core/actions.js";
+import { FAIL_REASONS } from "../../core/failure-reasons.js";
 import { isRoutable } from "../circuit-breaker.js";
 
 export function process(service, job) {
@@ -31,8 +32,10 @@ export function process(service, job) {
     const target = connectedServices[0];
     job.req.flyTo(target);
   } else {
-    // Configuring Miss but no origin = Fail
-    failRequest(job.req);
+    // Configuring Miss but no origin = Fail. "No origin" rather than the
+    // generic "no route" (#156): an edge cache with nothing behind it is the
+    // specific mistake, and naming it is the lesson.
+    failRequest(job.req, FAIL_REASONS.NO_ORIGIN);
   }
   return "next";
 }

--- a/src/sim/handlers/compute.js
+++ b/src/sim/handlers/compute.js
@@ -9,6 +9,7 @@
 // hoisted function declarations, dereferenced long after both evaluate.
 
 import { failOrPark } from "../../core/actions.js";
+import { FAIL_REASONS } from "../../core/failure-reasons.js";
 import { chargeServerlessInvocation } from "./serverless.js";
 
 export function process(service, job) {
@@ -20,6 +21,8 @@ export function process(service, job) {
 
   if (destType === "blocked") {
     chargePerRequest();
+    // Destination "blocked" is MALICIOUS traffic: failRequest relabels this
+    // one as the breach it is scored as, so no reason is passed here (#156).
     failOrPark(job.req, service);
     return "next";
   }
@@ -88,7 +91,7 @@ export function process(service, job) {
       if (sqlTarget) { chargePerRequest(); job.req.flyTo(sqlTarget); return "next"; }
     }
     chargePerRequest();
-    failOrPark(job.req, service);
+    failOrPark(job.req, service, FAIL_REASONS.NO_ROUTE);
     return "next";
   }
 
@@ -104,7 +107,7 @@ export function process(service, job) {
     job.req.flyTo(directTarget);
   } else {
     chargePerRequest();
-    failOrPark(job.req, service);
+    failOrPark(job.req, service, FAIL_REASONS.NO_ROUTE);
   }
   return "next";
 }

--- a/src/sim/handlers/db.js
+++ b/src/sim/handlers/db.js
@@ -3,12 +3,14 @@
 // unchanged from the per-type if-chain in Service.update().
 
 import { failRequest, finishRequest } from "../../core/actions.js";
+import { FAIL_REASONS } from "../../core/failure-reasons.js";
 
 export function process(service, job) {
   if (job.req.destination === "db") {
     finishRequest(job.req, service.type, service);
   } else {
-    failRequest(job.req);
+    // Not database traffic — a SQL DB is the wrong store for it (#156).
+    failRequest(job.req, FAIL_REASONS.WRONG_STORE);
   }
   return "next";
 }

--- a/src/sim/handlers/dns.js
+++ b/src/sim/handlers/dns.js
@@ -13,6 +13,7 @@
 
 import { STATE } from "../../state.js";
 import { failOrPark } from "../../core/actions.js";
+import { FAIL_REASONS } from "../../core/failure-reasons.js";
 import { isRoutable } from "../circuit-breaker.js";
 
 export function process(service, job) {
@@ -21,7 +22,7 @@ export function process(service, job) {
         .filter((s) => s && isRoutable(s));
 
     if (stacks.length === 0) {
-        failOrPark(job.req, service);
+        failOrPark(job.req, service, FAIL_REASONS.NO_ROUTE);
         return "next";
     }
 

--- a/src/sim/handlers/index.js
+++ b/src/sim/handlers/index.js
@@ -34,6 +34,7 @@
 
 import { STATE } from "../../state.js";
 import { failOrPark } from "../../core/actions.js";
+import { FAIL_REASONS } from "../../core/failure-reasons.js";
 import { isRoutable } from "../circuit-breaker.js";
 import { process as apigw } from "./apigw.js";
 import { process as cache } from "./cache.js";
@@ -67,7 +68,7 @@ export function genericForward(service, job) {
     service.rrIndex++;
     job.req.flyTo(target);
   } else {
-    failOrPark(job.req, service);
+    failOrPark(job.req, service, FAIL_REASONS.NO_ROUTE);
   }
   return "next";
 }

--- a/src/sim/handlers/nosql.js
+++ b/src/sim/handlers/nosql.js
@@ -3,15 +3,18 @@
 // Service.update().
 
 import { failRequest, finishRequest } from "../../core/actions.js";
+import { FAIL_REASONS } from "../../core/failure-reasons.js";
 
 export function process(service, job) {
   // NoSQL handles READ and WRITE, but NOT SEARCH
   if (job.req.type === "SEARCH") {
-    failRequest(job.req);
+    // A key-value store is not a search index — that is the whole reason the
+    // Search Engine node exists (#156).
+    failRequest(job.req, FAIL_REASONS.NOT_INDEXED);
   } else if (job.req.destination === "db") {
     finishRequest(job.req, service.type, service);
   } else {
-    failRequest(job.req);
+    failRequest(job.req, FAIL_REASONS.WRONG_STORE);
   }
   return "next";
 }

--- a/src/sim/handlers/pubsub.js
+++ b/src/sim/handlers/pubsub.js
@@ -18,6 +18,7 @@
 
 import { STATE } from "../../state.js";
 import { failOrPark } from "../../core/actions.js";
+import { FAIL_REASONS } from "../../core/failure-reasons.js";
 import { Request } from "../../entities/Request.js";
 import { isRoutable } from "../circuit-breaker.js";
 
@@ -28,7 +29,7 @@ export function process(service, job) {
 
     if (subs.length === 0) {
         // No subscriber to deliver to — fail the event (a wired DLQ may catch it).
-        failOrPark(job.req, service);
+        failOrPark(job.req, service, FAIL_REASONS.NO_SUBSCRIBER);
         return "next";
     }
 

--- a/src/sim/handlers/replica.js
+++ b/src/sim/handlers/replica.js
@@ -4,6 +4,7 @@
 
 import { STATE } from "../../state.js";
 import { failRequest, finishRequest } from "../../core/actions.js";
+import { FAIL_REASONS } from "../../core/failure-reasons.js";
 
 export function process(service, job) {
   const hasMaster = service.connections.some(id => {
@@ -11,13 +12,15 @@ export function process(service, job) {
     return s && (s.type === "db" || s.type === "nosql");
   });
   if (!hasMaster) {
-    failRequest(job.req);
+    // A replica replicates FROM somewhere — unwired, it has nothing to serve.
+    failRequest(job.req, FAIL_REASONS.NO_MASTER);
     return "next";
   }
   if (job.req.type === "READ" && job.req.destination === "db") {
     finishRequest(job.req, service.type, service);
   } else {
-    failRequest(job.req);
+    // The read-replica lesson (#156): WRITEs must go to the master.
+    failRequest(job.req, FAIL_REASONS.READ_ONLY_REPLICA);
   }
   return "next";
 }

--- a/src/sim/handlers/s3.js
+++ b/src/sim/handlers/s3.js
@@ -4,12 +4,14 @@
 // if-chain in Service.update().
 
 import { failRequest, finishRequest } from "../../core/actions.js";
+import { FAIL_REASONS } from "../../core/failure-reasons.js";
 
 export function process(service, job) {
   if (job.req.destination === "s3" || job.req.destination === "cdn") {
     finishRequest(job.req, service.type, service);
   } else {
-    failRequest(job.req);
+    // Object storage cannot answer database or search traffic (#156).
+    failRequest(job.req, FAIL_REASONS.WRONG_STORE);
   }
   return "next";
 }

--- a/src/sim/handlers/search.js
+++ b/src/sim/handlers/search.js
@@ -3,12 +3,14 @@
 // Service.update().
 
 import { failRequest, finishRequest } from "../../core/actions.js";
+import { FAIL_REASONS } from "../../core/failure-reasons.js";
 
 export function process(service, job) {
   if (job.req.type === "SEARCH") {
     finishRequest(job.req, service.type, service);
   } else {
-    failRequest(job.req);
+    // A search index serves SEARCH and nothing else (#156).
+    failRequest(job.req, FAIL_REASONS.SEARCH_ONLY);
   }
   return "next";
 }

--- a/src/sim/handlers/warehouse.js
+++ b/src/sim/handlers/warehouse.js
@@ -16,6 +16,7 @@
 
 import { TRAFFIC_TYPES } from "../../config.js";
 import { failRequest, finishRequest } from "../../core/actions.js";
+import { FAIL_REASONS } from "../../core/failure-reasons.js";
 
 export function process(service, job) {
     const t = job.req.type;
@@ -24,7 +25,9 @@ export function process(service, job) {
         finishRequest(job.req, service.type, service);
     } else {
         // READ / SEARCH / STATIC / anything else: a warehouse cannot serve it.
-        failRequest(job.req);
+        // The badge says so in as many words — this is the OLTP-vs-OLAP lesson
+        // and the one failure players most often read as a bug (#156).
+        failRequest(job.req, FAIL_REASONS.ANALYTICS_STORE);
     }
     return "next";
 }

--- a/src/sim/retry.js
+++ b/src/sim/retry.js
@@ -32,6 +32,7 @@ import { recordServiceError } from "../core/metrics.js";
 // established pattern: failRequest is a hoisted function declaration, only
 // dereferenced when a backoff actually expires.
 import { failRequest } from "../core/actions.js";
+import { FAIL_REASONS } from "../core/failure-reasons.js";
 import { isRoutable } from "./circuit-breaker.js";
 
 // A conservative "alternate path exists" test: another routable service of the
@@ -100,7 +101,9 @@ function tickRetry(req, dt) {
     if (peer && STATE.services.includes(peer) && isRoutable(peer)) {
         req.flyTo(peer);
     } else {
-        failRequest(req);
+        // The backoff bought the request a second chance and the peer was gone
+        // when it came due — the retry itself is what failed (#156).
+        failRequest(req, FAIL_REASONS.RETRY_FAILED);
     }
     return true;
 }

--- a/src/sim/stream.js
+++ b/src/sim/stream.js
@@ -28,6 +28,7 @@
 
 import { STATE } from "../state.js";
 import { failOrPark } from "../core/actions.js";
+import { FAIL_REASONS } from "../core/failure-reasons.js";
 import { isRoutable } from "./circuit-breaker.js";
 
 // Lazily seed the partition buckets + per-partition timers on first tick.
@@ -88,7 +89,12 @@ export function tickStream(service, dt) {
             // it cannot leak. The tail advances to the next head next frame.
             part.shift();
             service.partitionTimers[p] = 0;
-            failOrPark(head, service);
+            // "Partition stalled" (#156) rather than "no route": what the
+            // player has to learn here is that the whole partition was WAITING
+            // on this one head — everything behind it was blocked by it, and
+            // the neighbouring partitions kept flowing. That is head-of-line
+            // blocking, and it is the reason this node exists.
+            failOrPark(head, service, FAIL_REASONS.PARTITION_STALLED);
             continue;
         }
 

--- a/src/sim/topology.js
+++ b/src/sim/topology.js
@@ -13,6 +13,9 @@ import { Service } from "../entities/Service.js";
 import { flashMoney, removeRequest } from "../core/actions.js";
 import { updateRepairCostTable } from "../core/economy.js";
 import { isRoutable } from "./circuit-breaker.js";
+// Failure badges (#156) are anchored to services; wiping the board must
+// dispose their textures too — see the note in ui/failure-badges.js.
+import { clearFailureBadges } from "../ui/failure-badges.js";
 // Runtime-only cycle (game.js ⇄ topology.js) — established pattern: these
 // are top-level consts in game.js (scene groups + raycasting singletons),
 // only dereferenced at runtime, long after both modules evaluate.
@@ -393,6 +396,7 @@ function clearAllServices() {
     STATE.internetNode.connections = [];
     STATE.requests.forEach((r) => r.destroy());
     STATE.requests = [];
+    clearFailureBadges();
     STATE.money = STATE.sandboxBudget;
 }
 

--- a/src/ui/failure-badges.js
+++ b/src/ui/failure-badges.js
@@ -1,0 +1,267 @@
+// Educational failure badges (#156). When a request dies, a short floating
+// label rises over the node that dropped it — "No route", "Read-only replica",
+// "Queue full ×7" — and fades over ~1.5 s. Every failure becomes a teaching
+// moment instead of a red flash the player cannot read.
+//
+// WIRING: core/actions.js calls spawnFailureBadge() from failRequest and
+// throttleRequest with the reason its caller passed (see core/failure-reasons.
+// js), and game.js ticks tickFailureBadges(dt) once per animate() frame
+// alongside metricsTick — same game-scaled dt, so a badge freezes with the
+// board at timeScale 0 and the player can read the failure moment on a paused
+// or game-over screen (#189 / #194).
+//
+// AGGREGATION is what makes this usable rather than noise. At 2 RPS every
+// failure deserves its own label; at 40 RPS a cascading failure would spray
+// hundreds of unreadable sprites and tank the frame rate. So badges are keyed
+// by (service, reason): a repeat hit while the badge is still alive COUNTS UP
+// and refreshes its lifetime instead of spawning a second sprite. The active
+// set is capped at MAX_BADGES; over the cap the oldest is dropped (Map keeps
+// insertion order, so "oldest" is just the first key).
+//
+// THREE HYGIENE: each badge owns a canvas texture + sprite material, and both
+// are disposed on expiry, on clearFailureBadges() (called from resetGame and
+// clearAllServices) and when the cap evicts one. Sprites have no geometry of
+// their own — THREE shares one internally — so the texture and the material
+// are the whole disposal surface. Nothing else here allocates GPU memory.
+//
+// The badges live in their own scene group (game.js: badgeGroup) rather than
+// as children of the service meshes: a badge must outlive the node that
+// dropped the request, and sprite scale must not inherit a node's scale.
+
+import { STATE } from "../state.js";
+import { i18n } from "../i18n.js";
+import { SOFT_REASONS } from "../core/failure-reasons.js";
+// Runtime-only cycle (ui/failure-badges.js -> game.js -> core/actions.js ->
+// ui/failure-badges.js) — the established pattern, identical to the way
+// entities/Request.js reaches requestGroup: badgeGroup is a top-level const in
+// game.js, only dereferenced when a badge is actually spawned.
+import { badgeGroup } from "../../game.js";
+
+// Concurrent badges. 12 is roughly "one per node on a busy board" — enough to
+// see a cascade spread, few enough to stay readable and cheap.
+const MAX_BADGES = 12;
+// Seconds of GAME time a badge lives (refreshed by every aggregated hit).
+const BADGE_LIFETIME = 1.5;
+// Fraction of the lifetime spent fully opaque before the fade starts.
+const FADE_START = 0.55;
+// World units the label floats upward over its life, and where it starts.
+const RISE = 2.0;
+const BASE_Y = 5;
+// Canvas pixels per world unit — the one knob for on-screen label size.
+const PX_PER_UNIT = 15;
+
+const FONT_PX = 26;
+const FONT = `bold ${FONT_PX}px "Courier New", monospace`;
+const PAD_X = 14;
+const PAD_Y = 8;
+
+const HARD_COLOR = "#f87171"; // red-400: the board dropped work
+const SOFT_COLOR = "#fbbf24"; // amber-400: deliberate load shedding
+const BG_COLOR = "rgba(9, 12, 20, 0.78)";
+
+const STORAGE_KEY = "serverSurvivalFailureBadges";
+
+// key ("serviceId|reason") -> badge record. Insertion-ordered, which is what
+// makes the cap eviction "drop the oldest" without a timestamp field.
+const badges = new Map();
+
+// Default ON: this is an educational feature, and a player who never finds the
+// toggle should still be taught. Persisted like the sound prefs.
+let enabled = restoreEnabled();
+
+function restoreEnabled() {
+    try {
+        return localStorage.getItem(STORAGE_KEY) !== "off";
+    } catch {
+        return true; // private mode / storage disabled — keep the default
+    }
+}
+
+// ---------------------------------------------------------------- rendering
+
+// Draw (or redraw, after the count ticks up) the label into the badge's own
+// canvas and resize the sprite to match. happy-dom canvases have no 2D
+// context, so the whole draw is skipped there — the badge still exists, ages
+// and disposes exactly the same, which is what the headless tests exercise.
+function paint(badge) {
+    const text =
+        badge.count > 1
+            ? `${i18n.t(badge.reason)} ×${badge.count}`
+            : i18n.t(badge.reason);
+
+    const canvas = badge.canvas;
+    const ctx = typeof canvas.getContext === "function" ? canvas.getContext("2d") : null;
+
+    let textW;
+    if (ctx) {
+        ctx.font = FONT;
+        textW = ctx.measureText(text).width;
+    } else {
+        // No 2D context: approximate so the sprite still gets a sane scale.
+        textW = text.length * FONT_PX * 0.6;
+    }
+
+    canvas.width = Math.ceil(textW + PAD_X * 2);
+    canvas.height = FONT_PX + PAD_Y * 2;
+
+    if (ctx) {
+        // Resizing the canvas resets the context state — re-set everything.
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = BG_COLOR;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.font = FONT;
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillStyle = SOFT_REASONS.has(badge.reason) ? SOFT_COLOR : HARD_COLOR;
+        ctx.fillText(text, canvas.width / 2, canvas.height / 2);
+    }
+
+    badge.texture.needsUpdate = true;
+    badge.sprite.scale.x = canvas.width / PX_PER_UNIT;
+    badge.sprite.scale.y = canvas.height / PX_PER_UNIT;
+    badge.sprite.scale.z = 1;
+}
+
+function disposeBadge(badge) {
+    badgeGroup.remove(badge.sprite);
+    // A Sprite carries no geometry of its own (THREE shares one), so the
+    // texture and the material are the complete disposal surface.
+    if (badge.material.map) badge.material.map.dispose();
+    badge.material.dispose();
+}
+
+// ------------------------------------------------------------------- public
+
+// Called from core/actions.js on every failed / throttled request. `reason` is
+// a FAIL_REASONS value (null from a caller that has nothing to teach, e.g. a
+// test double), in which case nothing is drawn. Positions on the service the
+// request was headed to, falling back to the request marker itself for the
+// entry-routing failures that never reached a node.
+function spawnFailureBadge(req, reason) {
+    if (!enabled || !reason) return null;
+
+    const service =
+        req && req.target && req.target.id && req.target.id !== "internet"
+            ? req.target
+            : null;
+    const pos = service?.position || req?.mesh?.position || STATE.internetNode.position;
+    if (!pos) return null;
+
+    const key = (service?.id || "internet") + "|" + reason;
+
+    // Aggregate: the same node failing the same way keeps ONE badge that
+    // counts up and lives longer, instead of stacking unreadable duplicates.
+    const existing = badges.get(key);
+    if (existing) {
+        existing.count++;
+        existing.life = BADGE_LIFETIME;
+        paint(existing);
+        return existing;
+    }
+
+    // Over the cap: evict the oldest so a cascade cannot grow without bound.
+    while (badges.size >= MAX_BADGES) {
+        const oldestKey = badges.keys().next().value;
+        disposeBadge(badges.get(oldestKey));
+        badges.delete(oldestKey);
+    }
+
+    const canvas = document.createElement("canvas");
+    const texture = new THREE.CanvasTexture(canvas);
+    const material = new THREE.SpriteMaterial({
+        map: texture,
+        transparent: true,
+        depthTest: false,
+    });
+    const sprite = new THREE.Sprite(material);
+    sprite.position.set(pos.x, BASE_Y, pos.z);
+    badgeGroup.add(sprite);
+
+    const badge = {
+        key,
+        reason,
+        count: 1,
+        life: BADGE_LIFETIME,
+        canvas,
+        texture,
+        material,
+        sprite,
+    };
+    badges.set(key, badge);
+    paint(badge);
+    return badge;
+}
+
+// One per animate() frame, with the same game-scaled dt as metrics and the
+// breaker. Paused (timeScale 0): freeze — no ageing, no fading — so the badges
+// on a stopped or game-over board stay readable while the player inspects it.
+function tickFailureBadges(dt) {
+    if (STATE.timeScale === 0) return;
+
+    for (const [key, badge] of badges) {
+        badge.life -= dt;
+        if (badge.life <= 0) {
+            disposeBadge(badge);
+            badges.delete(key);
+            continue;
+        }
+        const age = 1 - badge.life / BADGE_LIFETIME; // 0 -> 1 over the lifetime
+        badge.sprite.position.y = BASE_Y + RISE * age;
+        badge.material.opacity =
+            age < FADE_START ? 1 : 1 - (age - FADE_START) / (1 - FADE_START);
+    }
+}
+
+// Drop every badge and its GPU resources. Called from resetGame() and from
+// clearAllServices() — a badge anchored to a node that no longer exists is
+// both meaningless and a leak.
+function clearFailureBadges() {
+    for (const badge of badges.values()) disposeBadge(badge);
+    badges.clear();
+}
+
+function areFailureBadgesEnabled() {
+    return enabled;
+}
+
+function setFailureBadgesEnabled(value) {
+    enabled = !!value;
+    try {
+        localStorage.setItem(STORAGE_KEY, enabled ? "on" : "off");
+    } catch {
+        // storage disabled — the preference just is not remembered
+    }
+    if (!enabled) clearFailureBadges();
+    syncFailureBadgeButton();
+}
+
+function toggleFailureBadges() {
+    setFailureBadgesEnabled(!enabled);
+}
+
+// Reflect the preference on the toolbar's settings cluster. Same treatment the
+// sound toggles use (dimmed icon + red tint when off), so the three buttons
+// read as one group.
+function syncFailureBadgeButton() {
+    const btn = document.getElementById("tool-badges");
+    document.getElementById("badges-icon")?.classList.toggle("opacity-40", !enabled);
+    if (btn) btn.classList.toggle("bg-red-900", !enabled);
+}
+
+// Test/introspection accessor — the live badge records, newest last.
+function getFailureBadges() {
+    return [...badges.values()];
+}
+
+export {
+    BADGE_LIFETIME,
+    MAX_BADGES,
+    areFailureBadgesEnabled,
+    clearFailureBadges,
+    getFailureBadges,
+    setFailureBadgesEnabled,
+    spawnFailureBadge,
+    syncFailureBadgeButton,
+    tickFailureBadges,
+    toggleFailureBadges,
+};

--- a/tests/helpers/three-stub.mjs
+++ b/tests/helpers/three-stub.mjs
@@ -102,13 +102,33 @@ class Material {
     this.color = new Color(typeof params.color === "number" ? params.color : 0);
     if (!("opacity" in params)) this.opacity = 1;
     if (!("transparent" in params)) this.transparent = false;
+    // #156: the failure-badge leak tests assert every texture/material a badge
+    // allocated was actually disposed, so the stub has to remember.
+    this.disposed = false;
   }
-  dispose() {}
+  dispose() {
+    this.disposed = true;
+  }
 }
 export class MeshStandardMaterial extends Material {}
 export class MeshBasicMaterial extends Material {}
 export class MeshLambertMaterial extends Material {}
 export class LineBasicMaterial extends Material {}
+export class SpriteMaterial extends Material {}
+
+// Canvas-backed texture (#156 failure badges). Real THREE uploads the canvas
+// to the GPU on needsUpdate; here it only has to be disposable and countable.
+export class Texture {
+  constructor(image = null) {
+    this.image = image;
+    this.needsUpdate = false;
+    this.disposed = false;
+  }
+  dispose() {
+    this.disposed = true;
+  }
+}
+export class CanvasTexture extends Texture {}
 
 class Geometry {
   dispose() {}
@@ -183,6 +203,15 @@ export class Mesh extends Object3D {
 }
 
 export class Line extends Mesh {}
+
+// A real Sprite carries no geometry of its own (THREE shares one internally),
+// which is exactly why the badge disposal path only touches map + material.
+export class Sprite extends Object3D {
+  constructor(material) {
+    super();
+    this.material = material;
+  }
+}
 
 export class OrthographicCamera extends Object3D {
   constructor(left, right, top, bottom, near, far) {
@@ -294,6 +323,10 @@ export const THREE_STUB = {
   Mesh,
   Line,
   Line3,
+  Sprite,
+  SpriteMaterial,
+  Texture,
+  CanvasTexture,
   OrthographicCamera,
   AmbientLight,
   DirectionalLight,

--- a/tests/sim/failure-badges.test.mjs
+++ b/tests/sim/failure-badges.test.mjs
@@ -1,0 +1,554 @@
+// Educational failure badges (#156) over the REAL sim. Three things are under
+// test, in order of importance:
+//
+//   1. INERTNESS. The `reason` argument threaded through failRequest /
+//      failOrPark / throttleRequest is attribution only. The same topology and
+//      the same traffic must produce byte-identical failure counts whether the
+//      badges are on or off — see "the reason argument is inert". If that test
+//      ever fails, the instrumentation grew a side effect and THE CARDINAL
+//      INVARIANT (every request ends in exactly one of finishRequest /
+//      failRequest / removeRequest) is no longer provable from the old suite.
+//   2. ATTRIBUTION. Every entry in the taxonomy is reached by DRIVING the sim
+//      (a WRITE really flown at a Read Replica), never by calling failRequest
+//      by hand — otherwise the test proves the constant exists, not that the
+//      site passes it.
+//   3. RESOURCES. Aggregation, the concurrency cap and disposal: no duplicate
+//      sprites, no unbounded growth, and every canvas texture + sprite
+//      material disposed on expiry, eviction and clear.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Request } from "../../src/entities/Request.js";
+import { routeRequestToEntry, spawnRequest } from "../../src/core/actions.js";
+import { FAIL_REASONS, SOFT_REASONS } from "../../src/core/failure-reasons.js";
+import {
+    BADGE_LIFETIME,
+    MAX_BADGES,
+    areFailureBadgesEnabled,
+    clearFailureBadges,
+    getFailureBadges,
+    setFailureBadgesEnabled,
+    tickFailureBadges,
+} from "../../src/ui/failure-badges.js";
+import { clearAllServices } from "../../src/sim/topology.js";
+import { badgeGroup } from "../../game.js";
+import { EN_TRANSLATIONS } from "../../src/locales/en.js";
+import { STATE, CONFIG, resetWorld, place, connect, run, step } from "../helpers/sim-world.mjs";
+
+beforeEach(() => {
+    resetWorld();
+    clearFailureBadges();
+    setFailureBadgesEnabled(true);
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    clearFailureBadges();
+});
+
+// --------------------------------------------------------------- utilities
+
+// Inject straight at a node, skipping entry routing — the request flies there,
+// queues, and is processed by that node's real handler.
+function injectTo(service, type = "READ") {
+    const req = new Request(type);
+    STATE.requests.push(req);
+    req.flyTo(service);
+    return req;
+}
+
+// Pin a node's utilization so its failure roll is deterministic:
+// calculateFailChanceBasedOnLoad(1) === 1, so every job it finishes fails.
+function setLoad(service, load) {
+    Object.defineProperty(service, "totalLoad", {
+        get: () => load,
+        configurable: true,
+    });
+}
+
+function reasons() {
+    return getFailureBadges().map((b) => b.reason);
+}
+
+function badgeFor(reason) {
+    return getFailureBadges().find((b) => b.reason === reason);
+}
+
+// Run the world until a badge with `reason` appears (or give up). Keeps the
+// tests free of hard-coded processing/flight timings.
+function runUntilReason(reason, limit = 12, dt = 0.1) {
+    for (let i = 0; i < Math.round(limit / dt); i++) {
+        if (badgeFor(reason)) return true;
+        step(dt);
+    }
+    return !!badgeFor(reason);
+}
+
+// Drive one terminal node with one request and return the reason it produced.
+function reasonAt(type, trafficType, wire) {
+    const node = place(type);
+    if (wire) wire(node);
+    injectTo(node, trafficType);
+    run(8);
+    return reasons();
+}
+
+// ------------------------------------------------------- taxonomy coverage
+
+describe("failure taxonomy: every reason is produced by the real sim", () => {
+    it("a full queue drops the arrival with 'Queue full'", () => {
+        const db = place("db");
+        // Park a full backlog on the node. Services are never ticked in this
+        // test — only the arriving request is — so the placeholders are never
+        // dequeued; all that matters is that queue.length is at the cap.
+        const cap = db.config.maxQueueSize || 20;
+        while (db.queue.length < cap) db.queue.push({});
+
+        const req = injectTo(db, "READ");
+        for (let i = 0; i < 10; i++) req.update(0.1);
+
+        expect(reasons()).toEqual([FAIL_REASONS.QUEUE_FULL]);
+        expect(badgeFor(FAIL_REASONS.QUEUE_FULL).key).toBe(
+            db.id + "|" + FAIL_REASONS.QUEUE_FULL
+        );
+    });
+
+    it("the load/health failure roll says 'Overloaded'", () => {
+        const compute = place("compute");
+        const db = place("db");
+        connect(compute, db);
+        setLoad(compute, 1); // failChance = 2*(1-0.5) = 1
+
+        injectTo(compute, "READ");
+        run(8);
+
+        expect(reasons()).toEqual([FAIL_REASONS.OVERLOADED]);
+    });
+
+    it("a backoff whose peer vanished says 'Retry failed'", () => {
+        // Two Compute nodes behind one ALB: the shared upstream is what makes
+        // the second one a PROVABLE retry peer for the first (see retry.js).
+        const alb = place("alb");
+        const a = place("compute");
+        const b = place("compute");
+        connect("internet", alb);
+        connect(alb, a);
+        connect(alb, b);
+        setLoad(a, 1);
+
+        const req = injectTo(a, "READ");
+        // Step until the retry is armed, then take the peer away mid-backoff.
+        for (let i = 0; i < 100 && !(req.retryDelay > 0); i++) step(0.1);
+        expect(req.retryDelay).toBeGreaterThan(0);
+        b.isDisabled = true;
+
+        run(3);
+        expect(reasons()).toEqual([FAIL_REASONS.RETRY_FAILED]);
+        expect(STATE.resilience.retries).toBe(1);
+    });
+
+    it("a request that already spent its retry and failed again says 'Retry failed', not 'Overloaded'", () => {
+        const alb = place("alb");
+        const a = place("compute");
+        const b = place("compute");
+        connect("internet", alb);
+        connect(alb, a);
+        connect(alb, b);
+        setLoad(a, 1);
+        setLoad(b, 1); // the peer is just as sick — the retry lands and dies
+
+        const req = injectTo(a, "READ");
+        run(12);
+
+        expect(req.retries).toBe(CONFIG.resilience.maxRetries);
+        expect(reasons()).toEqual([FAIL_REASONS.RETRY_FAILED]);
+    });
+
+    it("a Compute with nowhere to send its READ says 'No route'", () => {
+        expect(reasonAt("compute", "READ")).toEqual([FAIL_REASONS.NO_ROUTE]);
+    });
+
+    it("traffic with no entry point at all says 'No route' at the Internet", () => {
+        const req = new Request("READ");
+        STATE.requests.push(req);
+        routeRequestToEntry(req, "READ"); // Internet is wired to nothing
+
+        expect(reasons()).toEqual([FAIL_REASONS.NO_ROUTE]);
+        expect(badgeFor(FAIL_REASONS.NO_ROUTE).key).toBe("internet|" + FAIL_REASONS.NO_ROUTE);
+    });
+
+    it("a tripped downstream is relabelled 'Circuit open', not 'No route'", () => {
+        const compute = place("compute");
+        const db = place("db");
+        connect(compute, db);
+        db.breakerState = "open"; // routing skips it — but the wire IS there
+
+        injectTo(compute, "READ");
+        run(8);
+
+        expect(reasons()).toEqual([FAIL_REASONS.CIRCUIT_OPEN]);
+    });
+
+    it("a CDN miss with nothing behind it says 'No origin'", () => {
+        // UPLOAD is not STATIC, so the cache-hit roll is skipped entirely and
+        // the miss path is deterministic.
+        expect(reasonAt("cdn", "UPLOAD")).toEqual([FAIL_REASONS.NO_ORIGIN]);
+    });
+
+    it("a Pub/Sub topic with no subscriber says 'No subscriber'", () => {
+        expect(reasonAt("pubsub", "WRITE")).toEqual([FAIL_REASONS.NO_SUBSCRIBER]);
+    });
+
+    it("a Read Replica with no master says 'No master'", () => {
+        expect(reasonAt("replica", "READ")).toEqual([FAIL_REASONS.NO_MASTER]);
+    });
+
+    it("a WRITE flown at a Read Replica says 'Read-only replica'", () => {
+        const db = place("db");
+        const replica = place("replica");
+        connect(replica, db); // a real master, so this is purely the WRITE rule
+
+        injectTo(replica, "WRITE");
+        run(8);
+
+        expect(reasons()).toEqual([FAIL_REASONS.READ_ONLY_REPLICA]);
+        expect(EN_TRANSLATIONS[FAIL_REASONS.READ_ONLY_REPLICA]).toBe("Read-only replica");
+    });
+
+    it("a READ that reaches the Data Warehouse says it is an analytics store (OLTP vs OLAP)", () => {
+        expect(reasonAt("warehouse", "READ")).toEqual([FAIL_REASONS.ANALYTICS_STORE]);
+    });
+
+    it("STATIC traffic at the SQL database says 'Wrong store type'", () => {
+        expect(reasonAt("db", "STATIC")).toEqual([FAIL_REASONS.WRONG_STORE]);
+    });
+
+    it("database traffic at File Storage says 'Wrong store type'", () => {
+        expect(reasonAt("s3", "READ")).toEqual([FAIL_REASONS.WRONG_STORE]);
+    });
+
+    it("a SEARCH at the NoSQL store says there is no search index", () => {
+        expect(reasonAt("nosql", "SEARCH")).toEqual([FAIL_REASONS.NOT_INDEXED]);
+    });
+
+    it("a READ at the Search Engine says it serves search only", () => {
+        expect(reasonAt("search", "READ")).toEqual([FAIL_REASONS.SEARCH_ONLY]);
+    });
+
+    it("MALICIOUS reaching a terminal is a 'Breach!' whatever verdict dropped it", () => {
+        // The db handler's own verdict would be WRONG_STORE; failRequest
+        // overrides it, matching what updateScore already charges for.
+        expect(reasonAt("db", "MALICIOUS")).toEqual([FAIL_REASONS.BREACH]);
+        expect(STATE.failures.MALICIOUS).toBe(1);
+    });
+
+    it("an over-limit API Gateway says 'Throttled' — a soft, differently coloured fail", () => {
+        const gw = place("apigw");
+        injectTo(gw, "READ");
+        // Hold the node over its rate limit on every frame (and keep its 1 s
+        // counter reset from firing) so the throttle branch is deterministic.
+        for (let i = 0; i < 60; i++) {
+            gw.rateCounter = (gw.config.rateLimit || 20) + 5;
+            gw.rateTimer = 0;
+            step(0.05);
+            if (badgeFor(FAIL_REASONS.THROTTLED)) break;
+        }
+
+        expect(reasons()).toEqual([FAIL_REASONS.THROTTLED]);
+        expect(SOFT_REASONS.has(FAIL_REASONS.THROTTLED)).toBe(true);
+        expect(STATE.failures.READ).toBe(0); // throttling is not a scored failure
+    });
+
+    it("a Stream partition head with no consumer says 'Partition stalled' (head-of-line blocking)", () => {
+        const stream = place("stream");
+        injectTo(stream, "WRITE");
+        run(8);
+
+        expect(reasons()).toEqual([FAIL_REASONS.PARTITION_STALLED]);
+    });
+
+    it("every taxonomy entry has a real, short English label", () => {
+        for (const key of Object.values(FAIL_REASONS)) {
+            const label = EN_TRANSLATIONS[key];
+            expect(label, `missing en translation for ${key}`).toBeTruthy();
+            expect(label).not.toBe(key); // a missing key renders as the key itself
+            expect(label.length).toBeLessThanOrEqual(32); // it is a sprite, not a sentence
+        }
+    });
+});
+
+// ------------------------------------------------------------- aggregation
+
+describe("aggregation, cap and lifetime", () => {
+    it("the same node failing the same way counts up instead of spawning duplicates", () => {
+        const search = place("search");
+        for (let i = 0; i < 5; i++) injectTo(search, "READ");
+        runUntilReason(FAIL_REASONS.SEARCH_ONLY);
+        run(3);
+
+        const badges = getFailureBadges();
+        expect(badges).toHaveLength(1);
+        expect(badges[0].count).toBe(5);
+        expect(badgeGroup.children).toHaveLength(1); // one sprite, not five
+    });
+
+    it("an aggregated hit refreshes the badge's lifetime", () => {
+        const search = place("search");
+        injectTo(search, "READ");
+        runUntilReason(FAIL_REASONS.SEARCH_ONLY);
+
+        tickFailureBadges(BADGE_LIFETIME * 0.8);
+        const aged = badgeFor(FAIL_REASONS.SEARCH_ONLY).life;
+        expect(aged).toBeLessThan(BADGE_LIFETIME);
+
+        // A second failure at the same node: it aggregates onto the SAME badge
+        // and resets its clock. (tickFailureBadges is not driven by run(), so
+        // nothing ages in between.)
+        injectTo(search, "READ");
+        run(3);
+        expect(badgeFor(FAIL_REASONS.SEARCH_ONLY).life).toBe(BADGE_LIFETIME);
+        expect(badgeFor(FAIL_REASONS.SEARCH_ONLY).count).toBe(2);
+    });
+
+    it("two different reasons at one node get their own badges", () => {
+        const nosql = place("nosql");
+        injectTo(nosql, "SEARCH"); // NOT_INDEXED
+        injectTo(nosql, "STATIC"); // WRONG_STORE
+        run(6);
+
+        expect(new Set(reasons())).toEqual(
+            new Set([FAIL_REASONS.NOT_INDEXED, FAIL_REASONS.WRONG_STORE])
+        );
+    });
+
+    it("the same reason at two different nodes gets its own badge each", () => {
+        const a = place("search");
+        const b = place("search");
+        injectTo(a, "READ");
+        injectTo(b, "READ");
+        run(6);
+
+        const badges = getFailureBadges();
+        expect(badges).toHaveLength(2);
+        expect(badges.every((x) => x.reason === FAIL_REASONS.SEARCH_ONLY)).toBe(true);
+        expect(new Set(badges.map((x) => x.key)).size).toBe(2);
+    });
+
+    it("the concurrent badge count is capped, and the evicted oldest is disposed", () => {
+        const nodes = [];
+        for (let i = 0; i < MAX_BADGES + 3; i++) nodes.push(place("search"));
+        for (const n of nodes) injectTo(n, "READ");
+        run(6);
+
+        expect(getFailureBadges()).toHaveLength(MAX_BADGES);
+        expect(badgeGroup.children).toHaveLength(MAX_BADGES);
+        // The survivors are the newest ones — the first nodes were evicted.
+        const live = new Set(getFailureBadges().map((b) => b.key.split("|")[0]));
+        expect(live.has(nodes[nodes.length - 1].id)).toBe(true);
+        expect(live.has(nodes[0].id)).toBe(false);
+    });
+
+    it("badges expire after their lifetime and leave the scene graph empty", () => {
+        const search = place("search");
+        injectTo(search, "READ");
+        runUntilReason(FAIL_REASONS.SEARCH_ONLY);
+        expect(badgeGroup.children).toHaveLength(1);
+
+        tickFailureBadges(BADGE_LIFETIME + 0.01);
+
+        expect(getFailureBadges()).toHaveLength(0);
+        expect(badgeGroup.children).toHaveLength(0);
+    });
+
+    it("expiry disposes the canvas texture and the sprite material (no THREE leak)", () => {
+        const search = place("search");
+        injectTo(search, "READ");
+        runUntilReason(FAIL_REASONS.SEARCH_ONLY);
+
+        const badge = badgeFor(FAIL_REASONS.SEARCH_ONLY);
+        expect(badge.texture.disposed).toBe(false);
+        expect(badge.material.disposed).toBe(false);
+
+        tickFailureBadges(BADGE_LIFETIME + 0.01);
+
+        expect(badge.texture.disposed).toBe(true);
+        expect(badge.material.disposed).toBe(true);
+        expect(badge.sprite.parent).toBe(null);
+    });
+
+    it("a heavy cascade never grows the badge collection or the scene group", () => {
+        const nodes = [];
+        for (let i = 0; i < 6; i++) nodes.push(place("search"));
+        for (let wave = 0; wave < 8; wave++) {
+            for (const n of nodes) injectTo(n, "READ");
+            run(1.5);
+            expect(getFailureBadges().length).toBeLessThanOrEqual(MAX_BADGES);
+            expect(badgeGroup.children.length).toBe(getFailureBadges().length);
+        }
+
+        // Let everything age out: back to a clean scene graph.
+        for (let i = 0; i < 40; i++) tickFailureBadges(0.1);
+        expect(getFailureBadges()).toHaveLength(0);
+        expect(badgeGroup.children).toHaveLength(0);
+    });
+
+    it("clearAllServices wipes the badges with the board", () => {
+        const search = place("search");
+        injectTo(search, "READ");
+        runUntilReason(FAIL_REASONS.SEARCH_ONLY);
+        const badge = badgeFor(FAIL_REASONS.SEARCH_ONLY);
+
+        clearAllServices();
+
+        expect(getFailureBadges()).toHaveLength(0);
+        expect(badgeGroup.children).toHaveLength(0);
+        expect(badge.material.disposed).toBe(true);
+        expect(badge.texture.disposed).toBe(true);
+    });
+});
+
+// -------------------------------------------------------- pause and toggle
+
+describe("freeze on pause", () => {
+    it("badges do not age while the game is paused", () => {
+        const search = place("search");
+        injectTo(search, "READ");
+        runUntilReason(FAIL_REASONS.SEARCH_ONLY);
+        const before = badgeFor(FAIL_REASONS.SEARCH_ONLY).life;
+
+        STATE.timeScale = 0;
+        for (let i = 0; i < 30; i++) tickFailureBadges(0.1);
+
+        expect(getFailureBadges()).toHaveLength(1);
+        expect(badgeFor(FAIL_REASONS.SEARCH_ONLY).life).toBe(before);
+    });
+
+    it("they resume ageing — and expire — once the game runs again", () => {
+        const search = place("search");
+        injectTo(search, "READ");
+        runUntilReason(FAIL_REASONS.SEARCH_ONLY);
+
+        STATE.timeScale = 0;
+        tickFailureBadges(5);
+        expect(getFailureBadges()).toHaveLength(1);
+
+        STATE.timeScale = 1;
+        tickFailureBadges(BADGE_LIFETIME + 0.01);
+        expect(getFailureBadges()).toHaveLength(0);
+    });
+});
+
+describe("the toggle", () => {
+    it("is on by default", () => {
+        expect(areFailureBadgesEnabled()).toBe(true);
+    });
+
+    it("suppresses spawning entirely when off", () => {
+        setFailureBadgesEnabled(false);
+
+        const search = place("search");
+        for (let i = 0; i < 4; i++) injectTo(search, "READ");
+        run(6);
+
+        expect(getFailureBadges()).toHaveLength(0);
+        expect(badgeGroup.children).toHaveLength(0);
+        expect(STATE.failures.READ).toBe(4); // the failures still happened
+    });
+
+    it("clears and disposes the badges already on screen when switched off", () => {
+        const search = place("search");
+        injectTo(search, "READ");
+        runUntilReason(FAIL_REASONS.SEARCH_ONLY);
+        const badge = badgeFor(FAIL_REASONS.SEARCH_ONLY);
+
+        setFailureBadgesEnabled(false);
+
+        expect(getFailureBadges()).toHaveLength(0);
+        expect(badge.material.disposed).toBe(true);
+        expect(badgeGroup.children).toHaveLength(0);
+    });
+
+    it("persists the preference like the sound prefs do", () => {
+        setFailureBadgesEnabled(false);
+        expect(localStorage.getItem("serverSurvivalFailureBadges")).toBe("off");
+        setFailureBadgesEnabled(true);
+        expect(localStorage.getItem("serverSurvivalFailureBadges")).toBe("on");
+    });
+});
+
+// ---------------------------------------------------------------- inertness
+
+// A tiny deterministic PRNG so the two runs below see the identical stream of
+// rolls (service ids, traffic mix, cache hits and failure rolls all draw from
+// Math.random).
+function mulberry32(seed) {
+    let a = seed >>> 0;
+    return () => {
+        a = (a + 0x6d2b79f5) >>> 0;
+        let t = a;
+        t = Math.imul(t ^ (t >>> 15), t | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+// One fixed, deliberately half-broken session: a Compute with no data store,
+// a Search Engine fed the wrong traffic and MALICIOUS in the mix, so every
+// branch of the taxonomy fires. Returns everything the game scores.
+function playFixedSession(badgesOn) {
+    setFailureBadgesEnabled(badgesOn);
+    vi.spyOn(Math, "random").mockImplementation(mulberry32(0x5eed));
+    resetWorld();
+
+    const alb = place("alb");
+    const compute = place("compute");
+    const search = place("search");
+    connect("internet", alb);
+    connect(alb, compute);
+    connect(compute, search);
+
+    STATE.trafficDistribution = {
+        STATIC: 0.2, READ: 0.3, WRITE: 0.2, UPLOAD: 0.1, SEARCH: 0.1, MALICIOUS: 0.1,
+    };
+    for (let i = 0; i < 120; i++) {
+        spawnRequest();
+        run(0.2);
+    }
+    run(10);
+
+    return {
+        failures: { ...STATE.failures },
+        processed: STATE.requestsProcessed,
+        score: STATE.score.total,
+        reputation: Math.round(STATE.reputation * 1e6) / 1e6,
+        inFlight: STATE.requests.length,
+    };
+}
+
+describe("the reason argument is inert (regression guard for #156)", () => {
+    it("the same session scores identically with badges on and off", () => {
+        const withBadges = playFixedSession(true);
+        const withoutBadges = playFixedSession(false);
+
+        expect(withBadges).toEqual(withoutBadges);
+    });
+
+    it("that session really did exercise the failure paths it is guarding", () => {
+        const result = playFixedSession(true);
+        const totalFailures = Object.values(result.failures).reduce((a, b) => a + b, 0);
+
+        expect(totalFailures).toBeGreaterThan(0);
+        expect(result.failures.MALICIOUS).toBeGreaterThan(0);
+        // More than one distinct lesson was taught during the run.
+        expect(getFailureBadges().length).toBeGreaterThan(0);
+    });
+
+    it("every request still terminates exactly once (THE CARDINAL INVARIANT)", () => {
+        playFixedSession(true);
+        // failRequest schedules removeRequest on a 500 ms timer, so the only
+        // requests left are the ones waiting on it — none are still in flight
+        // or sitting in a queue.
+        for (const req of STATE.requests) {
+            expect(req.failed || req.throttled || req.parked).toBeTruthy();
+        }
+        expect(STATE.requests.every((r) => !r.isMoving || r.failed)).toBe(true);
+    });
+});


### PR DESCRIPTION
Closes #156. A failing request used to flash red and vanish; the player learned nothing. Now each failure spawns a short floating label at the failing service naming the cause.

## The taxonomy is wider than the issue asked for
#156 was written before Wave 1, and its six-row table predates the mechanics that most need explaining. 16 reasons ship, wired at **every** `failRequest`/`failOrPark`/`throttleRequest` site across 19 files:

- the originals — queue full, overloaded, no route, breach, throttled, wrong store type
- **the Wave 1 additions** — circuit open (#196), retry exhausted (#196), stalled stream partition (#198), analytics store rejecting a read (#198, the OLAP lesson), replica rejecting a write (#190, the read-replica lesson), no master, no subscriber, no origin

## Aggregation is what makes it usable
Twenty doomed requests produce **one badge counting up**, not twenty overlapping labels — verified at count 14 for a 20-request burst. Readable at 2 RPS while you debug a small topology, still readable when a big one collapses at 40 RPS. Capped at 12 concurrent.

Badges **freeze while paused**, so a game-over board can actually be read — this closes the loop with #189's transparent failure screen and #194's frozen metric buffers. Toggle lives in the toolbar settings cluster and persists like the sound prefs; default on, since it's a teaching feature.

## Safety
Purely additive instrumentation — the `reason` argument changes no control flow and no failure counts. The 448 pre-existing tests pass untouched; 38 new ones bring the suite to **486**.

## Verification (mine, in a real browser)
| Check | Result |
|---|---|
| Reason accuracy | no-route, circuit-open, analytics-store, overloaded each named correctly at the right node |
| Aggregation | 20-request burst → 1 badge at count 14 |
| Toggle off | zero badges spawned |
| i18n | resolves in en and ru (`Circuit open` / `Предохранитель разомкнут`), no raw keys |
| **THREE leak** | scene objects 20 → 34 peak → **back to 20** after expiry |
| **Pause freeze** | lifetime held at 1.45 across 400 paused ticks, expired normally on resume |
| Stability | 5 consecutive full runs, no flakes |

Zero console errors. No build step, no new dependencies.

## One honest note
`READ_ONLY_REPLICA` is effectively a defensive branch: normal routing never sends a WRITE to a replica, so a player who wires `Compute → Replica` with no master path sees **`No route` at the Compute** instead. That's arguably the better lesson — it points at the node whose wiring is actually wrong — but the replica guard stays for the paths that could reach it.