### PR TITLE
fix: SQS-fed Compute fleet never auto-scales when queue backs up (#220) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/src/sim/autoscaling.js
+++ b/src/sim/autoscaling.js
@@ -28,6 +28,7 @@
 
 import { CONFIG } from "../config.js";
 import { STATE } from "../state.js";
+import { isRoutable } from "./circuit-breaker.js";
 
 // Satellite ring geometry (visual only).
 const SAT_RADIUS = 3.4;
@@ -51,6 +52,38 @@ function warmupFor(service) {
     return service.type === "container"
         ? (cfg.containerWarmupSec ?? cfg.warmupSec)
         : cfg.warmupSec;
+}
+
+// Effective load for autoscaling decisions. When a Compute/Container node has
+// an upstream SQS queue, the fleet should scale out based on queue depth in
+// addition to CPU utilization — a backed-up queue means work is piling up even
+// if the current instances are idle (e.g. because they're waiting on a slow
+// downstream). Without this, an SQS-fed compute fleet never scales.
+function effectiveLoad(service) {
+    const util = service.totalLoad;
+    if (!canAutoscale(service)) return util;
+
+    // Find upstream SQS services that feed into this compute node.
+    const upstreamSQS = STATE.services.filter(
+        (s) =>
+            s.type === "sqs" &&
+            s.connections &&
+            s.connections.includes(service.id) &&
+            isRoutable(s)
+    );
+    if (upstreamSQS.length === 0) return util;
+
+    // Take the deepest queue fill ratio among all upstream SQS queues.
+    const maxFill = Math.max(
+        ...upstreamSQS.map((sqs) => {
+            const maxQ = sqs.config.maxQueueSize || 200;
+            return sqs.queue ? sqs.queue.length / maxQ : 0;
+        })
+    );
+
+    // Effective load is the higher of CPU utilization and queue depth.
+    // A queue at 90% fill triggers the same scale-out as 90% CPU.
+    return Math.max(util, maxFill);
 }
 
 // Seeded from the Service constructor for EVERY type. Non-compute services
@@ -122,7 +155,9 @@ function updateAutoscaling(service, dt) {
     // Utilization of the CURRENT ready fleet — totalLoad already divides by
     // the instance count, so a fleet at half load reads 0.5 no matter how
     // wide it is. That is what makes scale-in possible at all.
-    const util = service.totalLoad;
+    // When an upstream SQS queue is backing up, effectiveLoad incorporates
+    // queue depth so the fleet scales out pre-emptively.
+    const util = effectiveLoad(service);
     if (util > cfg.targetUtil) {
         service.asgAbove += dt;
         service.asgBelow = 0;
@@ -236,6 +271,7 @@ function disposeSatellites(service) {
 export {
     canAutoscale,
     disposeSatellites,
+    effectiveLoad,
     initAutoscaling,
     instanceCount,
     refreshSatellites,


### PR DESCRIPTION
## Problem

Issue #220: an SQS-fed Compute fleet with ASG enabled never auto-scales because `updateAutoscaling()` only looks at `service.totalLoad` (CPU utilization). When the fleet is idle — e.g. waiting on a slow downstream, or after a recent scale-in that left it under-provisioned — the queue depth grows unboundedly but no scale-out event fires.

## Root Cause

The autoscaling threshold check in `updateAutoscaling()` compares `service.totalLoad` against `targetUtil`. For an SQS-fed compute node, the CPU utilization can be low (idle fleet waiting for downstream) while the SQS queue is backing up. The queue depth signal was never surfaced to the autoscaling engine.

## Fix

Introduce `effectiveLoad(service)` — a function that computes the effective load as the maximum of:
1. **CPU utilization** (`service.totalLoad`) — unchanged existing behavior
2. **Upstream SQS queue fill ratio** — `Math.max(...upstreamSQS.map(q => q.queue.length / q.config.maxQueueSize))`

When no upstream SQS exists, or the service doesn't have autoscaling enabled, `effectiveLoad()` returns `utilization` unchanged (no-op).

### Design decisions

- **Circuit breaker awareness**: the function respects `isRoutable()` — if an upstream SQS has its circuit breaker open, it's excluded from the depth calculation. This prevents a broken SQS from falsely inflating the load.
- **Multi-SQS support**: when a compute node has multiple upstream SQS queues, the deepest queue wins. This matches the "worst bottleneck" principle.
- **Default maxQueueSize**: SQS queues default to 200 if `config.maxQueueSize` is not set (matches the existing convention in `src/entities/Service.js`).

## Testing

- `src/sim/autoscaling.js` lints clean
- All 142 unit tests pass
- 14 sim suite failures are pre-existing (Node.js built-in module compatibility in happy-dom environment)