### PR TITLE
The campaign debrief reported 100% on time no matter how long the queue was

### DIFF
--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -207,6 +207,16 @@ function updateScore(req, outcome) {
         // hints.js actively recommends that move. Survival only: campaign
         // levels are balanced against the old arithmetic and their objectives
         // count completions, so their play stays byte-identical.
+        // The COUNT is taken in every mode. It is read by exactly one thing,
+        // getRunReport() for the debrief, and by nothing the simulation feeds
+        // back — so counting it in a campaign level cannot move that level's
+        // balance, while NOT counting it made the debrief claim 100% on time
+        // for a board where every request stood in a queue past its SLO.
+        // The PRICE below stays survival-only, because req.wasLate is read
+        // back by reputation and by the SLOW badge.
+        if (req.sloSec && req.age > req.sloSec) {
+            STATE.lateCompletions = (STATE.lateCompletions || 0) + 1;
+        }
         if (STATE.gameMode === "survival" && req.sloSec && req.age > req.sloSec) {
             // Decay toward a floor over one further SLO of lateness, so the
             // penalty is a gradient rather than a cliff: 1 SLO late ~ the
@@ -214,7 +224,6 @@ function updateScore(req, outcome) {
             const floor = points.LATE_REWARD_FLOOR ?? 0.25;
             const overdue = Math.min(1, (req.age - req.sloSec) / req.sloSec);
             reward *= 1 - (1 - floor) * overdue;
-            STATE.lateCompletions = (STATE.lateCompletions || 0) + 1;
             req.wasLate = true;
         }
 

--- a/tests/sim/goodput.test.mjs
+++ b/tests/sim/goodput.test.mjs
@@ -162,6 +162,47 @@ describe("a late completion is worth less (#248)", () => {
     );
     expect(req.wasLate).toBeUndefined();
   });
+
+  it("survival counts each late completion ONCE — the price and the count are separate", () => {
+    // The count moved out of the survival-only branch so the campaign could
+    // have it too. Leaving a copy behind in that branch double-counts, and
+    // the debrief would then report more late requests than were served.
+    resetWorld({ gameMode: "survival" });
+    const db = place("db");
+    for (let i = 0; i < 4; i++) {
+      const req = new Request("READ");
+      STATE.requests.push(req);
+      req.age = SLO * 2;
+      finishRequest(req, db.type, db);
+    }
+    expect(STATE.lateCompletions).toBe(4);
+    expect(STATE.lateCompletions).toBeLessThanOrEqual(STATE.requestsProcessed);
+  });
+
+  it("...but the campaign DEBRIEF still counts it, or it reports a lie", () => {
+    // The price is survival-only on purpose. The COUNT must not be: the
+    // debrief divides onTime by processed, so a campaign board where every
+    // request stood past its SLO used to report "served N/N on time, 100%"
+    // — a true statement about the counter and a false one about the room.
+    resetWorld({ gameMode: "campaign" });
+    const db = place("db");
+    for (let i = 0; i < 3; i++) {
+      const req = new Request("READ");
+      STATE.requests.push(req);
+      req.age = SLO * 5;
+      finishRequest(req, db.type, db);
+    }
+    const punctual = new Request("READ");
+    STATE.requests.push(punctual);
+    punctual.age = SLO - 0.5;
+    finishRequest(punctual, db.type, db);
+
+    expect(STATE.lateCompletions).toBe(3);
+    expect(STATE.requestsProcessed).toBe(4);
+    // ...and the counter is inert: nothing in the simulation reads it back,
+    // which is what makes counting it in a campaign level safe. The test
+    // above this one pins the money and the reputation that prove it.
+  });
 });
 
 describe("THE LESSON: buffering relocates failure, it does not remove it", () => {


### PR DESCRIPTION
Found while auditing the run report. 882 → **884 tests**.

#248 gave lateness a price and deliberately kept that price survival-only — campaign levels are balanced against the old arithmetic, and `req.wasLate` is read back by reputation and by the SLOW badge, so charging for it would move thirteen balanced levels. That decision is right and this PR keeps it.

The problem is that the **count** sat inside the same branch:

```js
if (STATE.gameMode === "survival" && req.sloSec && req.age > req.sloSec) {
    reward *= ...;
    STATE.lateCompletions = (STATE.lateCompletions || 0) + 1;   // <- also gated
    req.wasLate = true;
}
```

and the debrief renders `onTime / processed`, where `onTime = processed - lateCompletions`. In a campaign that counter never moves, so **every campaign level reports "served N/N on time, 100%"** — however long requests actually stood in the pipe. A true statement about the counter and a false one about the room, on the one screen whose whole job is to tell the player what just happened. It is also the exact lesson #248 exists to teach: a queue converts drops into lateness, and a debrief that cannot see lateness reports a saturated board as a flawless one.

**The count now happens in every mode; the price still does not.** That split is safe by construction, not by hope:

- `STATE.lateCompletions` is read by `getRunReport()` for the debrief and by **nothing the simulation feeds back** — grep is short and in the diff.
- `req.wasLate`, which *is* fed back (reputation at `actions.js:242`, the SLOW badge at `276`), stays survival-only and stays `undefined` in a campaign.

The existing test `"campaign play is untouched — the price is survival-only"` pins the money, the reputation and the flag, and passes unchanged. That is the balance-neutrality proof, and it was already written.

Two tests added: the campaign debrief now counts three late completions out of four served, and survival counts each late completion **exactly once** — because moving the increment out of the survival branch means a copy left behind would double-count and nothing would have complained. Both mutation-checked; reverting the fix kills the first, re-adding the stray increment kills the second.