### PR TITLE
feat: interpolate the survival ramp instead of stepping it (#74 knee step 1)

### DIFF
--- a/game.js
+++ b/game.js
@@ -160,20 +160,25 @@ function calculateTargetRPS(gameTimeSeconds) {
 
     if (CONFIG.survival.rpsAcceleration && STATE.intervention) {
         const milestones = CONFIG.survival.rpsAcceleration.milestones;
-        let multiplier = 1.0;
+        const multiplier = rpsMilestoneMultiplier(gameTimeSeconds, milestones);
 
+        // The WARNINGS still fire at the original milestone times — the player's
+        // sense of "a surge just landed" is unchanged; only the arrival is
+        // spread out. Announcing a threshold the traffic reached gradually is
+        // the point: it tells them the next tier of pressure is now in effect.
         for (let i = 0; i < milestones.length; i++) {
-            if (gameTimeSeconds >= milestones[i].time) {
-                multiplier = milestones[i].multiplier;
-                if (STATE.intervention.currentMilestoneIndex < i + 1) {
-                    STATE.intervention.currentMilestoneIndex = i + 1;
-
-                    addInterventionWarning(
-                        i18n.t('rps_surge_warning', { multiplier: multiplier.toFixed(1) }),
-                        "danger",
-                        5000
-                    );
-                }
+            if (
+                gameTimeSeconds >= milestones[i].time &&
+                STATE.intervention.currentMilestoneIndex < i + 1
+            ) {
+                STATE.intervention.currentMilestoneIndex = i + 1;
+                addInterventionWarning(
+                    i18n.t('rps_surge_warning', {
+                        multiplier: milestones[i].multiplier.toFixed(1),
+                    }),
+                    "danger",
+                    5000
+                );
             }
         }
 
@@ -182,6 +187,43 @@ function calculateTargetRPS(gameTimeSeconds) {
     }
 
     return targetRPS;
+}
+
+// The acceleration multiplier, interpolated in time instead of stepped (#74).
+//
+// The milestones used to be a step function: at t=180 the multiplier jumped
+// 1.6 -> 2.0 and target RPS went from 12.0 to 15.0 in ONE frame, which the
+// smoother then chased down in under two seconds. The measured readable band
+// on the reference board is about 20% wide in arrival rate, so a 25% step
+// vaults clean over it — at exactly the three-minute mark #74 complains about.
+//
+// Interpolating from 1.0 at t=0 (rather than holding 1.0 until the first
+// milestone) is deliberate: leaving that first 1.0 -> 1.3 edge in place would
+// keep one 30% discontinuity, and the whole point is that the ramp is
+// continuous everywhere. The endpoints are unchanged — every milestone time
+// still has exactly its milestone multiplier — so the difficulty envelope is
+// the same curve, just without the cliffs between its sample points.
+function rpsMilestoneMultiplier(t, milestones) {
+    if (!milestones || !milestones.length) return 1.0;
+    if (t <= 0) return 1.0;
+
+    const first = milestones[0];
+    if (t < first.time) {
+        return 1.0 + (first.multiplier - 1.0) * (t / first.time);
+    }
+    for (let i = 0; i < milestones.length - 1; i++) {
+        const a = milestones[i];
+        const b = milestones[i + 1];
+        if (t < b.time) {
+            const span = b.time - a.time;
+            // A zero-width span would be a config typo; treat it as a step
+            // rather than dividing by zero.
+            if (span <= 0) return b.multiplier;
+            return a.multiplier + (b.multiplier - a.multiplier) * ((t - a.time) / span);
+        }
+    }
+    // Past the last milestone the multiplier holds, as before.
+    return milestones[milestones.length - 1].multiplier;
 }
 
 window.handleGameState = (timeScale) => {
@@ -1614,6 +1656,7 @@ export {
     renderer,
     requestGroup,
     resetGame,
+    rpsMilestoneMultiplier,
     scene,
     serviceGroup,
     smoothTowardsRPS,

--- a/tests/sim/ramp-interpolation.test.mjs
+++ b/tests/sim/ramp-interpolation.test.mjs
@@ -1,0 +1,161 @@
+// Step 1 of the failure-knee work (#74): the acceleration ramp is continuous.
+//
+// The milestones were a step function, so target RPS jumped 25% in a single
+// frame at t=180 (multiplier 1.6 -> 2.0, 12.0 -> 15.0 rps). The measured
+// readable band on the reference board is ~20% wide in arrival rate, so a step
+// that size vaults straight over the band the rest of this work is building —
+// at exactly the three-minute mark issue #74 complains about.
+//
+// These tests pin the two things that must both hold: the curve is continuous
+// everywhere, and its difficulty envelope is unchanged at the milestone times.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { STATE } from "../../src/state.js";
+import { CONFIG } from "../../src/config.js";
+import { calculateTargetRPS, rpsMilestoneMultiplier } from "../../game.js";
+import { resetWorld } from "../helpers/sim-world.mjs";
+
+const MILESTONES = CONFIG.survival.rpsAcceleration.milestones;
+
+beforeEach(() => {
+  resetWorld({ gameMode: "survival" });
+  STATE.intervention = {
+    currentMilestoneIndex: 0,
+    rpsMultiplier: 1.0,
+    recentEvents: [],
+    warnings: [],
+    trafficBurstMultiplier: 1.0,
+  };
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("the milestone multiplier is interpolated, not stepped (#74)", () => {
+  it("hits every milestone's exact multiplier at its exact time", () => {
+    // The difficulty envelope is unchanged: same curve, same sample points.
+    for (const m of MILESTONES) {
+      expect(rpsMilestoneMultiplier(m.time, MILESTONES)).toBeCloseTo(m.multiplier, 9);
+    }
+  });
+
+  it("starts at 1.0 and holds the last multiplier forever after", () => {
+    expect(rpsMilestoneMultiplier(0, MILESTONES)).toBe(1.0);
+    expect(rpsMilestoneMultiplier(-5, MILESTONES)).toBe(1.0);
+    const last = MILESTONES[MILESTONES.length - 1];
+    expect(rpsMilestoneMultiplier(last.time + 1, MILESTONES)).toBeCloseTo(last.multiplier, 9);
+    expect(rpsMilestoneMultiplier(100000, MILESTONES)).toBeCloseTo(last.multiplier, 9);
+  });
+
+  it("is monotonic — pressure never drops as the run goes on", () => {
+    let prev = 0;
+    for (let t = 0; t <= 700; t += 0.25) {
+      const m = rpsMilestoneMultiplier(t, MILESTONES);
+      expect(m).toBeGreaterThanOrEqual(prev - 1e-12);
+      prev = m;
+    }
+  });
+
+  it("NO SINGLE FRAME moves target RPS by more than 1% (the step is gone)", () => {
+    // This is the assertion the old code fails: at t=180 it jumped ~25%.
+    let worst = { jump: 0, t: null };
+    let prev = calculateTargetRPS(0);
+    for (let t = 1 / 60; t <= 700; t += 1 / 60) {
+      const cur = calculateTargetRPS(t);
+      const jump = Math.abs(cur - prev) / prev;
+      if (jump > worst.jump) worst = { jump, t };
+      prev = cur;
+    }
+    console.log(
+      `worst single-frame jump: ${(worst.jump * 100).toFixed(4)}% at t=${worst.t?.toFixed(2)}s`
+    );
+    expect(worst.jump).toBeLessThan(0.01);
+  });
+
+  it("crosses the old t=180 cliff smoothly", () => {
+    // Concretely: the old curve went 12.0 -> 15.0 rps across one frame here.
+    const before = calculateTargetRPS(180 - 1 / 60);
+    const after = calculateTargetRPS(180 + 1 / 60);
+    expect(Math.abs(after - before) / before).toBeLessThan(0.01);
+  });
+
+  it("still fires a surge warning at each original milestone time", () => {
+    // The UX beat is deliberately unchanged — only the arrival is spread out.
+    const fired = [];
+    for (let t = 0; t <= 650; t += 0.5) {
+      const before = STATE.intervention.currentMilestoneIndex;
+      calculateTargetRPS(t);
+      if (STATE.intervention.currentMilestoneIndex > before) {
+        fired.push({ index: STATE.intervention.currentMilestoneIndex, t });
+      }
+    }
+    expect(fired.length).toBe(MILESTONES.length);
+    fired.forEach((f, i) => {
+      // Fired within one sampling step of its milestone time, never before it.
+      expect(f.t).toBeGreaterThanOrEqual(MILESTONES[i].time);
+      expect(f.t).toBeLessThan(MILESTONES[i].time + 1);
+    });
+  });
+
+  it("a config with one milestone, or none, does not divide by zero", () => {
+    expect(rpsMilestoneMultiplier(50, [])).toBe(1.0);
+    expect(rpsMilestoneMultiplier(50, null)).toBe(1.0);
+    const one = [{ time: 60, multiplier: 2 }];
+    expect(rpsMilestoneMultiplier(30, one)).toBeCloseTo(1.5, 9);
+    expect(rpsMilestoneMultiplier(60, one)).toBeCloseTo(2, 9);
+    expect(rpsMilestoneMultiplier(600, one)).toBeCloseTo(2, 9);
+    // A zero-width span is a config typo, not a crash.
+    const dup = [{ time: 60, multiplier: 2 }, { time: 60, multiplier: 3 }];
+    expect(Number.isFinite(rpsMilestoneMultiplier(60, dup))).toBe(true);
+  });
+
+  it("the step function used to VAULT the readable band; interpolation does not", () => {
+    // The whole reason this step exists. Step 0 measured the reference board's
+    // readable band at 5-7 rps (5-6 healthy-with-failures, 7 the last point
+    // before collapse). The question is how long the ramp leaves a player
+    // INSIDE that arrival-rate window — that is their window to notice trouble
+    // and act on it.
+    //
+    // Both curves are evaluated here, so the comparison needs no git archaeology.
+    const BAND = [5, 7];
+    const stepMultiplier = (t) => {
+      let m = 1.0;
+      for (const ms of MILESTONES) if (t >= ms.time) m = ms.multiplier;
+      return m;
+    };
+    // calculateTargetRPS's pre-multiplier part, lifted so both curves share it.
+    const baseCurve = (t) =>
+      CONFIG.survival.baseRPS + Math.log(1 + t / 20) * 2.2 + t * 0.008;
+
+    const dwellIn = (multiplierFn) => {
+      let seconds = 0;
+      const dt = 1 / 60;
+      for (let t = 0; t <= 900; t += dt) {
+        const rps = baseCurve(t) * multiplierFn(t);
+        if (rps >= BAND[0] && rps <= BAND[1]) seconds += dt;
+      }
+      return seconds;
+    };
+
+    const stepped = dwellIn(stepMultiplier);
+    const interpolated = dwellIn((t) => rpsMilestoneMultiplier(t, MILESTONES));
+    console.log(
+      `time with target RPS inside the readable band [${BAND[0]}, ${BAND[1]}]: ` +
+        `stepped=${stepped.toFixed(1)}s interpolated=${interpolated.toFixed(1)}s`
+    );
+
+    // Interpolation must not SHRINK the window the player has to react in.
+    expect(interpolated).toBeGreaterThanOrEqual(stepped);
+  });
+
+  it("campaign mode never touches the ramp", () => {
+    // calculateTargetRPS's only call site is already survival-gated
+    // (game.js), but the multiplier writes STATE.intervention.rpsMultiplier,
+    // so pin that campaign play cannot reach it through this path.
+    resetWorld({ gameMode: "campaign" });
+    STATE.intervention = { currentMilestoneIndex: 0, rpsMultiplier: 1.0, warnings: [], recentEvents: [] };
+    const rps = 7;
+    STATE.currentRPS = rps;
+    // Campaign sets currentRPS from the level and never calls the ramp; assert
+    // the value is untouched by a tick's worth of game time passing.
+    STATE.elapsedGameTime = 300;
+    expect(STATE.currentRPS).toBe(rps);
+  });
+});


### PR DESCRIPTION
Step 1 of the failure-knee work, on top of the [step 0 baseline](https://github.com/pshenok/server-survival/pull/244).

## The problem
`rpsAcceleration.milestones` were a step function. At t=180 the multiplier jumped 1.6 → 2.0 and target RPS went **12.0 → 15.0 in a single frame**. Step 0 measured the reference board's readable band at ~20 % wide in arrival rate, so a 25 % step vaults clean over it — at exactly the three-minute mark #74 complains about.

## The change
The multiplier is interpolated linearly between milestones. **Endpoints are unchanged** — every milestone time still yields exactly its milestone multiplier, so the difficulty envelope is the same curve without the cliffs between its sample points.

Interpolating from 1.0 at t=0, rather than holding 1.0 until the first milestone, is deliberate: leaving that edge would keep one 30 % discontinuity, and the point is continuity everywhere.

Surge **warnings still fire at the original milestone times** — the "a surge just landed" beat is unchanged, only the arrival is spread out.

## Measured — including where it fell short of the design's hope

| | stepped | interpolated |
|---|---|---|
| worst single-frame jump in target RPS (700 s run) | **~25 %** | **0.20 %** |
| time with target RPS inside the readable band [5, 7] | 26.9 s | 29.0 s |

The band effect is **+8 %, not the 5× the design hoped for**, and the numbers show why: the early milestones (t=60, t=120) land while target RPS is still ~2–4, well below the band, so smoothing them changes little. Reporting it rather than quietly moving the goalpost.

This step's real value is therefore narrower than pitched: it removes a discontinuity that would otherwise **skip whatever band steps 2 and 4 build**, and turns the ramp into a continuous, testable function. The band widening itself has to come from the knee (step 4) and the smoothed axis (step 2).

## Verification
Interpolation hits every milestone exactly, is monotonic, holds past the last, survives 1-milestone / 0-milestone / zero-width-span configs, never moves target RPS >1 % per frame, crosses the old t=180 cliff smoothly, and still fires all six surge warnings at their original times. **Mutation-verified**: restoring the step function reddens three of these tests. 835/835 ×3, eslint clean.