### PR TITLE
feat: smoothedLoad — change the axis, not the curve (#74 knee step 2)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -648,6 +648,21 @@ export const CONFIG = {
   // instead of over-provisioning. Serverless still wins idle and spiky
   // traffic, a fixed Compute wins steady mid-range traffic, and the ASG is
   // the only option that survives past Serverless's capacity ceiling.
+  // Load signal (#74). `totalLoad` is an instantaneous ratio whose numerator is
+  // an integer job count, so on a tier-1 Compute (capacity 4) it can only take
+  // the values 0.75, 1.00, 1.25 — and a sweep of the reference board measured
+  // its mean dwell inside the interesting band at 0.10-0.25 s at EVERY load.
+  // That is a strobe, not a state: no threshold placed on the instantaneous
+  // signal can describe something a player is able to see and act on.
+  //
+  // `smoothedLoad` is the same quantity through a trailing exponential mean, so
+  // it is continuous (resolution ~0.001 instead of 1/capacity) and persists
+  // long enough to be read. tau is in GAME seconds — the update is driven by
+  // the game-scaled dt, so fast-forward advances it by game time, not frames.
+  load: {
+    smoothingTau: 2.5,
+  },
+
   autoscaling: {
     targetUtil: 0.7, // scale out above this sustained utilization
     scaleInUtil: 0.3, // scale in below this (hysteresis gap prevents flapping)

--- a/src/entities/Service.js
+++ b/src/entities/Service.js
@@ -78,6 +78,11 @@ export class Service {
     // outside that path (or opt out), so architecture-variety polls never
     // grant for a board the player did not build this session.
     this.playerPlaced = false;
+    // Trailing mean of totalLoad (#74). Starts cold at 0 on every path that
+    // builds a Service — placement, campaign pre-build, and Service.restore,
+    // which constructs through here — because a restored save is a cold boot
+    // and inheriting a previous session's average would be invisible state.
+    this.smoothedLoad = 0;
 
     let geo, mat;
     const materialProps = { roughness: 0.2 };
@@ -535,6 +540,22 @@ export class Service {
   }
 
   update(dt) {
+    // The smoothed load signal (#74), updated FIRST so every consumer in this
+    // frame reads a value that already includes this frame's state.
+    //
+    // alpha is 1 - e^(-dt/tau), not dt/tau. The exponential form is EXACTLY
+    // step-size invariant — two half-steps compose to one whole step, because
+    // (T-x)·e^(-a/tau)·e^(-b/tau) = (T-x)·e^(-(a+b)/tau) — so the signal is
+    // identical at 60 Hz, 144 Hz, and at timeScale 3 where dt is three times
+    // larger per frame. The naive linear alpha is not: it measured a 0.0005
+    // divergence over five seconds between 60 fps and fast-forward, small but
+    // real, and this game already shipped one frame-rate-dependent ramp (#242).
+    // It also cannot overshoot: e^(-dt/tau) > 0 for every finite dt, so no
+    // clamp is needed for a pathological frame.
+    const tau = CONFIG.load?.smoothingTau || 2.5;
+    this.smoothedLoad +=
+      (this.totalLoad - this.smoothedLoad) * (1 - Math.exp(-dt / tau));
+
     // Service degradation mechanic
     if (CONFIG.survival.degradation?.enabled && STATE.gameMode === "survival") {
       const degradeConfig = CONFIG.survival.degradation;

--- a/tests/helpers/reference-board.mjs
+++ b/tests/helpers/reference-board.mjs
@@ -136,9 +136,15 @@ export function sweepAt({
 
   const b = nodes.bottleneck;
   let minReputation = STATE.reputation;
+  // Both axes are tracked, always: the raw instantaneous signal and the
+  // smoothed one (#74 step 2). Reporting only one of them would make the
+  // knee work look like it moved the world when it moved the ruler.
   let bandFrames = 0;
   let episodes = 0;
   let inBand = false;
+  let rawBandFrames = 0;
+  let rawEpisodes = 0;
+  let rawInBand = false;
   let firstFailAt = null;
   let repCrossAt = null;
   let peakUtil = 0;
@@ -155,6 +161,14 @@ export function sweepAt({
       if (!inBand) episodes++;
     }
     inBand = isIn;
+
+    const rawUtil = b.totalLoad * 2;
+    const rawIsIn = rawUtil > band[0] && rawUtil < band[1];
+    if (rawIsIn) {
+      rawBandFrames++;
+      if (!rawInBand) rawEpisodes++;
+    }
+    rawInBand = rawIsIn;
 
     if (STATE.reputation < minReputation) minReputation = STATE.reputation;
     const failures = totalFailures();
@@ -180,6 +194,9 @@ export function sweepAt({
     bandResidencySec: +(bandFrames * dt).toFixed(2),
     episodes,
     meanDwellSec: episodes ? +((bandFrames * dt) / episodes).toFixed(3) : 0,
+    rawBandResidencySec: +(rawBandFrames * dt).toFixed(2),
+    rawEpisodes,
+    rawMeanDwellSec: rawEpisodes ? +((rawBandFrames * dt) / rawEpisodes).toFixed(3) : 0,
     timeToRepSec:
       repCrossAt !== null && firstFailAt !== null
         ? +(repCrossAt - firstFailAt).toFixed(1)

--- a/tests/sim/reference-baseline.test.mjs
+++ b/tests/sim/reference-baseline.test.mjs
@@ -77,20 +77,35 @@ describe("reference board baseline (#74 step 0)", () => {
     expect(widthRps / collapseRps).toBeLessThan(0.2);
   });
 
-  it("BASELINE PROPERTY 2 — the band is a strobe, not a state", () => {
-    // Mean dwell inside (0.90, 1.20) utilization, across every point that
-    // enters the band at all. The design's claim is that this is far too
-    // short to perceive; smoothing is what fixes it.
-    const entered = table.filter((r) => r.episodes > 0);
-    expect(entered.length).toBeGreaterThan(0);
-    const worstDwell = Math.max(...entered.map((r) => r.meanDwellSec));
+  it("BASELINE PROPERTY 2 — the RAW band is a strobe; the SMOOTHED one is a state", () => {
+    // Mean dwell inside (0.90, 1.20) utilization. This assertion was written
+    // in step 0 with one axis and a single bound; step 2 (smoothedLoad) is
+    // what flipped it, which is exactly what this file exists to record.
+    //
+    // The raw instantaneous signal is unchanged and still a strobe — its
+    // numerator is an integer job count, so it can only step between a few
+    // representable values and never rests inside the band. The smoothed
+    // signal, over the SAME runs, persists an order of magnitude longer:
+    // that is the difference between a state a player can read and a flicker
+    // they cannot.
+    const rawEntered = table.filter((r) => r.rawEpisodes > 0);
+    const smoothEntered = table.filter((r) => r.episodes > 0);
+    expect(rawEntered.length).toBeGreaterThan(0);
+    expect(smoothEntered.length).toBeGreaterThan(0);
+
+    const worstRaw = Math.max(...rawEntered.map((r) => r.rawMeanDwellSec));
+    const bestSmooth = Math.max(...smoothEntered.map((r) => r.meanDwellSec));
     console.log(
-      "max mean dwell across all sweep points:",
-      worstDwell,
-      "s over",
-      entered.map((r) => `${r.rps}rps:${r.meanDwellSec}s`).join(" ")
+      `mean dwell in band — RAW max ${worstRaw}s (` +
+        rawEntered.map((r) => `${r.rps}:${r.rawMeanDwellSec}`).join(" ") +
+        `)\n                     SMOOTHED max ${bestSmooth}s (` +
+        smoothEntered.map((r) => `${r.rps}:${r.meanDwellSec}`).join(" ") +
+        ")"
     );
-    expect(worstDwell).toBeLessThan(0.6);
+
+    expect(worstRaw).toBeLessThan(0.6); // still a strobe, unchanged by step 2
+    expect(bestSmooth).toBeGreaterThan(1.5); // now long enough to perceive
+    expect(bestSmooth).toBeGreaterThan(worstRaw * 5);
   });
 
   it("multi-seed reduction works and agrees with the single-seed run", () => {

--- a/tests/sim/smoothed-load.test.mjs
+++ b/tests/sim/smoothed-load.test.mjs
@@ -1,0 +1,198 @@
+// Step 2 of the failure-knee work (#74): the smoothed load signal.
+//
+// Step 0 measured why this exists: `totalLoad`'s numerator is an integer job
+// count, so on a tier-1 Compute it can only be 0.75, 1.00 or 1.25, and its mean
+// dwell inside the band the knee cares about never exceeded 0.245 s at any
+// load. A threshold on that signal describes a strobe. `smoothedLoad` is the
+// same quantity through a trailing exponential mean.
+//
+// This step adds the signal and NOTHING reads it yet, so the acceptance bar is
+// deliberately harsh: the rest of the suite must stay green with zero changed
+// assertions. If something moved, a consumer already existed and that is a bug,
+// not a test to update.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { STATE, CONFIG, resetWorld, place, connect, run } from "../helpers/sim-world.mjs";
+import { Request } from "../../src/entities/Request.js";
+import { routeRequestToEntry } from "../../src/core/actions.js";
+import { mulberry32 } from "../helpers/reference-board.mjs";
+
+const TAU = CONFIG.load.smoothingTau;
+
+beforeEach(() => resetWorld());
+afterEach(() => vi.restoreAllMocks());
+
+// Drive one service's smoothing in isolation by pinning totalLoad, so the test
+// measures the filter rather than the whole simulation around it.
+function pin(service, value) {
+  Object.defineProperty(service, "totalLoad", {
+    get: () => value,
+    configurable: true,
+  });
+}
+
+describe("smoothedLoad is a correct trailing mean (#74)", () => {
+  it("starts cold at zero on a freshly placed service", () => {
+    const s = place("compute");
+    expect(s.smoothedLoad).toBe(0);
+  });
+
+  it("reaches ~63% of a step after exactly tau, and ~95% after 3 tau", () => {
+    // The defining property of an exponential mean: 1 - 1/e after one tau.
+    const s = place("compute");
+    pin(s, 1.0);
+    for (let t = 0; t < TAU; t += 1 / 60) s.update(1 / 60);
+    expect(s.smoothedLoad).toBeGreaterThan(0.6);
+    expect(s.smoothedLoad).toBeLessThan(0.68);
+
+    for (let t = 0; t < 2 * TAU; t += 1 / 60) s.update(1 / 60);
+    expect(s.smoothedLoad).toBeGreaterThan(0.93);
+    expect(s.smoothedLoad).toBeLessThan(0.99);
+  });
+
+  it("converges to a steady load and never overshoots it", () => {
+    const s = place("compute");
+    pin(s, 0.8);
+    for (let t = 0; t < 10 * TAU; t += 1 / 60) {
+      s.update(1 / 60);
+      expect(s.smoothedLoad).toBeLessThanOrEqual(0.8 + 1e-9);
+    }
+    expect(s.smoothedLoad).toBeCloseTo(0.8, 3);
+  });
+
+  it("decays back toward zero when the load goes away", () => {
+    const s = place("compute");
+    pin(s, 1.0);
+    for (let t = 0; t < 5 * TAU; t += 1 / 60) s.update(1 / 60);
+    expect(s.smoothedLoad).toBeGreaterThan(0.95);
+
+    pin(s, 0);
+    for (let t = 0; t < 3 * TAU; t += 1 / 60) s.update(1 / 60);
+    expect(s.smoothedLoad).toBeLessThan(0.06);
+  });
+
+  it("tracks by GAME time, so fast-forward is not an advantage", () => {
+    // The bug this forbids: a per-frame constant would make the signal move
+    // 3x faster at timeScale 3 and differ between a 60 Hz and a 144 Hz screen.
+    const advance = (dt, seconds) => {
+      resetWorld();
+      const s = place("compute");
+      pin(s, 1.0);
+      const steps = Math.round(seconds / dt);
+      for (let i = 0; i < steps; i++) s.update(dt);
+      return s.smoothedLoad;
+    };
+    // The exponential alpha is EXACTLY step-size invariant, so these agree to
+    // floating-point noise rather than merely "closely" — asserted at 9
+    // decimals, which the naive linear alpha (dt/tau) fails by 0.0005.
+    const at60 = advance(1 / 60, 5);
+    const at144 = advance(1 / 144, 5);
+    const fastForward = advance(3 / 60, 5); // timeScale 3: dt is 3x per frame
+    const oneBigStep = advance(5, 5); // the whole interval in a single frame
+    expect(at144).toBeCloseTo(at60, 9);
+    expect(fastForward).toBeCloseTo(at60, 9);
+    expect(oneBigStep).toBeCloseTo(at60, 9);
+  });
+
+  it("a pathological frame cannot overshoot the target", () => {
+    // No clamp is needed: e^(-dt/tau) > 0 for every finite dt, so the signal
+    // approaches the target from below and never crosses it.
+    const s = place("compute");
+    pin(s, 1.0);
+    s.update(60); // a 60-second frame
+    expect(s.smoothedLoad).toBeLessThanOrEqual(1.0);
+    expect(s.smoothedLoad).toBeCloseTo(1.0, 6);
+  });
+
+  it("is smoother than the raw signal it follows — the point of the step", () => {
+    // A real board, not a pinned value: measure how much each signal jumps
+    // frame to frame while traffic churns through a saturated node.
+    const alb = place("alb");
+    const compute = place("compute");
+    const db = place("db");
+    connect("internet", alb);
+    connect(alb, compute);
+    connect(compute, db);
+
+    let rawJumps = 0;
+    let smoothJumps = 0;
+    let prevRaw = compute.totalLoad;
+    let prevSmooth = compute.smoothedLoad;
+    let spawnTimer = 0;
+    const dt = 1 / 60;
+    for (let i = 0; i < 60 * 20; i++) {
+      spawnTimer += dt;
+      while (spawnTimer >= 1 / 8) {
+        spawnTimer -= 1 / 8;
+        const req = new Request("READ");
+        STATE.requests.push(req);
+        routeRequestToEntry(req, "READ");
+      }
+      STATE.services.forEach((s) => s.update(dt));
+      STATE.requests.slice().forEach((r) => r.update(dt));
+      rawJumps += Math.abs(compute.totalLoad - prevRaw);
+      smoothJumps += Math.abs(compute.smoothedLoad - prevSmooth);
+      prevRaw = compute.totalLoad;
+      prevSmooth = compute.smoothedLoad;
+    }
+    console.log(
+      `total frame-to-frame variation over 20s — raw: ${rawJumps.toFixed(2)}, smoothed: ${smoothJumps.toFixed(2)}`
+    );
+    expect(rawJumps).toBeGreaterThan(0); // the raw signal really is churning
+    expect(smoothJumps).toBeLessThan(rawJumps);
+  });
+
+  it("nothing reads it yet: pinning it to nonsense changes no outcome", () => {
+    // The inertness proof for this step. If a consumer existed, forcing the
+    // signal to an absurd value would move something.
+    const build = () => {
+      const alb = place("alb");
+      const compute = place("compute");
+      const db = place("db");
+      connect("internet", alb);
+      connect(alb, compute);
+      connect(compute, db);
+      return { compute };
+    };
+
+    resetWorld();
+    build();
+    // Pin the PRNG after world building (service ids draw from it) so the two
+    // runs differ only in the forced signal. Without this the comparison is
+    // just two samples of a random process and fails at random.
+    vi.spyOn(Math, "random").mockImplementation(mulberry32(0xc0ffee));
+    for (let i = 0; i < 40; i++) {
+      const req = new Request("READ");
+      STATE.requests.push(req);
+      routeRequestToEntry(req, "READ");
+    }
+    run(20);
+    const normal = {
+      processed: STATE.requestsProcessed,
+      failures: { ...STATE.failures },
+      reputation: STATE.reputation,
+      money: STATE.money,
+    };
+
+    vi.restoreAllMocks();
+    resetWorld();
+    const { compute } = build();
+    // Force the smoothed signal far past anything the sim could produce.
+    Object.defineProperty(compute, "smoothedLoad", {
+      get: () => 99,
+      set: () => {},
+      configurable: true,
+    });
+    vi.spyOn(Math, "random").mockImplementation(mulberry32(0xc0ffee));
+    for (let i = 0; i < 40; i++) {
+      const req = new Request("READ");
+      STATE.requests.push(req);
+      routeRequestToEntry(req, "READ");
+    }
+    run(20);
+
+    expect(STATE.requestsProcessed).toBe(normal.processed);
+    expect(STATE.failures).toEqual(normal.failures);
+    expect(STATE.reputation).toBe(normal.reputation);
+    expect(STATE.money).toBe(normal.money);
+  });
+});


### PR DESCRIPTION
Step 2 of the failure-knee work, on top of [step 0](https://github.com/pshenok/server-survival/pull/244) and [step 1](https://github.com/pshenok/server-survival/pull/245).

## Why an axis and not a curve
Step 0 measured the real reason the failure curve can never produce a readable middle. `totalLoad`'s numerator is an integer job count, so on a tier-1 Compute (capacity 4) the signal can only be **0.75, 1.00 or 1.25** — the entire interesting band holds one representable state — and its mean dwell inside that band never exceeded **0.245 s at any load**. A threshold placed there describes a strobe, not a state. So this step changes what the thresholds will *look at*.

`smoothedLoad` is the same quantity through a trailing exponential mean, τ = 2.5 game seconds, updated at the top of `Service.update` so every consumer in a frame sees that frame.

## The alpha is exponential, and that mattered
`1 - e^(-dt/τ)`, not `dt/τ`. The exponential form is **exactly** step-size invariant: two half-steps compose to one whole step. This wasn't theoretical — my first implementation used the linear form and the test caught a **0.0005 divergence over five seconds between 60 fps and fast-forward**. Small, but this game already shipped one frame-rate-dependent ramp (fixed in #242), so the test now asserts invariance at **9 decimals** across 60 Hz / 144 Hz / timeScale 3 / the whole interval in a single frame. It also cannot overshoot, so no clamp is needed.

## Nothing reads it yet — on purpose
This step is inert. The acceptance bar was that the suite stays green **with zero changed assertions**, and that held: no pre-existing test moved.

One assertion *did* flip, and it is the step's proof rather than its cost. The step-0 baseline was written to record two properties "both meant to become false as the work lands". Property 2 flipped the moment the signal existed. The sweep now tracks **both axes on the same runs** — reporting only one would make this look like it moved the world when it moved the ruler:

| axis | max mean dwell in band |
|---|---|
| raw `totalLoad` | **0.245 s** (unchanged — still a strobe) |
| `smoothedLoad` | **3.158 s** |

An order of magnitude: the difference between a state a player can read and a flicker they cannot.

## Verification
The 1−1/e identity at τ, convergence without overshoot, decay, exact step-size invariance, a 60-second pathological frame, measured smoothness on a real board (frame-to-frame variation **16.50 → 2.88**), and an inertness proof that forces the signal to 99 and asserts every outcome is byte-identical. **Mutation-verified**: the linear alpha reddens one test, removing smoothing entirely reddens two. 843/843 ×5, eslint clean.

Next: step 3 moves the rings and the Monitoring alert onto this axis — today the ring turns orange exactly when a node starts dropping requests, and the $75 alert fires at 170 % of capacity.