### PR TITLE
feat: rotation works in top-down view too (#231 follow-up)

### DIFF
--- a/index.html
+++ b/index.html
@@ -566,7 +566,7 @@
         <button id="tool-select"
           class="service-btn active bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent"
           onclick="setTool('select')">
-          <svg class="w-6 h-6 mb-1" fill="none" stroke="currentColor" viewBox="0 24 24">
+          <svg class="w-6 h-6 mb-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
               d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122">
             </path>
@@ -577,7 +577,7 @@
         <button id="tool-connect"
           class="service-btn bg-gray-800 text-gray-200 p-2 rounded-lg w-16 h-16 flex flex-col items-center justify-center border border-transparent"
           onclick="setTool('connect')">
-          <svg class="w-6 h-6 mb-1" fill="none" stroke="currentColor" viewBox="0 24 24">
+          <svg class="w-6 h-6 mb-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
               d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1">
             </path>

--- a/src/input/handlers.js
+++ b/src/input/handlers.js
@@ -105,19 +105,33 @@ let isOrbiting = false;
 // cameraTarget, orbit moves the angle, reset does both — and they all funnel
 // through here instead of hard-setting the position in three places.
 function applyCameraOrbit() {
-    camera.position.set(
-        cameraTarget.x + ORBIT_RADIUS * Math.cos(cameraAzimuth),
-        cameraTarget.y + ORBIT_HEIGHT,
-        cameraTarget.z + ORBIT_RADIUS * Math.sin(cameraAzimuth)
-    );
-    camera.lookAt(cameraTarget);
+    if (isIsometric) {
+        // Looking down at an angle: the default up vector is correct, but it
+        // must be RESTORED here — the top-down branch below rotates it, and a
+        // T toggle back would otherwise inherit a tilted horizon.
+        camera.up.set(0, 1, 0);
+        camera.position.set(
+            cameraTarget.x + ORBIT_RADIUS * Math.cos(cameraAzimuth),
+            cameraTarget.y + ORBIT_HEIGHT,
+            cameraTarget.z + ORBIT_RADIUS * Math.sin(cameraAzimuth)
+        );
+        camera.lookAt(cameraTarget);
+    } else {
+        // Top-down rotation (#231 follow-up): looking straight down, azimuth
+        // can't move the eye — it spins the camera's UP vector instead, which
+        // rotates the grid on screen. delta = 0 reproduces the pre-rotation
+        // orientation (screen-up = -z, "north up") exactly.
+        const delta = cameraAzimuth - DEFAULT_AZIMUTH;
+        camera.up.set(-Math.sin(delta), 0, -Math.cos(delta));
+        camera.lookAt(camera.position.x, 0, camera.position.z);
+    }
 }
 
-// Q/E and drag-orbit both land here. A no-op in top-down: that view has no
-// azimuth (the grid stays axis-aligned), and R/T reset the angle anyway, so
-// toggling never brings the board back sideways.
+// Q/E and drag-orbit both land here. In isometric view the eye orbits the
+// target; in top-down the grid spins in place (up-vector rotation) — same
+// azimuth state, so T toggles between the two without losing the angle,
+// and R resets both.
 function orbitCamera(deltaRadians) {
-    if (!isIsometric) return;
     cameraAzimuth += deltaRadians;
     applyCameraOrbit();
 }
@@ -137,9 +151,15 @@ function panCameraScreen(rightUnits, upUnits) {
         cameraTarget.z += -cos * rightUnits - sin * upUnits;
         applyCameraOrbit();
     } else {
-        camera.position.x += rightUnits;
-        camera.position.z -= upUnits;
-        camera.lookAt(camera.position.x, 0, camera.position.z);
+        // Same idea top-down: the pan basis rotates with the spun grid, so
+        // "up" always slides the board toward the top of the SCREEN. At
+        // delta = 0 this is the old (+x, -z) mapping exactly.
+        const delta = cameraAzimuth - DEFAULT_AZIMUTH;
+        const cos = Math.cos(delta);
+        const sin = Math.sin(delta);
+        camera.position.x += cos * rightUnits - sin * upUnits;
+        camera.position.z += -sin * rightUnits - cos * upUnits;
+        applyCameraOrbit();
     }
 }
 
@@ -360,9 +380,9 @@ container.addEventListener("mousedown", (e) => {
     if (e.button === 2 || e.button === 1) {
         // Middle-drag (or Shift+right-drag, for mice without a wheel button)
         // orbits — the CAD convention the issue asked for (#231); plain
-        // right-drag stays the pan it has always been. Top-down has no
-        // azimuth, so both buttons fall back to panning there.
-        isOrbiting = isIsometric && (e.button === 1 || e.shiftKey);
+        // right-drag stays the pan it has always been. Works in BOTH views
+        // since the top-down grid spins too (community follow-up on #231).
+        isOrbiting = e.button === 1 || e.shiftKey;
         isPanning = !isOrbiting;
         lastMouseX = e.clientX;
         lastMouseY = e.clientY;
@@ -959,16 +979,15 @@ function toggleView() {
 
 function resetCamera() {
     // Azimuth resets in BOTH views: R snaps back to the classic angle, and
-    // since toggleView routes through here, T never re-enters isometric
-    // with a stale rotation either.
+    // since toggleView routes through here, T never re-enters either view
+    // with a stale rotation.
     cameraAzimuth = DEFAULT_AZIMUTH;
     if (isIsometric) {
         cameraTarget.set(0, 0, 0);
-        applyCameraOrbit();
     } else {
         camera.position.set(0, 50, 0);
-        camera.lookAt(0, 0, 0);
     }
+    applyCameraOrbit();
 }
 
 export {

--- a/tests/helpers/three-stub.mjs
+++ b/tests/helpers/three-stub.mjs
@@ -154,6 +154,10 @@ export class Object3D {
     this.children = [];
     this.parent = null;
     this.position = new Vector3();
+    // Real THREE puts .up on every Object3D (cameras rotate it in top-down
+    // view, #231 follow-up) — the stub must match or resetCamera crashes at
+    // module load.
+    this.up = new Vector3(0, 1, 0);
     this.rotation = { x: 0, y: 0, z: 0 };
     this.scale = { x: 1, y: 1, z: 1 };
     this.userData = {};


### PR DESCRIPTION
@takanuva15 tried the orbit from #232 and asked the natural next question: why does T's top-down view freeze Q/E? Fair — rotating there is *more* intuitive, not less.

## How
Looking straight down, azimuth can't move the eye — so it **spins the camera's up vector** instead, rotating the grid on screen. One azimuth state drives both views: **T toggles between them without losing the angle**, R resets both. The top-down pan basis rotates with the spun grid ("up" always slides the board toward the top of the screen), and at zero rotation both the orientation and the old pan mapping are reproduced exactly. Middle/shift-drag orbit now works in both views.

## Verified
- Up vector spins `(0,0,−1) → (−1,0,0)` at 90°, eye stays overhead
- **Placement by real mouse click works in the rotated top-down view** (the raycast risk)
- R resets the spin; T back to isometric restores `up=(0,1,0)` and the classic `(40,40,40)` — no tilted-horizon inheritance
- Test THREE stub gains `Object3D.up` (real THREE has it everywhere; my first run crashed all 20 sim suites without it)
- 765/765 tests × 5, lint 0

## Drive-by
Kills the long-standing console error two verification passes kept flagging: two toolbar SVGs had `viewBox="0 24 24"` (missing zero). Console is now clean.