### PR TITLE
A traffic shift outlived its run and rewrote the next run's baseline

### DIFF
--- a/game.js
+++ b/game.js
@@ -461,6 +461,20 @@ function resetGame(mode = "survival") {
         STATE.intervention.trafficBurstMultiplier = 1.0;
         STATE.intervention.currentMilestoneIndex = 0;
         STATE.intervention.rpsMultiplier = 1.0;
+        // A traffic shift belongs to its run just as much as a random event
+        // does, and four of its fields used to outlive one. The worst is
+        // originalTrafficDist: endTrafficShift() restores it, so a stranded
+        // one does not merely misfire once — it becomes the NEXT run's
+        // baseline, and every later shift in that run returns to the old
+        // run's mix instead of this one's.
+        //
+        // Cleared directly rather than through endTrafficShift(), which would
+        // restore that stale mix over the distribution this function has
+        // already chosen for the new mode a few lines above.
+        STATE.intervention.trafficShiftActive = false;
+        STATE.intervention.trafficShiftTimer = 0;
+        STATE.intervention.originalTrafficDist = null;
+        STATE.intervention.currentShift = null;
     }
 
     // Initialize balance overhaul state

--- a/tests/sim/reset-leaks.test.mjs
+++ b/tests/sim/reset-leaks.test.mjs
@@ -1,0 +1,76 @@
+// A run's events belong to that run. resetGame() already ends a live random
+// event and rewinds its timers, for a reason it states: the deadline is a
+// game-time stamp, so a stranded event measured against a clock restarting at
+// zero holds its effects over the whole next session.
+//
+// The traffic shift is the same kind of thing and was not on that list. Four
+// of its fields outlived a run, and the damaging one is originalTrafficDist:
+// endTrafficShift() RESTORES it, so a stranded copy does not misfire once —
+// it silently becomes the next run's baseline, and every shift in that run
+// returns to the old run's traffic mix instead of the new one's.
+import { describe, it, expect } from "vitest";
+import { STATE } from "../../src/state.js";
+import { resetGame } from "../../game.js";
+import { updateMaliciousSpike, updateTrafficShift } from "../../src/core/events.js";
+
+// Exactly what a run quit in the middle of a shift leaves behind.
+const GHOST = {
+    STATIC: 0.99, READ: 0.01, WRITE: 0, UPLOAD: 0,
+    SEARCH: 0, MALICIOUS: 0, INFERENCE: 0,
+};
+function quitMidShift() {
+    resetGame("survival");
+    STATE.intervention.trafficShiftActive = true;
+    STATE.intervention.trafficShiftTimer = 7;
+    STATE.intervention.originalTrafficDist = { ...GHOST };
+    STATE.intervention.currentShift = { id: "ghost" };
+}
+
+describe("a traffic shift does not outlive its run", () => {
+    it("resetGame clears every field of it, the way it already clears random events", () => {
+        quitMidShift();
+        resetGame("campaign");
+        expect(STATE.intervention.trafficShiftActive).toBe(false);
+        expect(STATE.intervention.trafficShiftTimer).toBe(0);
+        expect(STATE.intervention.originalTrafficDist).toBeNull();
+        expect(STATE.intervention.currentShift).toBeNull();
+    });
+
+    it("THE DAMAGE: the old run's mix used to become the new run's baseline", () => {
+        quitMidShift();
+        resetGame("survival");
+        const baseline = STATE.trafficDistribution.STATIC;
+
+        // Play out several shift cycles and collect every distribution the
+        // run settles BACK to. Each of those is a restore, and each one must
+        // be this run's baseline.
+        const restores = new Set();
+        for (let t = 1; t <= 200; t++) {
+            const before = STATE.trafficDistribution.STATIC;
+            updateTrafficShift(1);
+            const after = STATE.trafficDistribution.STATIC;
+            if (Math.abs(after - before) > 1e-9) restores.add(+after.toFixed(3));
+        }
+        // The run did shift at least once, or this proves nothing.
+        expect(restores.size).toBeGreaterThan(0);
+        // ...and the ghost's 0.99 is not among the values it ever took.
+        expect(restores.has(0.99)).toBe(false);
+        expect(STATE.intervention.originalTrafficDist === null
+            || STATE.intervention.originalTrafficDist.STATIC === baseline).toBe(true);
+    });
+
+    it("...and a malicious spike is not suppressed by a shift from a run that ended", () => {
+        // startMaliciousSpike() early-returns while a shift is active, and
+        // has no mode gate — so in a CAMPAIGN level, where updateTrafficShift
+        // returns early and can never clear the flag, a stranded shift used
+        // to suppress every spike for the rest of the page session.
+        quitMidShift();
+        resetGame("survival");
+        STATE.elapsedGameTime = 100000;
+        STATE.maliciousSpikeTimer = 100000;
+        for (let i = 0; i < 200 && !STATE.maliciousSpikeActive; i++) {
+            updateMaliciousSpike(1);
+        }
+        expect(STATE.maliciousSpikeActive).toBe(true);
+    });
+});


### PR DESCRIPTION
884 → **887 tests**.

`resetGame()` already ends a live random event and rewinds its timers, and the comment says exactly why: the deadline is a game-time stamp, so a stranded event measured against a clock restarting at zero holds its effects for the whole next session.

**The traffic shift is the same kind of thing and was not on that list.** Four fields survived a reset: `trafficShiftActive`, `trafficShiftTimer`, `originalTrafficDist`, `currentShift`.

## The damage

`originalTrafficDist` is the one that hurts, because `endTrafficShift()` **restores** it. A stranded copy therefore does not misfire once — it becomes the next run's baseline. Measured with the real `resetGame`, control against leaked, tracing `STATIC`'s share:

```
control: 0.3 → 0.15 (t=40) → 0.3 → 0.1 (t=105) → 0.3
leaked:  0.3 → 0.99 (t=18) → 0.15 → 0.99 → 0.15
```

Every shift in the control returns to `0.3`, the run's own mix. In the leaked run the **previous** run's mix takes over at t=18 and every later shift returns to that one instead. The player is playing someone else's traffic profile for the rest of the session, and nothing on screen says so.

## The second harm, which is permanent

`startMaliciousSpike()` early-returns while a shift is active and has **no mode gate**, while `updateTrafficShift()` returns early outside survival (unless a level sets `enableSurvivalShifts`). So one survival run quit mid-shift suppresses **every malicious spike in every campaign level afterwards** — and nothing in a campaign can clear the flag, so it stays suppressed until the player happens to start another survival run and wait the shift out.

## The fix

Clear the four fields alongside the random-event block. **Directly, not via `endTrafficShift()`** — that would restore the stale mix over the distribution `resetGame` has already chosen for the new mode a few lines above.

Three tests: the fields are clear after a reset, the ghost mix never appears among the values a fresh run settles back to, and a malicious spike is not suppressed by a shift from a run that ended. Each of the four cleared fields is mutation-checked individually — dropping any one turns a test red, so none of them is a dead assignment.