### PR TITLE
The campaign charged for auto-repair while auto-repair was switched off

### DIFF
--- a/src/core/economy.js
+++ b/src/core/economy.js
@@ -351,6 +351,11 @@ function processAutoRepair(dt) {
 
 function getAutoRepairUpkeep() {
     if (!STATE.autoRepairEnabled) return 0;
+    // Gated exactly like processAutoRepair() below, and for the same reason:
+    // outside survival the healing does not happen, so charging for it bills
+    // the player for a service the mode has switched off. The toggle stays
+    // pressable everywhere — it just costs nothing where it does nothing.
+    if (STATE.gameMode !== "survival") return 0;
 
     const percent = CONFIG.survival.degradation?.autoRepairCostPercent || 0.1;
     // 10% of total service cost per second

--- a/tests/sim/economy.test.mjs
+++ b/tests/sim/economy.test.mjs
@@ -22,6 +22,7 @@ describe("getAutoRepairUpkeep", () => {
   });
 
   it("charges autoRepairCostPercent of total service cost per minute", () => {
+    resetWorld({ gameMode: "survival" });   // the mode that actually repairs
     place("db"); // 150
     place("waf"); // 40
     STATE.autoRepairEnabled = true;
@@ -30,11 +31,42 @@ describe("getAutoRepairUpkeep", () => {
   });
 
   it("scales with the number of services", () => {
+    resetWorld({ gameMode: "survival" });
     STATE.autoRepairEnabled = true;
     place("s3"); // 25
     const one = getAutoRepairUpkeep();
+    expect(one).toBeGreaterThan(0);         // or the doubling below is 0 === 0
     place("s3");
     expect(getAutoRepairUpkeep()).toBeCloseTo(one * 2, 10);
+  });
+
+  // processAutoRepair has had a test on BOTH sides of the mode gate since it
+  // was written. The cost never did — it was only ever exercised through
+  // whichever mode the default fixture happened to use, so the day the
+  // healing became survival-only the bill silently stayed universal.
+  it("COSTS NOTHING WHERE IT DOES NOTHING: no charge outside survival", () => {
+    for (const mode of ["campaign", "sandbox"]) {
+      resetWorld({ gameMode: mode });
+      place("db");
+      place("waf");
+      STATE.autoRepairEnabled = true;
+      expect(getAutoRepairUpkeep(), `${mode} must not be billed`).toBe(0);
+    }
+  });
+
+  it("...and the campaign is where that bill actually landed", () => {
+    // resetGame("campaign") sets upkeepEnabled = true, and game.js charges
+    // `autoRepairCost > 0 && STATE.upkeepEnabled`. So a campaign level with
+    // the toggle on drained money every frame while processAutoRepair()
+    // healed nothing — paying upkeep for a switched-off service.
+    resetWorld({ gameMode: "campaign" });
+    const db = place("db");
+    db.health = 50;
+    STATE.autoRepairEnabled = true;
+    STATE.upkeepEnabled = true;
+    expect(getAutoRepairUpkeep()).toBe(0);
+    processAutoRepair(2);
+    expect(db.health).toBe(50);   // still no healing — the gate is symmetric
   });
 });
 


### PR DESCRIPTION
884 → **886 tests**.

`processAutoRepair()` has been survival-only since it was written, and it has a test on both sides of that gate — *heals in survival*, *does nothing outside survival*.

`getAutoRepairUpkeep()` never got the same gate:

```js
function getAutoRepairUpkeep() {
    if (!STATE.autoRepairEnabled) return 0;
    // ...no mode check
```

and `game.js` charges it whenever `autoRepairCost > 0 && STATE.upkeepEnabled` — which `resetGame("campaign")` sets to **true**. So a campaign level with the toggle on drained money every frame while nothing healed. The player paid upkeep for a service the mode had switched off, and the upkeep display showed the charge as though it were buying something.

The cost is now gated exactly like the benefit. The toggle stays pressable everywhere; it just costs nothing where it does nothing. Note this only ever *charged* — the conservative fix, and provably so, since the healing path is untouched and campaign balance moves only by stopping a drain that bought nothing.

## Why the tests did not catch it

Same asymmetry as the code. The healing was tested in both modes; the cost was only ever exercised through whichever mode the default fixture happened to use — and `resetWorld()` defaults to `sandbox`. So on the day the healing became survival-only, the bill silently stayed universal and every test stayed green.

Fixed on both sides:

- the two arithmetic tests now say `survival` out loud instead of inheriting it from a default;
- the doubling test gained a `> 0` assertion, because with the gate in place it would otherwise have checked `0 ≈ 0 * 2` — green and meaningless;
- the mode dimension the cost never had is now covered on both sides, including the campaign case where the bill actually landed.

Mutation-checked: removing the gate turns both new tests red.