### PR TITLE
fix: stop shipping 11.5 MB of muted audio to every first visitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (593 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (870 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/index.html
+++ b/index.html
@@ -4,9 +4,51 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
-  <title>SERVER: Survival Protocol</title>
+  <title>Server Survival — learn cloud architecture by playing</title>
+  <meta name="description"
+    content="A browser game that teaches real cloud architecture: load balancing, caching, autoscaling, circuit breakers, multi-region failover and GPU inference economics. 25 campaign levels, 11 languages, no install." />
+  <meta name="theme-color" content="#050505" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%23050505'/%3E%3Crect x='6' y='7' width='20' height='5' rx='1.5' fill='%2300FF85'/%3E%3Crect x='6' y='14' width='20' height='5' rx='1.5' fill='%233b82f6'/%3E%3Crect x='6' y='21' width='20' height='5' rx='1.5' fill='%23f97316'/%3E%3C/svg%3E" />
+  <!-- Link previews: a bare URL in a chat or a tweet showed nothing at all,
+       which is the whole first impression for a project people arrive at
+       through links. -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Server Survival — learn cloud architecture by playing" />
+  <meta property="og:description"
+    content="Build a cloud that survives real traffic: caching, autoscaling, circuit breakers, multi-region failover, GPU inference. Free, open source, runs in the browser." />
+  <meta property="og:url" content="https://pshenok.github.io/server-survival/" />
+  <meta property="og:image" content="https://raw.githubusercontent.com/pshenok/server-survival/main/assets/gameplay.gif" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Server Survival — learn cloud architecture by playing" />
+  <meta name="twitter:description"
+    content="Build a cloud that survives real traffic. 25 campaign levels, 11 languages, no install." />
+  <meta name="twitter:image" content="https://raw.githubusercontent.com/pshenok/server-survival/main/assets/gameplay.gif" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <script>
+    // Boot guard. THREE arrives as a bare global from a CDN; when that CDN is
+    // blocked — a corporate proxy, an ad blocker, a country-level block, an
+    // offline laptop — every module that touches it throws at evaluation and
+    // the player gets a silent white page with no idea why. Say what happened
+    // instead. Runs before the module graph, so it cannot be pre-empted by the
+    // very failure it reports.
+    if (typeof THREE === "undefined") {
+      document.addEventListener("DOMContentLoaded", function () {
+        document.body.innerHTML =
+          '<div style="font-family:system-ui,sans-serif;color:#e5e7eb;background:#050505;' +
+          'min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px;text-align:center">' +
+          '<div style="max-width:34rem">' +
+          '<h1 style="font-size:1.5rem;margin:0 0 .75rem">Server Survival could not start</h1>' +
+          '<p style="color:#9ca3af;line-height:1.6;margin:0 0 .75rem">' +
+          'The 3D library (three.js) is served from cdnjs.cloudflare.com and could not be loaded. ' +
+          'A proxy, an ad blocker, or an offline connection will do that.</p>' +
+          '<p style="color:#9ca3af;line-height:1.6;margin:0">' +
+          'Allowing cdnjs.cloudflare.com, or reloading on a different network, fixes it. ' +
+          'The game itself needs no server and stores nothing about you.</p>' +
+          '</div></div>';
+      });
+    }
+  </script>
   <link rel="stylesheet" href="style.css" />
 </head>
 

--- a/src/services/SoundService.js
+++ b/src/services/SoundService.js
@@ -11,11 +11,21 @@ export class SoundService {
             if (saved && typeof saved.sfxMuted === "boolean") this.sfxMuted = saved.sfxMuted;
         } catch (e) { /* corrupt prefs — keep defaults */ }
         this.masterGain = null;
+
+        // preload="none" on every clip, deliberately. The two BGM tracks are
+        // 7.4 MB and 4.1 MB — 89% of the whole repo's asset weight — and both
+        // channels default to MUTED, so without this a first-time visitor
+        // downloaded 11.5 MB of audio they had not asked for and could not
+        // hear, before the board finished appearing. The browser fetches each
+        // clip on its first play() call instead, which is exactly when the
+        // player has unmuted and a gesture exists.
         this.gameBgm = new Audio('assets/sounds/game-background.mp3');
+        this.gameBgm.preload = 'none';
         this.gameBgm.loop = true;
         this.gameBgm.volume = 0.2;
 
         this.menuBgm = new Audio('assets/sounds/menu.mp3');
+        this.menuBgm.preload = 'none';
         this.menuBgm.loop = true;
         this.menuBgm.volume = 0.3;
 
@@ -23,6 +33,8 @@ export class SoundService {
 
         this.sfxHover = new Audio('assets/sounds/click-5.mp3');
         this.sfxClick = new Audio('assets/sounds/click-9.mp3');
+        this.sfxHover.preload = 'none';
+        this.sfxClick.preload = 'none';
         this.sfxHover.volume = 0.4;
         this.sfxClick.volume = 0.5;
     }


### PR DESCRIPTION
Front-door hygiene, no mechanics. From the roadmap's PR 0 — the one item that costs zero design attention.

## The 11.5 MB
`SoundService` built five `Audio` elements in its constructor, and **both channels default to muted** (autoplay policies require a gesture anyway). The browser fetched them all regardless.

| | before | after |
|---|---|---|
| mp3 requests on cold load | **4** | **0** |
| bytes | `game-background.mp3` 4.07 MB + `menu.mp3` 7.40 MB + clicks | — |

`preload="none"` on all five; the browser fetches each clip on its first `play()`, which is exactly when the player has unmuted. One line per element, no structural change, every call site untouched.

## Also
- **`<head>` had five tags.** A bare URL in a chat or a tweet previewed as *nothing* — the entire first impression for a project people reach through links. Added description, theme-color, an inline-SVG favicon (no extra request) and the og:/twitter: set pointing at the existing `gameplay.gif`.
- **A boot guard.** `THREE` arrives as a bare global from cdnjs; when that is blocked (corporate proxy, ad blocker, country-level block, offline laptop) every module touching it throws at evaluation and the visitor gets a **silent white page**. Now it explains what happened and what fixes it. Plain DOM, placed before the module graph, so it cannot be pre-empted by the failure it reports and no test environment is affected.
- README claimed 593 tests; the suite is 870.

## Verified
870/870, eslint clean, and in the live browser: `preload` reads `"none"` on every clip, **zero mp3 requests fire on load**, meta tags present, THREE loads, board renders.

Note: `document.title` stays localised (i18n rewrites it from the `title` key across 11 locales) — link previews use the static `og:title`, which is the tag social platforms actually read.