### PR TITLE
The armed tool outlived its run and walked past a level's service ban

### DIFF
--- a/game.js
+++ b/game.js
@@ -482,6 +482,24 @@ function resetGame(mode = "survival") {
     STATE.gameStartTime = performance.now();
     STATE.maliciousSpikeTimer = 0;
     STATE.maliciousSpikeActive = false;
+    // The pointer belongs to the run too. activeTool is the sharper of the
+    // two: the click handler places with
+    // createService(PLACEMENT_TYPE_MAP[STATE.activeTool]) and never consults
+    // the toolbar gate, which only decides which BUTTONS render. So a tool
+    // armed in one run stayed armed into the next, and a campaign level that
+    // allows only s3 could be handed a GPU by a player who never saw a GPU
+    // button — the ban is on the toolbar, and the toolbar was bypassed.
+    //
+    // selectedNodeId is the quieter one: ids restart with the board, so a
+    // stale id either points at nothing or, worse, at a DIFFERENT node in
+    // the new run, which then renders as selected with nobody having
+    // clicked it — and in "connect" mode is one click from a wire the
+    // player did not draw.
+    STATE.activeTool = "select";
+    STATE.selectedNodeId = null;
+    // A run that ended while the main menu was open left its own speed here,
+    // and Resume restores it: a new run could start at the old run's 2x.
+    STATE.previousTimeScale = 1;
     STATE.normalTrafficDist = null;
     STATE.autoRepairEnabled = false;
     resetMetrics();

--- a/tests/sim/reset-leaks.test.mjs
+++ b/tests/sim/reset-leaks.test.mjs
@@ -12,6 +12,8 @@ import { describe, it, expect } from "vitest";
 import { STATE } from "../../src/state.js";
 import { resetGame } from "../../game.js";
 import { updateMaliciousSpike, updateTrafficShift } from "../../src/core/events.js";
+import { PLACEMENT_TYPE_MAP } from "../../src/input/handlers.js";
+import { CAMPAIGN_LEVELS } from "../../src/campaign/levels.js";
 
 // Exactly what a run quit in the middle of a shift leaves behind.
 const GHOST = {
@@ -72,5 +74,46 @@ describe("a traffic shift does not outlive its run", () => {
             updateMaliciousSpike(1);
         }
         expect(STATE.maliciousSpikeActive).toBe(true);
+    });
+});
+
+describe("the pointer does not outlive its run either", () => {
+    it("THE BYPASS: an armed tool used to survive into a level that forbids it", () => {
+        // The toolbar gate decides which BUTTONS render. The click handler
+        // does not consult it — it places with
+        // createService(PLACEMENT_TYPE_MAP[STATE.activeTool]). So a tool
+        // armed in one run stayed armed into the next, and the first click
+        // on empty ground placed a service the level never offered.
+        const gated = CAMPAIGN_LEVELS.find(
+            (l) => (l.allowedServices || []).length > 0
+                && !(l.allowedServices || []).includes("gpu")
+        );
+        expect(gated, "a level that allows some services but not the GPU").toBeTruthy();
+
+        resetGame("survival");
+        STATE.activeTool = "gpu";           // armed in the run that just ended
+        resetGame("campaign");
+
+        // Nothing placeable is armed, so a click on the ground places nothing.
+        expect(PLACEMENT_TYPE_MAP[STATE.activeTool]).toBeUndefined();
+        expect(STATE.activeTool).toBe("select");
+    });
+
+    it("a stale node id does not come back selected in the next run", () => {
+        // Ids restart with the board, so a surviving id either points at
+        // nothing or at a DIFFERENT node — which then draws as selected with
+        // nobody having clicked it, and in connect mode is one click away
+        // from a wire the player never drew.
+        resetGame("survival");
+        STATE.selectedNodeId = "service-7";
+        resetGame("survival");
+        expect(STATE.selectedNodeId).toBeNull();
+    });
+
+    it("and a new run does not resume at the previous run's speed", () => {
+        resetGame("survival");
+        STATE.previousTimeScale = 4;        // menu opened during a 4x run
+        resetGame("campaign");
+        expect(STATE.previousTimeScale).toBe(1);
     });
 });


### PR DESCRIPTION
889 → **892 tests**.

Found by auditing `STATE` against what `resetGame()` actually writes: of 37 top-level keys, three were never reset and are not covered indirectly by `resetResilience()` or `recomputePower()`.

## `activeTool` — the sharp one

`applyToolbarGating()` decides which **buttons render**. The click handler never consults it:

```js
} else if (PLACEMENT_TYPE_MAP[STATE.activeTool]) {
    ...
    if (i.type === "ground") {
        createService(PLACEMENT_TYPE_MAP[STATE.activeTool], snapToGrid(i.pos));
    }
}
```

So a tool armed in one run stayed armed into the next, and a campaign level whose `allowedServices` is `["s3"]` could be handed a GPU by a player who never saw a GPU button. The ban lives on the toolbar, and the toolbar was bypassed by simply not using it.

## `selectedNodeId` — the quiet one

Ids restart with the board, so a surviving id either points at nothing or — worse — at a **different** node in the new run, which then draws as selected with nobody having clicked it. In `connect` mode that is one click away from a wire the player never drew.

## `previousTimeScale`

Written when the main menu opens, restored by Resume. A run that ended from the menu handed its speed to the next one: start a level, press Resume, play at the previous run's 2x.

Three tests, one per field, each mutation-checked individually — dropping any single reset turns exactly one test red, so none of the three is carried by the others.