### PR TITLE
feat: the load warnings tell the truth (#74 knee step 3)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -659,8 +659,28 @@ export const CONFIG = {
   // it is continuous (resolution ~0.001 instead of 1/capacity) and persists
   // long enough to be read. tau is in GAME seconds — the update is driven by
   // the game-scaled dt, so fast-forward advances it by game time, not frames.
+  // Every threshold below is expressed in smoothedLoad, where 0.5 is 100% of
+  // rated capacity (the denominator carries a x2 — see Service.totalLoad). The
+  // shipped numbers were all calibrated against the WRONG half of that scale:
+  // the ring turned orange at 0.5 — exactly when a node begins dropping
+  // requests — and red only at 0.8, which is 160% of capacity, deep inside
+  // collapse. The $75 Monitoring node alerted at 0.85, i.e. 170%, long past
+  // the point where the information could still be used.
+  //
+  // Recalibrated so the colours mean what a player would assume: red is "at
+  // capacity, dropping next", and the alert arrives BEFORE the first drop.
+  // The ordering alertUtil < ringRed = failureOnset is asserted in
+  // tests/sim/rings-and-alert.test.mjs rather than left as a comment.
   load: {
     smoothingTau: 2.5,
+    ringYellow: 0.25, // 50% of capacity — working, worth noticing
+    ringOrange: 0.35, // 70% — busy
+    ringRed: 0.45, // 90% — at capacity, drops start next
+    alertUtil: 0.375, // 85% — fires ahead of the first failure
+    // 2 samples at 2 Hz = 1 s. The shipped 6 (3 s) existed to filter a noisy
+    // instantaneous signal; stacking it on a 2.5 s trailing mean would land
+    // the alert after the failures it is meant to precede.
+    alertSustainSamples: 2,
   },
 
   autoscaling: {

--- a/src/core/metrics.js
+++ b/src/core/metrics.js
@@ -12,6 +12,7 @@
 // window) and resetMetrics() from resetGame().
 
 import { STATE } from "../state.js";
+import { CONFIG } from "../config.js";
 import { i18n } from "../i18n.js";
 // Cyclic import chain (metrics.js -> events.js -> game.js -> actions.js ->
 // metrics.js) is safe — established pattern: addInterventionWarning is a
@@ -22,8 +23,10 @@ const SAMPLE_INTERVAL = 0.5; // seconds of game time between samples (2 Hz)
 export const METRICS_BUFFER_SIZE = 120; // 120 samples × 0.5 s = 60 s window
 
 const ALERT_COOLDOWN = 15; // seconds of game time, per service+rule
-const UTIL_THRESHOLD = 0.85;
-const UTIL_SUSTAINED_SAMPLES = 6; // 3 s at 2 Hz
+// Utilization thresholds live in CONFIG.load (#74) so the ring colours, the
+// alert and the failure onset are calibrated against one another instead of
+// drifting apart in three files. Both are read at call time, not captured
+// here, so a config change cannot be shadowed by module-eval order.
 const QUEUE_THRESHOLD = 0.9; // fraction of maxQueueSize
 const ERROR_RATE_THRESHOLD = 0.2;
 const ERROR_MIN_EVENTS = 5; // rate alone is noise on 1-2 requests
@@ -34,7 +37,7 @@ let sampleCount = 0;
 // serviceId -> {
 //   util, queueDepth, errorRate, latency: ring buffers (newest last),
 //   errors, successes, latencySum, latencyCount: counters reset per sample,
-//   utilStreak: consecutive samples above UTIL_THRESHOLD (alert rule 1)
+//   utilStreak: consecutive samples above CONFIG.load.alertUtil (alert rule 1)
 // }
 const serviceMetrics = new Map();
 
@@ -113,7 +116,13 @@ function takeSample() {
 
     for (const service of STATE.services) {
         const m = bufferFor(service.id);
-        const util = service.totalLoad || 0;
+        // The SMOOTHED load (#74): the sampled series, the alert and the
+        // panel's red tint all read the same axis the load rings do. Sampling
+        // the instantaneous signal produced a sparkline of a quantity that on
+        // a tier-1 Compute can only be 0.75, 1.00 or 1.25 — and an alert that
+        // fired at 170% of rated capacity. Real observability shows a windowed
+        // average for exactly this reason.
+        const util = service.smoothedLoad || 0;
         const queueDepth = service.queue.length;
         const events = m.errors + m.successes;
         const errorRate = events > 0 ? m.errors / events : 0;
@@ -146,9 +155,9 @@ function takeSample() {
 }
 
 function checkAlerts(service, m, util, queueDepth, errorRate, events) {
-    if (util > UTIL_THRESHOLD) m.utilStreak++;
+    if (util > CONFIG.load.alertUtil) m.utilStreak++;
     else m.utilStreak = 0;
-    if (m.utilStreak >= UTIL_SUSTAINED_SAMPLES) {
+    if (m.utilStreak >= CONFIG.load.alertSustainSamples) {
         fireAlert(service, "util", "alert_high_load", "warning");
     }
 

--- a/src/entities/Service.js
+++ b/src/entities/Service.js
@@ -767,21 +767,34 @@ export class Service {
       }
     }
 
-    if (this.totalLoad > 0.8) {
+    // Load ring (#74): reads smoothedLoad, not the instantaneous signal, and
+    // on thresholds recalibrated to the half of the scale the player lives in.
+    // Before this, orange lit up exactly when a node began dropping requests
+    // and red only at 160% of capacity — so the board showed green and yellow
+    // right up to the moment it was already failing. It also flickered: the
+    // raw signal's mean dwell in any band was under a quarter-second.
+    //
+    // Both modes deliberately. "Campaign levels are identical" means their
+    // SIMULATION is identical; loadRing is written here and read nowhere in
+    // src/, game.js or tests/, so this cannot move a level's outcome — and
+    // teaching one colour language in the campaign and another in survival
+    // would be worse than the bug.
+    const ringLoad = this.smoothedLoad;
+    if (ringLoad > CONFIG.load.ringRed) {
       this.loadRing.material.color.setHex(0xff0000);
       if (STATE.selectedNodeId === this.id) {
         this.loadRing.material.opacity = 1.0;
       } else {
         this.loadRing.material.opacity = 0.8;
       }
-    } else if (this.totalLoad > 0.5) {
+    } else if (ringLoad > CONFIG.load.ringOrange) {
       this.loadRing.material.color.setHex(0xffaa00);
       if (STATE.selectedNodeId === this.id) {
         this.loadRing.material.opacity = 1.0;
       } else {
         this.loadRing.material.opacity = 0.6;
       }
-    } else if (this.totalLoad > 0.2) {
+    } else if (ringLoad > CONFIG.load.ringYellow) {
       this.loadRing.material.color.setHex(0xffff00);
       if (STATE.selectedNodeId === this.id) {
         this.loadRing.material.opacity = 1.0;

--- a/src/ui/metrics-panel.js
+++ b/src/ui/metrics-panel.js
@@ -12,6 +12,7 @@
 // nothing samples, so the panel keeps showing the frozen failure moment.
 
 import { STATE } from "../state.js";
+import { CONFIG } from "../config.js";
 import { i18n } from "../i18n.js";
 import {
     METRICS_BUFFER_SIZE,
@@ -36,7 +37,9 @@ const COLUMNS = [
         key: "util",
         label: "metrics_col_util",
         max: () => 1,
-        alert: (v) => v > 0.85,
+        // Same constant the alert rule uses (#74) — the red tint in the panel
+        // and the warning banner must never disagree about what "hot" means.
+        alert: (v) => v > CONFIG.load.alertUtil,
     },
     {
         key: "queueDepth",

--- a/tests/sim/metrics.test.mjs
+++ b/tests/sim/metrics.test.mjs
@@ -61,9 +61,17 @@ describe("ring buffer sampling", () => {
     expect(getSampleCount()).toBe(countBefore);
   });
 
-  it("util samples reflect the service's current totalLoad", () => {
+  it("util samples reflect the service's smoothedLoad (#74)", () => {
+    // The sampled series moved from the instantaneous totalLoad to the
+    // trailing mean: sampling the raw signal produced a sparkline of a
+    // quantity that can only take a few representable values, and an alert
+    // calibrated to 170% of rated capacity. Real observability windows its
+    // averages for the same reason.
     const db = place("db"); // capacity 8 → totalLoad = queue/(8*2)
     db.queue = new Array(8).fill({});
+    // The sim, not the metrics clock, advances the trailing mean; this test
+    // isolates the metrics layer, so drive the signal directly.
+    db.smoothedLoad = 0.5;
     tick(0.5);
     const m = getServiceMetrics(db.id);
     expect(m.util[m.util.length - 1]).toBeCloseTo(0.5, 5);
@@ -204,10 +212,19 @@ describe("hasMonitoring gating", () => {
 });
 
 describe("threshold alerts", () => {
+  // A node held in steady overload. The alert reads smoothedLoad (#74), which
+  // the SIM advances inside Service.update; these tests isolate the metrics
+  // layer from the sim on purpose, so the settled value is set directly — that
+  // is what a node sitting above the threshold for a few seconds looks like.
   function overload(service) {
-    // totalLoad = (processing + queue) / (capacity * 2); push it past 0.85.
     const need = Math.ceil(service.config.capacity * 2 * 0.9);
     service.queue = new Array(need).fill({});
+    service.smoothedLoad = CONFIG.load.alertUtil + 0.05;
+  }
+
+  function relieve(service) {
+    service.queue = [];
+    service.smoothedLoad = 0;
   }
 
   it("does NOT fire without a monitoring service", () => {
@@ -217,25 +234,30 @@ describe("threshold alerts", () => {
     expect(warningsMatching("High load")).toHaveLength(0);
   });
 
-  it("high-load fires only after 6 consecutive samples above 0.85", () => {
+  it("high-load fires after the configured sustained samples (#74)", () => {
+    // 2 samples at 2 Hz = 1 s, down from 6 (3 s). The old count existed to
+    // filter a noisy instantaneous signal; stacking it on top of a 2.5 s
+    // trailing mean would land the alert AFTER the failures it must precede.
     place("monitor");
     const db = place("db");
     overload(db);
-    tick(2.5); // 5 samples — not yet
+    const samples = CONFIG.load.alertSustainSamples;
+    tick(0.5 * (samples - 1)); // one short
     expect(warningsMatching("High load")).toHaveLength(0);
-    tick(0.5); // 6th sample
+    tick(0.5); // the sample that trips it
     expect(warningsMatching("High load")).toHaveLength(1);
   });
 
   it("a dip below the threshold resets the sustained-load streak", () => {
     place("monitor");
     const db = place("db");
+    const samples = CONFIG.load.alertSustainSamples;
     overload(db);
-    tick(2.5); // 5 samples over
-    db.queue = []; // dip
+    tick(0.5 * (samples - 1)); // one short of firing
+    relieve(db); // dip
     tick(0.5);
     overload(db);
-    tick(2.5); // 5 more — streak restarted, still no alert
+    tick(0.5 * (samples - 1)); // one short again — streak restarted
     expect(warningsMatching("High load")).toHaveLength(0);
   });
 

--- a/tests/sim/rings-and-alert.test.mjs
+++ b/tests/sim/rings-and-alert.test.mjs
@@ -1,0 +1,162 @@
+// Step 3 of the failure-knee work (#74): the warnings tell the truth.
+//
+// Every load signal the player can see was calibrated against the wrong half
+// of the scale. `totalLoad` divides by capacity x instances x 2, so 0.5 IS
+// 100% of rated capacity — and the shipped thresholds were:
+//
+//   ring yellow  0.2   =  40% of capacity
+//   ring orange  0.5   = 100%  <- exactly where the node starts dropping
+//   ring red     0.8   = 160%  <- deep inside collapse
+//   alert        0.85  = 170%  <- the $75 observability node, far too late
+//
+// So the board showed green and yellow right up to the moment it was already
+// failing, and the Monitoring alert arrived when the information was useless.
+// This step moves all four onto smoothedLoad and recalibrates them.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { STATE, CONFIG, resetWorld, place, connect } from "../helpers/sim-world.mjs";
+import { metricsTick, resetMetrics } from "../../src/core/metrics.js";
+import { calculateFailChanceBasedOnLoad } from "../../src/core/actions.js";
+import { sweepAt } from "../helpers/reference-board.mjs";
+
+beforeEach(() => {
+  resetWorld({ gameMode: "survival" });
+  resetMetrics();
+  STATE.intervention = { warnings: [], recentEvents: [] };
+});
+afterEach(() => vi.restoreAllMocks());
+
+const RING = { red: 0xff0000, orange: 0xffaa00, yellow: 0xffff00 };
+
+function ringColorAt(smoothed) {
+  const s = place("compute");
+  // The ring is repainted from smoothedLoad at the end of update(); pin the
+  // raw signal so the smoothing cannot drag the value while we read it.
+  Object.defineProperty(s, "smoothedLoad", { value: smoothed, writable: true });
+  Object.defineProperty(s, "totalLoad", { get: () => smoothed, configurable: true });
+  s.update(1 / 60);
+  return s.loadRing.material.color.getHex();
+}
+
+describe("the load ring is calibrated to capacity (#74)", () => {
+  it("THE ORDERING INVARIANT: alert < red = failure onset", () => {
+    // The single assertion that keeps the three systems honest with each
+    // other. Failure onset is 0.45 in smoothedLoad terms because the shipped
+    // curve begins dropping above totalLoad 0.5 and the knee (step 4) begins
+    // at 90% of capacity; the alert must land BEFORE the ring goes red, and
+    // the ring must go red no later than the first drop.
+    const { alertUtil, ringRed, ringOrange, ringYellow } = CONFIG.load;
+    expect(alertUtil).toBeLessThan(ringRed);
+    expect(ringYellow).toBeLessThan(ringOrange);
+    expect(ringOrange).toBeLessThan(ringRed);
+    // Red is at or before the point the shipped curve starts failing (0.5).
+    expect(ringRed).toBeLessThanOrEqual(0.5);
+    expect(calculateFailChanceBasedOnLoad(ringRed)).toBe(0);
+  });
+
+  it("red means at capacity, not 160% of it", () => {
+    // 0.5 smoothedLoad = 100% of rated capacity.
+    expect(ringColorAt(0.5)).toBe(RING.red);
+    // The old threshold: 0.8 was 160% — everything between was mislabelled.
+    expect(ringColorAt(0.46)).toBe(RING.red);
+  });
+
+  it("orange is busy-but-fine, and no longer means already-dropping", () => {
+    expect(ringColorAt(0.4)).toBe(RING.orange);
+    // Under the shipped thresholds this exact load painted YELLOW while the
+    // node was at 80% of capacity.
+    expect(ringColorAt(0.36)).toBe(RING.orange);
+  });
+
+  it("yellow starts at half capacity", () => {
+    expect(ringColorAt(0.3)).toBe(RING.yellow);
+    expect(ringColorAt(0.26)).toBe(RING.yellow);
+  });
+
+  it("an idle node is not painted as busy", () => {
+    expect(ringColorAt(0.1)).not.toBe(RING.yellow);
+    expect(ringColorAt(0)).not.toBe(RING.yellow);
+  });
+
+  it("reads the smoothed signal, so it cannot strobe", () => {
+    // A node whose instantaneous load spikes for a single frame must not
+    // flash red; the whole point of step 2's axis.
+    const s = place("compute");
+    let raw = 0.1;
+    Object.defineProperty(s, "totalLoad", { get: () => raw, configurable: true });
+    for (let i = 0; i < 120; i++) s.update(1 / 60); // settle low
+    const calm = s.loadRing.material.color.getHex();
+    raw = 3.0; // one pathological frame
+    s.update(1 / 60);
+    expect(s.loadRing.material.color.getHex()).toBe(calm);
+  });
+});
+
+describe("the Monitoring alert arrives before the failures (#74)", () => {
+  it("fires ahead of the first dropped request on a rising load", () => {
+    // The behaviour the $75 node is sold for: warn while there is still time
+    // to act. Measured on a node driven steadily up through its capacity.
+    place("monitor");
+    const alb = place("alb");
+    const compute = place("compute");
+    const db = place("db");
+    connect("internet", alb);
+    connect(alb, compute);
+    connect(compute, db);
+
+    let alertAt = null;
+    let firstFailChanceAt = null;
+    let load = 0.2;
+    for (let t = 0; t < 60; t += 0.5) {
+      load += 0.01; // a slow, steady climb through the thresholds
+      Object.defineProperty(compute, "totalLoad", { get: () => load, configurable: true });
+      compute.smoothedLoad = load; // settled, as a slow climb would be
+      metricsTick(0.5);
+      if (
+        alertAt === null &&
+        STATE.intervention.warnings.some((w) => w.message.includes("High load"))
+      ) {
+        alertAt = load;
+      }
+      if (firstFailChanceAt === null && calculateFailChanceBasedOnLoad(load) > 0) {
+        firstFailChanceAt = load;
+      }
+    }
+    console.log(
+      `alert fired at load ${alertAt}, failures would begin at ${firstFailChanceAt}`
+    );
+    expect(alertAt).not.toBeNull();
+    expect(firstFailChanceAt).not.toBeNull();
+    expect(alertAt).toBeLessThan(firstFailChanceAt);
+  });
+
+  it("the panel's red tint and the alert agree on what hot means", async () => {
+    // Two files, one constant: a divergence here is invisible until a player
+    // sees a red cell with no warning, or the reverse.
+    const panel = await import("../../src/ui/metrics-panel.js");
+    const src = panel.default ?? panel;
+    expect(typeof src).toBe("object");
+    // The predicate is not exported; assert the constant it must use exists
+    // and is the same one the alert rule reads.
+    expect(CONFIG.load.alertUtil).toBeGreaterThan(0);
+    expect(CONFIG.load.alertUtil).toBeLessThan(CONFIG.load.ringRed);
+  });
+});
+
+describe("the red ring is meaningful, not wallpaper (#74)", () => {
+  it("stays quiet on a healthy board and sustained when overloaded", () => {
+    // The failure mode this guards: a threshold so low that red is permanent
+    // and therefore ignored. Measured on the reference board at a load with
+    // zero failures, versus one deep in collapse.
+    const healthy = sweepAt({ rps: 4, seconds: 60 });
+    const drowning = sweepAt({ rps: 20, seconds: 60 });
+    console.log(
+      `healthy rps=4: failures=${healthy.failures} peakUtil=${healthy.peakUtil} | ` +
+        `drowning rps=20: failures=${drowning.failures} peakUtil=${drowning.peakUtil}`
+    );
+    // A board with zero failures must not be sitting above the red threshold.
+    expect(healthy.failures).toBe(0);
+    expect(healthy.peakUtil / 2).toBeLessThan(CONFIG.load.ringRed + 0.05);
+    // A collapsing board must be well past it.
+    expect(drowning.peakUtil / 2).toBeGreaterThan(CONFIG.load.ringRed);
+  });
+});


### PR DESCRIPTION
Step 3 of the failure-knee work, on top of [step 2](https://github.com/pshenok/server-survival/pull/246).

## The bug, stated plainly
`totalLoad` divides by `capacity × instances × 2`, so **0.5 is 100 % of rated capacity**. Every shipped threshold was calibrated against the wrong half of that scale:

| signal | was | = % of capacity | now | = % of capacity |
|---|---|---|---|---|
| ring yellow | 0.2 | 40 % | **0.25** | 50 % |
| ring orange | 0.5 | **100 %** ← starts dropping here | **0.35** | 70 % |
| ring red | 0.8 | **160 %** ← deep in collapse | **0.45** | 90 % |
| Monitoring alert | 0.85 | **170 %** | **0.375** | 85 % |

The board showed green and yellow right up to the moment it was already failing, and the $75 node the game sells as *observability* warned at 170 % of capacity — when the information could no longer be used.

## Measured result
On a steadily rising load: **the alert fires at 0.39, failures begin at 0.50.** The warning now precedes the problem instead of trailing it by 70 %. Confirmed in the live browser: 52 % of capacity paints yellow, 72 % orange, **92 % red** — before the first drop, not after collapse.

Sustain drops 6 samples → 2 (3 s → 1 s). Six existed to filter a noisy instantaneous signal; stacking 3 s of sustain on a 2.5 s trailing mean would land the alert *after* the failures it exists to precede.

## Why both modes
"Campaign levels are identical" means their **simulation** is identical. `loadRing` is written in `Service.update` and read nowhere in `src/`, `game.js` or `tests/`; `fireAlert` is DOM and sound. Teaching one colour language in the campaign and another in survival would be worse than the bug — campaign players see orange while dropping requests today too. **All 162 campaign / level / beatability tests pass untouched.**

## Also
- The metrics layer samples the smoothed signal, and the panel's red tint reads the same `CONFIG.load.alertUtil` the alert rule does — two files disagreeing about "hot" is invisible until a player sees a red cell with no warning.
- Thresholds live in one `CONFIG.load` block with the ordering invariant (`alert < red ≤ failure onset`) asserted as a **test**, not left as a comment.
- `tests/sim/metrics.test.mjs` is rebaselined — the budgeted cost the design named in advance, and the only pre-existing test that moved.

**Mutation-verified**: restoring the shipped thresholds reddens 5 of the new tests; pointing the ring back at the raw signal reddens the anti-strobe test. 852/852 ×5, eslint clean, zero console errors.

Next: step 4 — the knee itself, the only step that changes simulation.