### PR TITLE
feat: share architecture — PNG export + shareable URL (#157)

### DIFF
--- a/game.js
+++ b/game.js
@@ -91,6 +91,17 @@ import {
     lastPointerPos,
     resetCamera,
 } from "./src/input/handlers.js";
+// Share Architecture (#157): the share modal, PNG export, and the ?arch=
+// link. consumeSharedArchParam/rebuildSharedArch are called from the boot
+// path below; the modal handlers are re-exposed in the ESM-boundary block.
+import {
+    closeShareModal,
+    consumeSharedArchParam,
+    copyShareLink,
+    downloadArchitecturePNG,
+    rebuildSharedArch,
+    showShareModal,
+} from "./src/ui/share.js";
 // Service palette (toolbar categories, 2026-07-24): index.html ships only the
 // empty shell, so the tab strip and the active category's buttons are drawn
 // from here. The call sits in the body, not in toolbar.js's own evaluation,
@@ -636,9 +647,20 @@ function retryWithSameArchitecture() {
     STATE.sound?.playPlace();
 }
 
-// Initial setup - show menu, don't start game loop yet
+// Initial setup - show menu, don't start game loop yet. Exception (#157): a
+// valid ?arch= share link skips the menu entirely and drops the player into
+// Sandbox with the shared build already placed — that's the whole point of
+// the link. The param is stripped from the URL bar either way, so reloads
+// don't re-trigger and saves don't confuse.
 setTimeout(() => {
-    showMainMenu();
+    const sharedArch = consumeSharedArchParam();
+    if (sharedArch) {
+        document.getElementById("main-menu-modal").classList.add("hidden");
+        resetGame("sandbox");
+        rebuildSharedArch(sharedArch);
+    } else {
+        showMainMenu();
+    }
 }, 100);
 
 // getIntersect (canvas raycast picking) moved to src/input/handlers.js
@@ -1474,6 +1496,12 @@ window.saveGameState = saveGameState;
 window.onSaveGameFileUpload = onSaveGameFileUpload;
 window.onClickContinueGame = onClickContinueGame;
 
+// #157: the share modal's inline handlers in index.html.
+window.showShareModal = showShareModal;
+window.closeShareModal = closeShareModal;
+window.copyShareLink = copyShareLink;
+window.downloadArchitecturePNG = downloadArchitecturePNG;
+
 // #155 PR 7: the build/wire/demolish cluster now lives in src/sim/topology.js;
 // index.html's sandbox "Clear All" button still resolves this on window.
 window.clearAllServices = clearAllServices;
@@ -1503,6 +1531,7 @@ export {
     renderer,
     requestGroup,
     resetGame,
+    scene,
     serviceGroup,
     syncInput,
 };

--- a/index.html
+++ b/index.html
@@ -305,6 +305,15 @@
             d="M8 7H5a2 2 0 00-2 2v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4"></path>
         </svg>
       </button>
+      <button onclick="showShareModal()" id="btn-share"
+        class="time-btn w-10 h-10 rounded-lg border border-gray-600 text-gray-400 hover:text-white hover:border-cyan-500 hover:text-cyan-400 flex items-center justify-center"
+        data-i18n-title="share_arch"
+        title="Share Architecture">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+            d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"></path>
+        </svg>
+      </button>
       <button onclick="restartGame()" id="btn-restart"
         class="time-btn w-10 h-10 rounded-lg border border-gray-600 text-gray-400 hover:text-white hover:border-red-500 hover:text-red-400 flex items-center justify-center mr-2"
         data-i18n-title="restart_game"
@@ -797,6 +806,48 @@
         </button>
 
         <button onclick="closeSaveModal()"
+          data-i18n="cancel"
+          class="w-full bg-gray-800 hover:bg-gray-700 text-gray-300 font-bold py-3 px-8 rounded-lg border border-gray-600 transition hover:text-white font-mono uppercase">
+          Cancel
+        </button>
+      </div>
+
+      <div class="mt-8 text-xs text-gray-500 font-mono"></div>
+    </div>
+  </div>
+
+  <!-- Share Architecture Modal (#157) -->
+  <div id="share-modal" class="absolute inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm hidden">
+    <div
+      class="relative bg-gray-900/90 p-12 rounded-2xl border border-cyan-500/30 shadow-2xl max-w-md w-full text-center">
+
+      <h1
+        data-i18n="share_title"
+        class="text-5xl font-black text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-teal-300 mb-2 tracking-tighter filter drop-shadow-[0_0_10px_rgba(6,182,212,0.5)]">
+        Share Architecture
+      </h1>
+
+      <p data-i18n="share_desc" class="text-sm text-gray-400 mb-6">
+        Download a snapshot of your build, or copy a link that opens it in Sandbox.
+      </p>
+
+      <div class="space-y-4">
+
+        <button onclick="downloadArchitecturePNG()" id="btn-share-png"
+          data-i18n="share_png"
+          class="w-full bg-cyan-600 hover:bg-cyan-500 text-white font-bold py-4 px-8 rounded-lg shadow-lg transform transition hover:scale-105 font-mono uppercase text-lg border border-cyan-400/50">
+          Download PNG
+        </button>
+
+        <button onclick="copyShareLink()" id="btn-share-link"
+          data-i18n="share_copy_link"
+          class="w-full bg-teal-600 hover:bg-teal-500 text-white font-bold py-4 px-8 rounded-lg shadow-lg transform transition hover:scale-105 font-mono uppercase text-lg border border-teal-400/50">
+          Copy Link
+        </button>
+
+        <div id="share-status" class="text-sm font-mono h-5"></div>
+
+        <button onclick="closeShareModal()"
           data-i18n="cancel"
           class="w-full bg-gray-800 hover:bg-gray-700 text-gray-300 font-bold py-3 px-8 rounded-lg border border-gray-600 transition hover:text-white font-mono uppercase">
           Cancel

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -584,4 +584,14 @@ export const DE_TRANSLATIONS = {
     "fail_partition_stalled": "Partition blockiert",
     "fail_breach": "Einbruch!",
     "fail_throttled": "Gedrosselt",
+
+    // Share Architecture (#157): the share modal + top-bar button.
+    "share_arch": "Architektur teilen",
+    "share_title": "Architektur teilen",
+    "share_desc": "Lade einen Schnappschuss deines Aufbaus herunter oder kopiere einen Link, der ihn im Sandbox-Modus öffnet.",
+    "share_png": "PNG herunterladen",
+    "share_copy_link": "Link kopieren",
+    "share_link_copied": "Link in die Zwischenablage kopiert!",
+    "share_too_large": "Dieser Aufbau ist zu groß für einen Link.",
+    "share_copy_failed": "Kopieren fehlgeschlagen — der Browser hat den Zugriff auf die Zwischenablage blockiert.",
 };

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -584,4 +584,14 @@ export const EN_TRANSLATIONS = {
     "fail_partition_stalled": "Partition stalled",
     "fail_breach": "Breach!",
     "fail_throttled": "Throttled",
+
+    // Share Architecture (#157): the share modal + top-bar button.
+    "share_arch": "Share Architecture",
+    "share_title": "Share Architecture",
+    "share_desc": "Download a snapshot of your build, or copy a link that opens it in Sandbox.",
+    "share_png": "Download PNG",
+    "share_copy_link": "Copy Link",
+    "share_link_copied": "Link copied to clipboard!",
+    "share_too_large": "This build is too large to fit in a link.",
+    "share_copy_failed": "Copy failed — your browser blocked clipboard access.",
 };

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -584,4 +584,14 @@ export const FR_TRANSLATIONS = {
     "fail_partition_stalled": "Partition bloquée",
     "fail_breach": "Intrusion !",
     "fail_throttled": "Limité",
+
+    // Share Architecture (#157): the share modal + top-bar button.
+    "share_arch": "Partager l'architecture",
+    "share_title": "Partager l'architecture",
+    "share_desc": "Téléchargez une image de votre construction ou copiez un lien qui l'ouvre en mode bac à sable.",
+    "share_png": "Télécharger le PNG",
+    "share_copy_link": "Copier le lien",
+    "share_link_copied": "Lien copié dans le presse-papiers !",
+    "share_too_large": "Cette construction est trop grande pour tenir dans un lien.",
+    "share_copy_failed": "Échec de la copie — le navigateur a bloqué l'accès au presse-papiers.",
 };

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -584,4 +584,14 @@ export const IT_TRANSLATIONS = {
     "fail_partition_stalled": "Partizione bloccata",
     "fail_breach": "Violazione!",
     "fail_throttled": "Limitato",
+
+    // Share Architecture (#157): the share modal + top-bar button.
+    "share_arch": "Condividi l'architettura",
+    "share_title": "Condividi l'architettura",
+    "share_desc": "Scarica un'istantanea della tua costruzione o copia un link che la apre in modalità sandbox.",
+    "share_png": "Scarica PNG",
+    "share_copy_link": "Copia link",
+    "share_link_copied": "Link copiato negli appunti!",
+    "share_too_large": "Questa costruzione è troppo grande per stare in un link.",
+    "share_copy_failed": "Copia non riuscita — il browser ha bloccato l'accesso agli appunti.",
 };

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -584,4 +584,14 @@ export const KO_TRANSLATIONS = {
     "fail_partition_stalled": "파티션 정체",
     "fail_breach": "침해!",
     "fail_throttled": "속도 제한",
+
+    // Share Architecture (#157): the share modal + top-bar button.
+    "share_arch": "아키텍처 공유",
+    "share_title": "아키텍처 공유",
+    "share_desc": "빌드의 스냅샷을 다운로드하거나, 샌드박스에서 열리는 링크를 복사하세요.",
+    "share_png": "PNG 다운로드",
+    "share_copy_link": "링크 복사",
+    "share_link_copied": "링크가 클립보드에 복사되었습니다!",
+    "share_too_large": "이 빌드는 링크에 담기에는 너무 큽니다.",
+    "share_copy_failed": "복사 실패 — 브라우저가 클립보드 접근을 차단했습니다.",
 };

--- a/src/locales/nep.js
+++ b/src/locales/nep.js
@@ -584,4 +584,14 @@ export const NE_TRANSLATIONS = {
     "fail_partition_stalled": "पार्टिसन अवरुद्ध",
     "fail_breach": "उल्लङ्घन!",
     "fail_throttled": "सीमित",
+
+    // Share Architecture (#157): the share modal + top-bar button.
+    "share_arch": "आर्किटेक्चर साझा गर्नुहोस्",
+    "share_title": "आर्किटेक्चर साझा गर्नुहोस्",
+    "share_desc": "आफ्नो निर्माणको स्न्यापसट डाउनलोड गर्नुहोस्, वा स्यान्डबक्समा खोल्ने लिङ्क कपी गर्नुहोस्।",
+    "share_png": "PNG डाउनलोड गर्नुहोस्",
+    "share_copy_link": "लिङ्क कपी गर्नुहोस्",
+    "share_link_copied": "लिङ्क क्लिपबोर्डमा कपी भयो!",
+    "share_too_large": "यो निर्माण लिङ्कमा अटाउन धेरै ठूलो छ।",
+    "share_copy_failed": "कपी असफल — ब्राउजरले क्लिपबोर्ड पहुँच रोक्यो।",
 };

--- a/src/locales/pt-BR.js
+++ b/src/locales/pt-BR.js
@@ -584,4 +584,14 @@ export const PT_BR_TRANSLATIONS = {
     "fail_partition_stalled": "Partição travada",
     "fail_breach": "Invasão!",
     "fail_throttled": "Limitado",
+
+    // Share Architecture (#157): the share modal + top-bar button.
+    "share_arch": "Compartilhar arquitetura",
+    "share_title": "Compartilhar arquitetura",
+    "share_desc": "Baixe uma imagem da sua construção ou copie um link que a abre no modo sandbox.",
+    "share_png": "Baixar PNG",
+    "share_copy_link": "Copiar link",
+    "share_link_copied": "Link copiado para a área de transferência!",
+    "share_too_large": "Esta construção é grande demais para caber em um link.",
+    "share_copy_failed": "Falha ao copiar — o navegador bloqueou o acesso à área de transferência.",
 };

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -584,4 +584,14 @@ export const RU_TRANSLATIONS = {
     "fail_partition_stalled": "Партиция застряла",
     "fail_breach": "Взлом!",
     "fail_throttled": "Ограничено",
+
+    // Share Architecture (#157): the share modal + top-bar button.
+    "share_arch": "Поделиться архитектурой",
+    "share_title": "Поделиться архитектурой",
+    "share_desc": "Скачайте снимок вашей постройки или скопируйте ссылку, открывающую её в песочнице.",
+    "share_png": "Скачать PNG",
+    "share_copy_link": "Скопировать ссылку",
+    "share_link_copied": "Ссылка скопирована в буфер обмена!",
+    "share_too_large": "Постройка слишком большая, чтобы уместиться в ссылке.",
+    "share_copy_failed": "Не удалось скопировать — браузер заблокировал доступ к буферу обмена.",
 };

--- a/src/locales/zh.js
+++ b/src/locales/zh.js
@@ -584,4 +584,14 @@ export const ZH_TRANSLATIONS = {
     "fail_partition_stalled": "分区阻塞",
     "fail_breach": "被攻破！",
     "fail_throttled": "被限流",
+
+    // Share Architecture (#157): the share modal + top-bar button.
+    "share_arch": "分享架构",
+    "share_title": "分享架构",
+    "share_desc": "下载你的架构快照，或复制一个可在沙盒模式中打开它的链接。",
+    "share_png": "下载 PNG",
+    "share_copy_link": "复制链接",
+    "share_link_copied": "链接已复制到剪贴板！",
+    "share_too_large": "该架构太大，无法放入链接。",
+    "share_copy_failed": "复制失败——浏览器阻止了剪贴板访问。",
 };

--- a/src/sim/topology.js
+++ b/src/sim/topology.js
@@ -67,24 +67,12 @@ function restoreService(serviceData, pos) {
     STATE.sound.playPlace();
 }
 
-function createConnection(fromId, toId) {
-    if (fromId === toId) return;
-    const getEntity = (id) =>
-        id === "internet"
-            ? STATE.internetNode
-            : STATE.services.find((s) => s.id === id);
-    const from = getEntity(fromId),
-        to = getEntity(toId);
-    if (!from || !to || from.connections.includes(toId)) return;
-    // Reject the reverse edge of an existing link. ALB⇄SQS is the only pair valid
-    // in both directions, and having both at once loops requests forever (SQS
-    // pushes to ALB, ALB's generic forwarding pushes back) — they never reach
-    // finishRequest/failRequest and leak. Either single direction stays legal.
-    if (to.connections && to.connections.includes(fromId)) return;
-
+// The static edge allowlist, factored out of createConnection so the share
+// link decoder (#157) can pre-filter a hostile payload against the SAME table
+// instead of copying it. Pure over the two type strings — the stateful guards
+// (existing edge, reverse edge, entity lookup) stay in createConnection.
+function isValidEdge(t1, t2) {
     let valid = false;
-    const t1 = from.type,
-        t2 = to.type;
 
     if (t1 === "internet" && (t2 === "waf" || t2 === "alb")) valid = true;
     else if (t1 === "waf" && t2 === "alb") valid = true;
@@ -173,7 +161,28 @@ function createConnection(fromId, toId) {
     // scheduled batch load (Scheduler), or a Stream. Pure terminal, no outgoing.
     else if ((t1 === "pubsub" || t1 === "scheduler" || t1 === "stream") && t2 === "warehouse") valid = true;
 
-    if (!valid) {
+    return valid;
+}
+
+function createConnection(fromId, toId) {
+    if (fromId === toId) return;
+    const getEntity = (id) =>
+        id === "internet"
+            ? STATE.internetNode
+            : STATE.services.find((s) => s.id === id);
+    const from = getEntity(fromId),
+        to = getEntity(toId);
+    if (!from || !to || from.connections.includes(toId)) return;
+    // Reject the reverse edge of an existing link. ALB⇄SQS is the only pair valid
+    // in both directions, and having both at once loops requests forever (SQS
+    // pushes to ALB, ALB's generic forwarding pushes back) — they never reach
+    // finishRequest/failRequest and leak. Either single direction stays legal.
+    if (to.connections && to.connections.includes(fromId)) return;
+
+    const t1 = from.type,
+        t2 = to.type;
+
+    if (!isValidEdge(t1, t2)) {
         new Audio("assets/sounds/click-9.mp3").play();
         console.error(i18n.t('invalid_topology_detailed'));
         return;
@@ -408,6 +417,7 @@ export {
     deleteObject,
     findSPOFs,
     getConnectionAtPoint,
+    isValidEdge,
     restoreService,
     snapToGrid,
     updateConnectionsForNode,

--- a/src/ui/share.js
+++ b/src/ui/share.js
@@ -1,0 +1,336 @@
+// Share Architecture (#157): PNG export + shareable ?arch= URL.
+//
+// Two ways out of the share modal:
+//   1. "Download PNG" — a clean snapshot of the scene with a small watermark,
+//      read back from the WebGL canvas right after a synchronous re-render
+//      (the renderer runs without preserveDrawingBuffer, which is the right
+//      trade: that flag costs every frame, this feature runs once in a while).
+//   2. "Copy Link"    — the architecture ONLY (service types + positions +
+//      connections + sandbox budget; no score, reputation or save-state),
+//      compact JSON → base64url → ?arch= on the current origin+path.
+//
+// SECURITY: the ?arch= param is untrusted input — anyone can hand-craft a
+// link. decodeArchParam is the single gate: strict structural validation
+// (versioned format, type strings checked against CONFIG.services, finite
+// in-grid positions, hard caps on counts and payload size), and anything
+// malformed is ignored with one console.warn — never a throw, never an eval.
+// The rebuild then goes EXCLUSIVELY through createService/createConnection,
+// so the placement rules, the edge allowlist and the reverse-edge/cycle
+// guard (#192) all apply a second time on live state.
+
+import { CONFIG } from "../config.js";
+import { STATE } from "../state.js";
+import { i18n } from "../i18n.js";
+import { createConnection, createService, isValidEdge } from "../sim/topology.js";
+// Runtime-only cycle (game.js ⇄ share.js) — established pattern: these are
+// top-level consts / hoisted declarations in game.js, only dereferenced at
+// runtime, long after both modules evaluate.
+import { camera, renderer, scene, syncInput } from "../../game.js";
+
+const ARCH_VERSION = 1;
+// Hard caps: ~60 services covers every realistic build (the issue budgets
+// for ~50) while keeping a hostile payload from allocating thousands.
+const MAX_SERVICES = 60;
+const MAX_CONNECTIONS = 240;
+// The issue's viability bound for the whole link.
+const MAX_URL_LENGTH = 2000;
+// Reject grossly oversized params before even base64-decoding them.
+const MAX_PARAM_LENGTH = 4096;
+// One full grid width of slack around the origin: the drawn grid spans
+// ±(gridSize·tileSize)/2, and drag placement snaps but does not clamp, so a
+// node parked just off the edge still shares — 1e300 does not.
+const POSITION_BOUND = CONFIG.gridSize * CONFIG.tileSize;
+// The issue says "server-survival.dev", but that domain doesn't exist —
+// watermark the URL the game actually lives at.
+const WATERMARK = "pshenok.github.io/server-survival";
+
+// ==================== ENCODE ====================
+
+const round2 = (n) => Math.round(n * 100) / 100;
+
+// The wire format, flat for compactness (50 services must fit in ~2KB):
+//   v — format version, b — sandbox budget,
+//   t — service types in placement order,
+//   p — positions as [x0, z0, x1, z1, ...] (y is always 0 on the grid),
+//   c — service→service edges as flat index pairs [from0, to0, from1, ...],
+//   i — internet→service edges as indices into t.
+function encodeArch() {
+    const indexById = new Map(STATE.services.map((s, idx) => [s.id, idx]));
+    const t = STATE.services.map((s) => s.type);
+    const p = [];
+    for (const s of STATE.services) {
+        p.push(round2(s.position.x), round2(s.position.z));
+    }
+    const c = [];
+    const inet = [];
+    // STATE.connections already carries the internet edges too (createConnection
+    // pushes {from:"internet"} entries), so one pass covers both lists.
+    for (const conn of STATE.connections) {
+        const to = indexById.get(conn.to);
+        if (to === undefined) continue;
+        if (conn.from === "internet") {
+            inet.push(to);
+        } else {
+            const from = indexById.get(conn.from);
+            if (from !== undefined) c.push(from, to);
+        }
+    }
+    return { v: ARCH_VERSION, b: Math.round(STATE.sandboxBudget) || 0, t, p, c, i: inet };
+}
+
+function toBase64Url(str) {
+    return btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fromBase64Url(param) {
+    const b64 = param.replace(/-/g, "+").replace(/_/g, "/");
+    return atob(b64 + "=".repeat((4 - (b64.length % 4)) % 4));
+}
+
+// Full shareable URL for the current build, or null when it would blow the
+// ~2KB budget (the caller shows the i18n'd "too large" message instead).
+function buildShareUrl() {
+    const param = toBase64Url(JSON.stringify(encodeArch()));
+    const url = `${location.origin}${location.pathname}?arch=${param}`;
+    return url.length > MAX_URL_LENGTH ? null : url;
+}
+
+// ==================== DECODE / VALIDATE ====================
+
+const isIndex = (n, len) => Number.isInteger(n) && n >= 0 && n < len;
+
+// Untrusted-input gate. Returns a normalized architecture or null; logs a
+// single console.warn either way something gets ignored. The services array
+// keeps the ORIGINAL indices (dropped slots become null) so the connection
+// index space stays aligned with what the payload claimed.
+function decodeArchParam(raw) {
+    let dropped = 0;
+    try {
+        if (typeof raw !== "string" || raw.length === 0 || raw.length > MAX_PARAM_LENGTH) {
+            throw new Error("bad size");
+        }
+        const data = JSON.parse(fromBase64Url(raw));
+        if (!data || typeof data !== "object" || data.v !== ARCH_VERSION) {
+            throw new Error("bad version");
+        }
+        const { t, p, c, i: inet } = data;
+        if (!Array.isArray(t) || !Array.isArray(p) || !Array.isArray(c) || !Array.isArray(inet)) {
+            throw new Error("bad shape");
+        }
+        if (t.length > MAX_SERVICES || p.length !== t.length * 2) throw new Error("bad counts");
+        if (c.length > MAX_CONNECTIONS * 2 || c.length % 2 !== 0) throw new Error("bad counts");
+        if (inet.length > MAX_SERVICES) throw new Error("bad counts");
+
+        // Services: type must be a key CONFIG.services OWNS (hasOwnProperty, so
+        // "toString"/"__proto__" don't sneak through), position finite and on
+        // or near the grid. Bad entries are dropped, good ones survive.
+        const services = t.map((type, idx) => {
+            const x = p[idx * 2];
+            const z = p[idx * 2 + 1];
+            const ok =
+                typeof type === "string" &&
+                Object.prototype.hasOwnProperty.call(CONFIG.services, type) &&
+                typeof x === "number" && Number.isFinite(x) && Math.abs(x) <= POSITION_BOUND &&
+                typeof z === "number" && Number.isFinite(z) && Math.abs(z) <= POSITION_BOUND;
+            if (!ok) dropped++;
+            return ok ? { type, x, z } : null;
+        });
+
+        // Edges: both endpoints must be surviving services and the pair must be
+        // on the same allowlist createConnection enforces — pre-filtering here
+        // just keeps a hostile edge from triggering the in-game invalid-wire
+        // error path; createConnection still has the final word (and the
+        // stateful reverse-edge guard) during the rebuild.
+        const connections = [];
+        for (let k = 0; k < c.length; k += 2) {
+            const from = c[k], to = c[k + 1];
+            const ok =
+                isIndex(from, services.length) && isIndex(to, services.length) &&
+                from !== to && services[from] && services[to] &&
+                isValidEdge(services[from].type, services[to].type);
+            if (ok) connections.push([from, to]);
+            else dropped++;
+        }
+        const internet = inet.filter((idx) => {
+            const ok = isIndex(idx, services.length) && services[idx] &&
+                isValidEdge("internet", services[idx].type);
+            if (!ok) dropped++;
+            return ok;
+        });
+
+        const budget = Number.isFinite(data.b)
+            ? Math.min(1_000_000, Math.max(0, Math.round(data.b)))
+            : CONFIG.sandbox.defaultBudget;
+
+        if (dropped > 0) {
+            console.warn(`Shared architecture: ignored ${dropped} invalid entr${dropped === 1 ? "y" : "ies"}`);
+        }
+        return { budget, services, connections, internet };
+    } catch {
+        console.warn("Ignoring invalid ?arch= parameter");
+        return null;
+    }
+}
+
+// Reads ?arch= off the address bar, strips it (so reloads don't re-trigger
+// and saves don't confuse), and returns the decoded architecture or null.
+// Called once from game.js's boot path.
+function consumeSharedArchParam() {
+    const params = new URLSearchParams(location.search);
+    const raw = params.get("arch");
+    if (raw === null) return null;
+    params.delete("arch");
+    const rest = params.toString();
+    history.replaceState(null, "", location.pathname + (rest ? `?${rest}` : "") + location.hash);
+    return decodeArchParam(raw);
+}
+
+// ==================== REBUILD ====================
+
+// Places a decoded architecture into the (already reset) sandbox. Services go
+// through createService — which charges full price, so grant exactly the
+// build's cost up front and settle against the shared budget afterwards —
+// and edges through createConnection, whose allowlist and reverse-edge guard
+// make the final call on every wire.
+function rebuildSharedArch(arch) {
+    const totalCost = arch.services.reduce(
+        (sum, s) => sum + (s ? CONFIG.services[s.type].cost : 0),
+        0
+    );
+    STATE.money = totalCost;
+
+    // Original payload index → live service id (null when createService
+    // declined the placement, e.g. two services on one tile).
+    const ids = arch.services.map((s) => {
+        if (!s) return null;
+        const before = STATE.services.length;
+        createService(s.type, new THREE.Vector3(s.x, 0, s.z));
+        return STATE.services.length > before
+            ? STATE.services[STATE.services.length - 1].id
+            : null;
+    });
+    const spent = totalCost - STATE.money;
+
+    for (const idx of arch.internet) {
+        if (ids[idx]) createConnection("internet", ids[idx]);
+    }
+    for (const [from, to] of arch.connections) {
+        if (ids[from] && ids[to]) createConnection(ids[from], ids[to]);
+    }
+
+    STATE.sandboxBudget = arch.budget;
+    STATE.money = Math.max(0, arch.budget - spent);
+    syncInput("budget", arch.budget);
+}
+
+// ==================== SHARE MODAL ====================
+
+function setShareStatus(key, colorClass) {
+    const status = document.getElementById("share-status");
+    if (!status) return;
+    status.textContent = key ? i18n.t(key) : "";
+    status.className = `text-sm font-mono h-5 ${colorClass || ""}`;
+}
+
+function showShareModal() {
+    setShareStatus(null);
+    document.getElementById("share-modal")?.classList.remove("hidden");
+}
+
+function closeShareModal() {
+    document.getElementById("share-modal")?.classList.add("hidden");
+}
+
+function legacyCopy(text) {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.position = "fixed";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.select();
+    let ok;
+    try {
+        ok = document.execCommand("copy");
+    } catch {
+        ok = false;
+    }
+    ta.remove();
+    return ok === true;
+}
+
+function copyShareLink() {
+    const url = buildShareUrl();
+    if (!url) {
+        setShareStatus("share_too_large", "text-yellow-400");
+        return;
+    }
+    const done = (ok) =>
+        setShareStatus(ok ? "share_link_copied" : "share_copy_failed",
+            ok ? "text-green-400" : "text-red-400");
+    if (navigator.clipboard?.writeText) {
+        navigator.clipboard.writeText(url).then(
+            () => done(true),
+            () => done(legacyCopy(url))
+        );
+    } else {
+        done(legacyCopy(url));
+    }
+}
+
+// ==================== PNG EXPORT ====================
+
+function downloadArchitecturePNG() {
+    // The WebGL drawing buffer is cleared after presentation (no
+    // preserveDrawingBuffer), so re-render and read it back in the SAME
+    // synchronous task — the standard fix, free except when actually sharing.
+    renderer.render(scene, camera);
+    const glCanvas = renderer.domElement;
+    if (!glCanvas.width || !glCanvas.height) {
+        // A zero-sized drawing buffer (minimized/hidden window) would make
+        // drawImage throw from a click handler — bail quietly instead.
+        console.warn("Share: canvas has no size, PNG export skipped");
+        return;
+    }
+
+    const out = document.createElement("canvas");
+    out.width = glCanvas.width;
+    out.height = glCanvas.height;
+    const ctx = out.getContext("2d");
+    ctx.drawImage(glCanvas, 0, 0);
+
+    // Small watermark, bottom-right, with a dark offset copy for legibility
+    // on the bright parts of the scene.
+    const pad = Math.round(out.width / 80);
+    const fontSize = Math.max(12, Math.round(out.width / 90));
+    ctx.font = `${fontSize}px monospace`;
+    ctx.textAlign = "right";
+    ctx.textBaseline = "bottom";
+    ctx.fillStyle = "rgba(0, 0, 0, 0.6)";
+    ctx.fillText(WATERMARK, out.width - pad + 1, out.height - pad + 1);
+    ctx.fillStyle = "rgba(255, 255, 255, 0.8)";
+    ctx.fillText(WATERMARK, out.width - pad, out.height - pad);
+
+    out.toBlob((blob) => {
+        if (!blob) return;
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "my-architecture.png";
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+    }, "image/png");
+}
+
+export {
+    buildShareUrl,
+    closeShareModal,
+    consumeSharedArchParam,
+    copyShareLink,
+    decodeArchParam,
+    downloadArchitecturePNG,
+    encodeArch,
+    rebuildSharedArch,
+    showShareModal,
+};

--- a/tests/sim/share.test.mjs
+++ b/tests/sim/share.test.mjs
@@ -1,0 +1,308 @@
+// Share Architecture (#157): the ?arch= wire format over the REAL modules.
+// Three concerns: the encode→decode round trip is lossless for what it
+// promises to carry (types, positions, connections, budget); the decoder is a
+// hard gate for hostile payloads (never throws, drops garbage, enforces the
+// caps); and the rebuild goes through createService/createConnection so the
+// edge allowlist and the reverse-edge guard (#192) hold even against a
+// hand-crafted link.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  buildShareUrl,
+  decodeArchParam,
+  encodeArch,
+  rebuildSharedArch,
+} from "../../src/ui/share.js";
+import { createConnection, createService } from "../../src/sim/topology.js";
+import { STATE, CONFIG, resetWorld } from "../helpers/sim-world.mjs";
+
+let warnSpy, errorSpy;
+
+beforeEach(() => {
+  resetWorld();
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+  errorSpy.mockRestore();
+});
+
+// Place at an explicit grid position (sim-world's place() marches x outward
+// past the share format's position bound, so these tests pick their own).
+function placeAt(type, x, z) {
+  const before = STATE.services.length;
+  createService(type, new globalThis.THREE.Vector3(x, 0, z));
+  expect(STATE.services.length).toBe(before + 1);
+  return STATE.services[STATE.services.length - 1];
+}
+
+// The param string exactly as a link would carry it.
+function currentParam() {
+  const url = buildShareUrl();
+  expect(url).not.toBeNull();
+  return url.split("?arch=")[1];
+}
+
+function b64url(str) {
+  return Buffer.from(str).toString("base64url");
+}
+
+function payload(obj) {
+  return b64url(JSON.stringify(obj));
+}
+
+// A small legal build: internet → waf → alb → compute → db.
+function buildPipeline() {
+  const waf = placeAt("waf", -16, 0);
+  const alb = placeAt("alb", -8, 0);
+  const compute = placeAt("compute", 0, 4);
+  const db = placeAt("db", 8, -4);
+  createConnection("internet", waf.id);
+  createConnection(waf.id, alb.id);
+  createConnection(alb.id, compute.id);
+  createConnection(compute.id, db.id);
+  return { waf, alb, compute, db };
+}
+
+describe("encode → decode round trip", () => {
+  it("preserves service types and positions", () => {
+    buildPipeline();
+    const arch = decodeArchParam(currentParam());
+
+    expect(arch).not.toBeNull();
+    expect(arch.services.map((s) => s.type)).toEqual(["waf", "alb", "compute", "db"]);
+    expect(arch.services.map((s) => [s.x, s.z])).toEqual([
+      [-16, 0], [-8, 0], [0, 4], [8, -4],
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("preserves connections and the internet edges as indices", () => {
+    buildPipeline();
+    const arch = decodeArchParam(currentParam());
+
+    expect(arch.internet).toEqual([0]);
+    expect(arch.connections).toEqual([[0, 1], [1, 2], [2, 3]]);
+  });
+
+  it("preserves the sandbox budget", () => {
+    STATE.sandboxBudget = 3456;
+    buildPipeline();
+    expect(decodeArchParam(currentParam()).budget).toBe(3456);
+  });
+
+  it("rebuilds the identical topology through createService/createConnection", () => {
+    STATE.sandboxBudget = 3456;
+    buildPipeline();
+    const arch = decodeArchParam(currentParam());
+    const totalCost =
+      CONFIG.services.waf.cost + CONFIG.services.alb.cost +
+      CONFIG.services.compute.cost + CONFIG.services.db.cost;
+
+    resetWorld({ money: 0 });
+    rebuildSharedArch(arch);
+
+    expect(STATE.services.map((s) => s.type)).toEqual(["waf", "alb", "compute", "db"]);
+    expect(STATE.services.map((s) => [s.position.x, s.position.z])).toEqual([
+      [-16, 0], [-8, 0], [0, 4], [8, -4],
+    ]);
+    expect(STATE.internetNode.connections).toEqual([STATE.services[0].id]);
+    expect(STATE.connections).toHaveLength(4); // internet edge + 3 service edges
+    expect(STATE.sandboxBudget).toBe(3456);
+    expect(STATE.money).toBe(3456 - totalCost);
+  });
+
+  it("keeps the URL under 2000 chars for a 50-service build", () => {
+    const types = [
+      "waf", "alb", "alb",
+      ...Array(17).fill("compute"),
+      ...Array(10).fill("cache"),
+      ...Array(10).fill("db"),
+      ...Array(10).fill("s3"),
+    ];
+    const services = types.map((type, i) =>
+      placeAt(type, (i % 15) * 4 - 28, Math.floor(i / 15) * 4 - 20)
+    );
+    createConnection("internet", services[0].id);
+    createConnection(services[0].id, services[1].id);
+    createConnection(services[0].id, services[2].id);
+    for (let i = 3; i < 20; i++) {
+      createConnection(services[i % 2 === 0 ? 1 : 2].id, services[i].id); // alb → compute
+      createConnection(services[i].id, services[i + 17].id); // compute → cache/db/s3-ish
+    }
+    expect(STATE.connections.length).toBeGreaterThan(30);
+
+    const url = buildShareUrl();
+    expect(url).not.toBeNull();
+    expect(url.length).toBeLessThan(2000);
+
+    const arch = decodeArchParam(url.split("?arch=")[1]);
+    expect(arch.services).toHaveLength(50);
+    expect(arch.connections.length + arch.internet.length).toBe(STATE.connections.length);
+  });
+});
+
+describe("hostile / malformed input", () => {
+  it("drops an unknown service type but keeps the valid ones", () => {
+    const arch = decodeArchParam(payload({
+      v: 1, b: 1000,
+      t: ["waf", "totally-not-a-service", "alb"],
+      p: [0, 0, 8, 0, 16, 0],
+      c: [], i: [0],
+    }));
+    expect(arch.services[0].type).toBe("waf");
+    expect(arch.services[1]).toBeNull();
+    expect(arch.services[2].type).toBe("alb");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops an Object.prototype key posing as a service type", () => {
+    const arch = decodeArchParam(payload({
+      v: 1, b: 1000, t: ["toString"], p: [0, 0], c: [], i: [],
+    }));
+    expect(arch.services).toEqual([null]);
+  });
+
+  it("drops non-finite and non-numeric positions", () => {
+    // 1e999 survives JSON.parse as Infinity; a string coordinate is a type lie.
+    const raw = b64url('{"v":1,"b":100,"t":["waf","alb"],"p":[1e999,0,"8",0],"c":[],"i":[]}');
+    const arch = decodeArchParam(raw);
+    expect(arch.services).toEqual([null, null]);
+  });
+
+  it("drops positions outside the grid", () => {
+    const bound = CONFIG.gridSize * CONFIG.tileSize;
+    const arch = decodeArchParam(payload({
+      v: 1, b: 100, t: ["waf", "alb"], p: [bound + 1, 0, -8, 0], c: [], i: [],
+    }));
+    expect(arch.services[0]).toBeNull();
+    expect(arch.services[1]).not.toBeNull();
+  });
+
+  it("rejects an oversized raw param outright", () => {
+    expect(decodeArchParam("A".repeat(5000))).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects malformed base64 without throwing", () => {
+    expect(decodeArchParam("%%%not-base64%%%")).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects valid base64 of non-JSON without throwing", () => {
+    expect(decodeArchParam(b64url("hello world"))).toBeNull();
+  });
+
+  it("rejects JSON that is not a v1 architecture object", () => {
+    expect(decodeArchParam(b64url("42"))).toBeNull();
+    expect(decodeArchParam(payload({ v: 2, b: 1, t: [], p: [], c: [], i: [] }))).toBeNull();
+    expect(decodeArchParam(payload({ v: 1, b: 1, t: "waf", p: [], c: [], i: [] }))).toBeNull();
+  });
+
+  it("enforces the service-count cap", () => {
+    const n = 61;
+    const arch = decodeArchParam(payload({
+      v: 1, b: 100,
+      t: Array(n).fill("waf"),
+      p: Array(n * 2).fill(0),
+      c: [], i: [],
+    }));
+    expect(arch).toBeNull();
+  });
+
+  it("enforces the connection-count cap and pair alignment", () => {
+    const base = { v: 1, b: 100, t: ["waf", "alb"], p: [0, 0, 8, 0], i: [] };
+    expect(decodeArchParam(payload({ ...base, c: Array(482).fill(0) }))).toBeNull();
+    expect(decodeArchParam(payload({ ...base, c: [0, 1, 0] }))).toBeNull(); // odd length
+  });
+
+  it("clamps or defaults a bogus budget instead of trusting it", () => {
+    const base = { v: 1, t: [], p: [], c: [], i: [] };
+    expect(decodeArchParam(payload({ ...base })).budget).toBe(CONFIG.sandbox.defaultBudget);
+    expect(decodeArchParam(payload({ ...base, b: "9999" })).budget).toBe(CONFIG.sandbox.defaultBudget);
+    expect(decodeArchParam(payload({ ...base, b: -50 })).budget).toBe(0);
+    expect(decodeArchParam(payload({ ...base, b: 1e12 })).budget).toBe(1_000_000);
+  });
+
+  it("drops connection indices that are out of range or self-referential", () => {
+    const arch = decodeArchParam(payload({
+      v: 1, b: 100, t: ["waf", "alb"], p: [0, 0, 8, 0],
+      c: [0, 7, -1, 1, 0, 0, 1.5, 1, 0, 1], i: [9],
+    }));
+    expect(arch.connections).toEqual([[0, 1]]); // only the legal waf → alb pair
+    expect(arch.internet).toEqual([]);
+  });
+});
+
+describe("rebuild security (allowlist + guards)", () => {
+  it("silently refuses an injected illegal edge like db → waf", () => {
+    const arch = decodeArchParam(payload({
+      v: 1, b: 1000, t: ["db", "waf"], p: [0, 0, 8, 0], c: [0, 1], i: [],
+    }));
+    expect(arch.connections).toEqual([]); // filtered against the same allowlist
+
+    rebuildSharedArch(arch);
+    expect(STATE.services).toHaveLength(2); // the services themselves are fine
+    expect(STATE.connections).toHaveLength(0);
+    expect(errorSpy).not.toHaveBeenCalled(); // no in-game invalid-wire error path
+  });
+
+  it("refuses an illegal internet edge (internet → db)", () => {
+    const arch = decodeArchParam(payload({
+      v: 1, b: 1000, t: ["db"], p: [0, 0], c: [], i: [0],
+    }));
+    expect(arch.internet).toEqual([]);
+    rebuildSharedArch(arch);
+    expect(STATE.internetNode.connections).toEqual([]);
+  });
+
+  it("keeps the #192 reverse-edge guard: an injected ALB⇄SQS pair cannot form a cycle", () => {
+    const arch = decodeArchParam(payload({
+      v: 1, b: 1000, t: ["alb", "sqs"], p: [0, 0, 8, 0],
+      c: [0, 1, 1, 0], i: [0], // both directions individually legal
+    }));
+    expect(arch.connections).toHaveLength(2); // decode can't know — state guard's job
+
+    rebuildSharedArch(arch);
+    const [alb, sqs] = STATE.services;
+    expect(alb.connections).toEqual([sqs.id]);
+    expect(sqs.connections).toEqual([]); // reverse edge refused → no loop
+    expect(STATE.connections).toHaveLength(2); // internet → alb, alb → sqs
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("charges the shared build against the shared budget, floored at zero", () => {
+    const cost = CONFIG.services.waf.cost + CONFIG.services.alb.cost;
+    const arch = decodeArchParam(payload({
+      v: 1, b: 500, t: ["waf", "alb"], p: [0, 0, 8, 0], c: [0, 1], i: [0],
+    }));
+
+    rebuildSharedArch(arch);
+    expect(STATE.services).toHaveLength(2);
+    expect(STATE.sandboxBudget).toBe(500);
+    expect(STATE.money).toBe(500 - cost);
+
+    // A budget smaller than the build still places everything — money just
+    // bottoms out instead of silently truncating the shared architecture.
+    resetWorld({ money: 0 });
+    rebuildSharedArch(decodeArchParam(payload({
+      v: 1, b: 10, t: ["waf", "alb"], p: [0, 0, 8, 0], c: [0, 1], i: [0],
+    })));
+    expect(STATE.services).toHaveLength(2);
+    expect(STATE.money).toBe(0);
+  });
+
+  it("survives two services claiming the same tile (createService refuses the second)", () => {
+    const arch = decodeArchParam(payload({
+      v: 1, b: 1000, t: ["waf", "waf", "alb"], p: [0, 0, 0, 0, 8, 0],
+      c: [0, 2, 1, 2], i: [0, 1],
+    }));
+
+    rebuildSharedArch(arch);
+    expect(STATE.services.map((s) => s.type)).toEqual(["waf", "alb"]);
+    expect(STATE.internetNode.connections).toHaveLength(1);
+    // The dropped duplicate's edges vanish with it — only waf[0] → alb remains.
+    expect(STATE.connections).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Closes #157. The community ask: let players show off their builds. Every architecture screenshot on Twitter/Reddit is free promo — now the game makes that easy instead of hard.

## What ships
- **Download PNG** — synchronous re-render → composite → watermark → `my-architecture.png`. One deviation from the issue: the watermark reads `pshenok.github.io/server-survival`, because the issue's `server-survival.dev` doesn't exist.
- **Copy link** — the architecture (types, positions, connections, sandbox budget — nothing else) packs into versioned flat arrays → base64url → `?arch=`. **A realistic 20-service build is ~600 chars**; anything over 2000 is refused with a friendly message. Opening the link skips the menu, boots Sandbox with the build placed, and strips the param via `replaceState` so reloads don't re-trigger.

## Security (the part I verified hardest)
`?arch=` is untrusted input from anyone's link. Two-layer defense:
1. `decodeArchParam` validates strictly — own-key type check (so `__proto__`/`constructor` can't pose as service types), finite in-grid positions, capped counts (≤60 services), clamped budget. Invalid entries become `null` placeholders that are **never placed**.
2. Rebuild goes **exclusively** through `createService`/`createConnection`, so the edge allowlist, tile-collision and the #192 reverse-edge guard all apply to hostile payloads. The edge table itself is now the exported `isValidEdge()` — one source of truth instead of a duplicated list.

My battery: garbage base64, oversized payloads, `__proto__` types, NaN positions, negative budget, an injected illegal `db→waf` edge — all absorbed with a single `console.warn`, nothing placed or wired that shouldn't be, no throws.

## Verification
- Full loop in a real browser: build → Copy link → navigate to the generated URL → menu skipped, all 5 services + connections rebuilt at exact positions, param stripped, **30/30 requests flow on the shared build**
- PNG pixel-checked non-blank with the watermark (decoded back through `<img>` + canvas sampling); a zero-sized drawing buffer (minimized window) now bails quietly instead of throwing from the click handler
- 22 new tests (suite **539**), five consecutive runs, no flakes, lint 0, zero console errors