### PR TITLE
feat: prioritized load shedding — the shed order is a decision (#248)

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -46,6 +46,7 @@ export const CONFIG = {
   trafficTypes: {
     STATIC: {
       name: "STATIC",
+      criticality: "SHEDDABLE",
       sloSec: 3, // #248
 
       method: "GET",
@@ -59,6 +60,7 @@ export const CONFIG = {
     },
     READ: {
       name: "READ",
+      criticality: "STANDARD",
       sloSec: 7, // #248: a completion later than this still counts, but pays less
 
       method: "GET",
@@ -72,6 +74,7 @@ export const CONFIG = {
     },
     WRITE: {
       name: "WRITE",
+      criticality: "CRITICAL",
       sloSec: 7, // #248: a completion later than this still counts, but pays less
 
       method: "POST/PUT",
@@ -85,6 +88,7 @@ export const CONFIG = {
     },
     UPLOAD: {
       name: "UPLOAD",
+      criticality: "CRITICAL",
       sloSec: 9, // #248: a completion later than this still counts, but pays less
 
       method: "POST+file",
@@ -98,6 +102,7 @@ export const CONFIG = {
     },
     SEARCH: {
       name: "SEARCH",
+      criticality: "STANDARD",
       sloSec: 8, // #248: a completion later than this still counts, but pays less
 
       method: "GET+query",
@@ -126,6 +131,10 @@ export const CONFIG = {
       // mean 1.28 — see entities/Request.js) and scales the GPU batch time.
       // Never cacheable — every generation is unique output.
       name: "INFERENCE",
+      // STANDARD, not CRITICAL: inference is the growth curve, not the thing
+      // that pays the bills, and the Inference Gateway owns its own deadline
+      // mechanic — the API Gateway's policy is the outer, coarser gate.
+      criticality: "STANDARD",
       method: "POST",
       color: 0xd946ef,
       reward: 0.5,
@@ -681,6 +690,25 @@ export const CONFIG = {
   // capacity, dropping next", and the alert arrives BEFORE the first drop.
   // The ordering alertUtil < ringRed = failureOnset is asserted in
   // tests/sim/rings-and-alert.test.mjs rather than left as a comment.
+  // Prioritized load shedding (#248). Real systems classify traffic in
+  // ADVANCE and shed by class under pressure — Google's CRITICAL vs
+  // SHEDDABLE_PLUS, Envoy's priority levels — because during an incident
+  // nobody has time to decide what matters. Without it the shed order is
+  // whatever the topology happens to produce: measured on the reference board
+  // at 8 rps the game lost READ 118 / SEARCH 32 / WRITE 28 / UPLOAD 19 and
+  // STATIC 0, i.e. the $1.20 and $1.50 traffic died while the $0.50 traffic
+  // was untouched, with no player agency at all.
+  //
+  // Fractions of the API Gateway's rate limit at which each class starts
+  // being refused. SHEDDABLE goes first and CRITICAL is protected to the very
+  // limit, so a gateway under pressure degrades in a chosen order instead of
+  // an accidental one.
+  shedding: {
+    SHEDDABLE: 0.6,
+    STANDARD: 0.85,
+    CRITICAL: 1.0,
+  },
+
   load: {
     smoothingTau: 2.5,
     ringYellow: 0.25, // 50% of capacity — working, worth noticing

--- a/src/sim/handlers/apigw.js
+++ b/src/sim/handlers/apigw.js
@@ -4,6 +4,7 @@
 // bookkeeping, not job dispatch). Logic lifted unchanged from the per-type
 // if-chain in Service.update().
 
+import { CONFIG } from "../../config.js";
 import { failOrPark, throttleRequest } from "../../core/actions.js";
 import { FAIL_REASONS } from "../../core/failure-reasons.js";
 // Runtime-only cycle (index.js ⇄ apigw.js): forwardCandidates is a hoisted
@@ -11,12 +12,32 @@ import { FAIL_REASONS } from "../../core/failure-reasons.js";
 // long after both modules finish evaluating. Established pattern.
 import { forwardCandidates } from "./index.js";
 
+// The share of the rate limit at which a class starts being refused (#248).
+// A gateway that sheds blindly protects nothing: measured on the reference
+// board at 8 rps, the topology alone killed READ 118 / SEARCH 32 / WRITE 28 /
+// UPLOAD 19 and STATIC 0 — the $1.20 and $1.50 traffic died while the $0.50
+// traffic sailed through, and the player had no say in it.
+//
+// Real systems classify in ADVANCE (Google's CRITICAL vs SHEDDABLE_PLUS,
+// Envoy's priority levels) precisely because nobody can make this decision
+// during an incident. Unclassified traffic is treated as CRITICAL: refusing
+// something the config never spoke about would be the wrong default.
+function shedThresholdFor(req) {
+  const cls = req.typeConfig?.criticality;
+  const policy = CONFIG.shedding || {};
+  return policy[cls] ?? 1.0;
+}
+
 export function process(service, job) {
   service.rateCounter = (service.rateCounter || 0) + 1;
   const rateLimit = service.config.rateLimit || 20;
 
-  if (service.rateCounter > rateLimit) {
-    // Rate limited - soft fail
+  // PRIORITIZED SHEDDING (#248). The gateway degrades in a chosen order:
+  // SHEDDABLE goes at 60% of the limit, STANDARD at 85%, CRITICAL is carried
+  // to the very last slot. Throttling stays the soft-fail it always was — it
+  // feeds neither the breaker nor the error rate — so this changes WHICH
+  // requests are shed, never how many the gateway can serve.
+  if (service.rateCounter > rateLimit * shedThresholdFor(job.req)) {
     throttleRequest(job.req, FAIL_REASONS.THROTTLED);
     return "next";
   }

--- a/tests/sim/criticality-shedding.test.mjs
+++ b/tests/sim/criticality-shedding.test.mjs
@@ -1,0 +1,177 @@
+// Prioritized load shedding (#248) — the lesson, machine-proven.
+//
+// Before this, the API Gateway shed BLINDLY: everything past the rate limit
+// was refused in arrival order, so what survived an overload was decided by
+// topology and luck. Measured on the reference board at 8 rps, that meant
+// READ 118 / SEARCH 32 / WRITE 28 / UPLOAD 19 lost and STATIC 0 — the $1.20
+// and $1.50 traffic died while the $0.50 traffic sailed through, and the
+// player could not influence it by any means at all.
+//
+// Real systems classify traffic in ADVANCE — Google's CRITICAL vs
+// SHEDDABLE_PLUS, Envoy's priority levels — precisely because nobody can make
+// that call during an incident. This is that mechanic.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { STATE, CONFIG, resetWorld, place, connect } from "../helpers/sim-world.mjs";
+import { mulberry32, frame } from "../helpers/reference-board.mjs";
+
+beforeEach(() => resetWorld({ gameMode: "survival" }));
+afterEach(() => vi.restoreAllMocks());
+
+// A board fronted by an API Gateway, which is the node that owns the policy.
+function gatewayBoard() {
+  resetWorld({ money: 1e9, gameMode: "survival" });
+  vi.spyOn(Math, "random").mockImplementation(mulberry32(0x5eed));
+  const waf = place("waf");
+  const apigw = place("apigw");
+  const alb = place("alb");
+  const compute = place("compute");
+  const db = place("db");
+  const s3 = place("s3");
+  const search = place("search");
+  connect("internet", waf);
+  connect(waf, apigw);
+  connect(apigw, alb);
+  connect(alb, compute);
+  connect(compute, db);
+  connect(compute, s3);
+  connect(compute, search);
+  if (!STATE.services.length) throw new Error("board did not build");
+  return { apigw, compute };
+}
+
+// An even mix so the shed order is about POLICY, not about which class happens
+// to be common.
+const EVEN_MIX = {
+  STATIC: 0.25, READ: 0.25, WRITE: 0.2, UPLOAD: 0.15, SEARCH: 0.15,
+  MALICIOUS: 0, INFERENCE: 0,
+};
+
+// Run the SAME board and the SAME seeded traffic under a given policy. The
+// blind policy (every class refused at the limit) is what the gateway did
+// before #248, so the two runs differ only in the shed ORDER — which is the
+// claim under test. Comparing absolute counts against each other instead
+// would prove nothing: CRITICAL is 35% of this mix and SHEDDABLE 25%, so
+// "more criticals survived" is true before the feature exists.
+function runAt(rps, { policy, seconds = 40 } = {}) {
+  const original = CONFIG.shedding;
+  if (policy) CONFIG.shedding = policy;
+  try {
+    gatewayBoard();
+    STATE.currentRPS = rps;
+    STATE.trafficDistribution = { ...EVEN_MIX };
+    const before = { ...STATE.finances.income.countByType };
+    for (let i = 0; i < Math.round(seconds * 60); i++) frame(1 / 60);
+    const served = {};
+    for (const t of Object.keys(EVEN_MIX)) {
+      served[t] = (STATE.finances.income.countByType[t] || 0) - (before[t] || 0);
+    }
+    return { served, income: +STATE.finances.income.total.toFixed(2) };
+  } finally {
+    CONFIG.shedding = original;
+    vi.restoreAllMocks();
+  }
+}
+
+const BLIND = { SHEDDABLE: 1.0, STANDARD: 1.0, CRITICAL: 1.0 };
+
+describe("traffic classes are declared, not discovered (#248)", () => {
+  it("every served class carries a criticality, and the policy knows it", () => {
+    const policy = CONFIG.shedding;
+    expect(policy.SHEDDABLE).toBeLessThan(policy.STANDARD);
+    expect(policy.STANDARD).toBeLessThan(policy.CRITICAL);
+    expect(policy.CRITICAL).toBe(1.0); // critical is carried to the last slot
+
+    for (const [type, cfg] of Object.entries(CONFIG.trafficTypes)) {
+      if (type === "MALICIOUS") continue; // never served, never classified
+      if (type === "INFERENCE") {
+        // Owns its own deadline mechanic at the Inference Gateway.
+        expect(cfg.criticality).toBeDefined();
+        continue;
+      }
+      expect(policy[cfg.criticality], `${type} has an unknown class`).toBeDefined();
+    }
+  });
+
+  it("the money and the class agree: nothing cheap outranks something dear", () => {
+    // Not a tautology — it is the design constraint. If a SHEDDABLE class ever
+    // paid more than a CRITICAL one, the gateway would be protecting the wrong
+    // revenue and the lesson would invert.
+    const rank = { SHEDDABLE: 0, STANDARD: 1, CRITICAL: 2 };
+    const served = Object.entries(CONFIG.trafficTypes).filter(
+      ([t, c]) => t !== "MALICIOUS" && c.criticality
+    );
+    for (const [ta, ca] of served) {
+      for (const [tb, cb] of served) {
+        if (rank[ca.criticality] > rank[cb.criticality]) {
+          expect(ca.reward, `${ta} outranks ${tb} but pays less`).toBeGreaterThanOrEqual(cb.reward);
+        }
+      }
+    }
+  });
+});
+
+describe("THE LESSON: the shed order is a decision, not an accident", () => {
+  it("at mild overload the policy earns MORE than shedding blindly", () => {
+    // 24 rps against a tier-1 gateway's 30 rps limit: the cheap class is
+    // refused early, which frees downstream slots for traffic worth more.
+    const blind = runAt(24, { policy: BLIND });
+    const tiered = runAt(24);
+    const fmt = (r) =>
+      Object.entries(r.served).filter(([t]) => EVEN_MIX[t] > 0)
+        .map(([t, n]) => `${t}=${n}`).join(" ");
+    console.log(
+      `\nMILD  BLIND : ${fmt(blind)}  income=$${blind.income}` +
+        `\nMILD  TIERED: ${fmt(tiered)}  income=$${tiered.income}`
+    );
+    expect(tiered.served.STATIC).toBeLessThan(blind.served.STATIC);
+    expect(tiered.income).toBeGreaterThan(blind.income);
+  });
+
+  it("at DEEP overload it protects what was declared critical — and that costs something", () => {
+    // 50 rps. Here the honest result is a trade, not a free win: CRITICAL
+    // survival is bought with SHEDDABLE traffic AND with some SEARCH, which
+    // is STANDARD despite paying $1.20. That is the consequence of
+    // classifying by ROLE (a transaction outranks a query) rather than by
+    // price list, and it is the decision the player is being taught to make
+    // in advance. Measured: UPLOAD 5 -> 8, STATIC 6 -> 3, income 33.38 ->
+    // 32.51. A policy is a choice about what to lose, not a way to lose less.
+    const blind = runAt(50, { policy: BLIND });
+    const tiered = runAt(50);
+    const fmt = (r) =>
+      Object.entries(r.served).filter(([t]) => EVEN_MIX[t] > 0)
+        .map(([t, n]) => `${t}=${n}`).join(" ");
+    console.log(
+      `\nDEEP  BLIND : ${fmt(blind)}  income=$${blind.income}` +
+        `\nDEEP  TIERED: ${fmt(tiered)}  income=$${tiered.income}`
+    );
+
+    const criticalTiered = tiered.served.WRITE + tiered.served.UPLOAD;
+    const criticalBlind = blind.served.WRITE + blind.served.UPLOAD;
+    expect(criticalTiered).toBeGreaterThan(criticalBlind);
+    expect(tiered.served.STATIC).toBeLessThan(blind.served.STATIC);
+  });
+
+  it("a healthy board sheds nothing at all — the policy is invisible below the limit", () => {
+    // If the classes cost anything when there is headroom, this would be a tax
+    // on playing rather than a lesson about pressure.
+    const r = runAt(4);
+    for (const [type, n] of Object.entries(r.served)) {
+      if (EVEN_MIX[type] > 0) {
+        expect(n, `${type} should be served freely at low load`).toBeGreaterThan(0);
+      }
+    }
+    expect(r.served.STATIC).toBeGreaterThan(0); // the first class to be shed is fine here
+  });
+
+  it("shedding stays a SOFT fail: it never trips the breaker", () => {
+    // Throttling is the gateway working as designed. If it fed the breaker,
+    // protecting revenue would look like a broken gateway and the node would
+    // take itself out of rotation for doing its job.
+    const { apigw } = gatewayBoard();
+    STATE.currentRPS = 30;
+    STATE.trafficDistribution = { ...EVEN_MIX };
+    for (let i = 0; i < 40 * 60; i++) frame(1 / 60);
+    expect(apigw.breaker?.state ?? "closed").toBe("closed");
+    vi.restoreAllMocks();
+  });
+});


### PR DESCRIPTION
The API Gateway shed **blindly**: everything past the rate limit was refused in arrival order, so what survived an overload was decided by topology and luck. Measured on the reference board at 8 rps: **READ 118 / SEARCH 32 / WRITE 28 / UPLOAD 19 lost, STATIC 0** — the $1.20 and $1.50 traffic died while the $0.50 traffic sailed through, and the player could not influence it by any means at all.

Real systems classify traffic **in advance** — Google's CRITICAL vs SHEDDABLE_PLUS, Envoy's priority levels — precisely because nobody can make that call during an incident.

## What lands
Every traffic class declares a `criticality`, and the gateway refuses classes at different fractions of its rate limit: **SHEDDABLE at 60 %, STANDARD at 85 %, CRITICAL carried to the last slot**. Unclassified traffic is treated as CRITICAL — refusing something the config never spoke about is the wrong default.

Classified **by role, not by price list**: STATIC is SHEDDABLE (degrade the images), READ and SEARCH are STANDARD (a query), WRITE and UPLOAD are CRITICAL (a transaction).

## Measured — including where it costs

**Mild overload** (24 rps vs a 30 rps limit):
| policy | STATIC | READ | WRITE | UPLOAD | SEARCH | income |
|---|---|---|---|---|---|---|
| blind | 8 | 5 | 7 | 8 | 8 | $34.96 |
| **tiered** | 6 | **11** | 7 | 8 | 8 | **$39.56** |

**Deep overload** (50 rps):
| policy | STATIC | READ | WRITE | UPLOAD | SEARCH | income |
|---|---|---|---|---|---|---|
| blind | 6 | 8 | 7 | 5 | 9 | $33.38 |
| **tiered** | 3 | 8 | 7 | **8** | 5 | $32.51 |

At mild overload the policy **earns more** — refusing the cheap class early frees downstream slots for traffic worth more. At deep overload it is a **trade, not a free win**: CRITICAL survival (UPLOAD 5→8) is bought with SHEDDABLE traffic *and* with some SEARCH, which is STANDARD despite paying $1.20.

That is the honest consequence of classifying by role rather than by price, and it is exactly the decision the player is being taught to make in advance: **a policy is a choice about what to lose, not a way to lose less.** Both tables are in the test so neither can quietly drift.

## Safety
Shedding stays the soft-fail it always was — it feeds neither the breaker nor the metrics error rate — so this changes *which* requests are refused, never how many the gateway can serve. A test pins the breaker staying closed under sustained shedding: a gateway protecting revenue must not look like a broken one and take itself out of rotation.

## The first version of this test passed with the feature reverted
It compared absolute served counts between classes — and CRITICAL is 35 % of the test mix against SHEDDABLE's 25 %, so *"more criticals survived"* was true before the mechanic existed. Rewritten to run the **same seeded board under both policies** and compare them directly; the mutation now reddens two assertions.

870/870 ×3, eslint clean, all 141 campaign / level / beatability tests unchanged.