### PR TITLE
An abandoned campaign level kept grading, and won itself on an empty board

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (38 test files, 903 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (39 test files, 907 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/game.js
+++ b/game.js
@@ -385,6 +385,28 @@ function resetGame(mode = "survival") {
     // a side effect of the category tabs). Any non-campaign mode starts ungated.
     if (mode !== "campaign") applyToolbarGating([], []);
 
+    // ...and the campaign CONTROLLER stops with it. `active` is set by
+    // loadLevel() and cleared by exit(), which only exitCampaignToMap()
+    // called — so every other way out of a level (Escape to the pause menu,
+    // then New Game or Sandbox; or the menu's own campaign exit) left the
+    // controller running. animate() then kept calling campaign.tick(dt) on
+    // the NEW run: it repainted the abandoned level's objectives over the
+    // HUD, fired that level's scripted bursts into a survival board, and
+    // graded the new run against the old level's conditions.
+    //
+    // The worst of that is not cosmetic. resetGame hands the new run
+    // reputation 100 while STATE.campaign.completedByType still holds the
+    // completions banked during the campaign attempt, and those two together
+    // are the win gate: a level abandoned in failure was scored a WIN — three
+    // stars, persisted, next level unlocked — on a sandbox board with no
+    // services on it at all. Levels with a timeoutSec did the mirror of it,
+    // ending a later run in a LOSE debrief and freezing its clock.
+    //
+    // startCampaignLevel() calls resetGame("campaign") before loadLevel(),
+    // so gating on the mode is what keeps this from shutting down the run it
+    // is about to start.
+    if (mode !== "campaign") window.campaign?.exit();
+
     // Set budget based on mode
     if (mode === "campaign") {
         STATE.money = 0; // will be set by startCampaignLevel from level.budget

--- a/tests/sim/campaign-lifetime.test.mjs
+++ b/tests/sim/campaign-lifetime.test.mjs
@@ -1,0 +1,93 @@
+// A campaign level's controller belongs to that level.
+//
+// `window.campaign.active` is set by loadLevel() and cleared by exit(), and
+// exit() was called from exactly one place: exitCampaignToMap(). Every other
+// way out of a level — Escape to the pause menu and then New Game or Sandbox,
+// or the menu's own campaign exit — left the controller running, and
+// animate() keeps calling campaign.tick(dt) for as long as it is.
+//
+// The cosmetic half of that is the abandoned level's objectives repainting
+// over a survival HUD. The real half is that the controller GRADES: resetGame
+// hands a new run reputation 100 while STATE.campaign.completedByType still
+// holds what was banked during the campaign attempt, and those two together
+// are the win gate. A level abandoned in failure was scored a WIN on a
+// sandbox board with nothing built on it.
+import { describe, it, expect, beforeEach } from "vitest";
+import { STATE } from "../../src/state.js";
+import { resetGame } from "../../game.js";
+
+// What the campaign map writes before a level is playable.
+function unlock(upTo = 25) {
+    try {
+        localStorage.setItem(
+            "serverSurvivalCampaignProgress",
+            JSON.stringify({ version: 1, completed: {}, highestUnlocked: upTo })
+        );
+    } catch { /* storage unavailable — startCampaignLevel still runs */ }
+}
+
+// One frame of animate(), verbatim in the part that matters.
+function frame(dt) {
+    if (window.campaign?.active) window.campaign.tick(dt);
+}
+
+describe("a campaign level does not keep grading after you leave it", () => {
+    beforeEach(() => {
+        try { localStorage.clear(); } catch { /* */ }
+        unlock();
+    });
+
+    it("THE FREE WIN: an abandoned level used to be won off an empty sandbox board", () => {
+        window.startCampaignLevel(1);
+        // Play most of it, then fail the standing on purpose: 50 READs
+        // served, reputation under the level's floor. This is a LOSS.
+        for (let i = 0; i < 50; i++) window.campaign.onRequestCompleted({ type: "READ" }, "db");
+        STATE.reputation = 60;
+        frame(0.6);
+        expect(STATE.campaign.ended, "the level must not be over yet").toBe(false);
+
+        // Escape, then "Sandbox Mode" — what window.startSandbox() does.
+        resetGame("sandbox");
+        expect(window.campaign.active, "the controller should have shut down").toBe(false);
+
+        // A whole second of sandbox on a board with nothing on it.
+        for (let i = 0; i < 10; i++) frame(0.1);
+        expect(STATE.gameMode).toBe("sandbox");
+        expect(STATE.services.length).toBe(0);
+        expect(STATE.campaign.outcome, "a sandbox board cannot win a campaign level").not.toBe("win");
+        expect(STATE.campaign.ended, "and no level may END during a sandbox run").toBe(false);
+        // resetGame starts every run paused, so timeScale is 0 either way —
+        // the debrief modal is the signal that a level resolved on top of it.
+        const debrief = document.getElementById("campaign-debrief-modal");
+        expect(debrief?.classList.contains("hidden"), "a debrief opened over the sandbox").toBe(true);
+    });
+
+    it("THE MIRROR: an abandoned level's timeout used to end a later run in a LOSE", () => {
+        window.startCampaignLevel(2);
+        frame(0.6);
+        resetGame("survival");
+        // Play past whatever deadline the abandoned level was counting to.
+        STATE.elapsedGameTime = 100000;
+        for (let i = 0; i < 10; i++) frame(0.1);
+        expect(STATE.campaign.outcome).not.toBe("lose");
+        expect(STATE.campaign.ended, "a survival run was ended by a level nobody was playing").toBe(false);
+    });
+
+    it("the scripted traffic of a level stops when the level does", () => {
+        window.startCampaignLevel(5);
+        frame(0.6);
+        resetGame("survival");
+        const before = STATE.requests.length;
+        for (let i = 0; i < 200; i++) frame(0.1);
+        expect(STATE.requests.length, "a level's bursts fired into a survival run").toBe(before);
+    });
+
+    it("...but starting a campaign level still arms it — the gate is the mode, not the call", () => {
+        // resetGame("campaign") runs INSIDE startCampaignLevel, before
+        // loadLevel. If the shutdown were unconditional it would disarm the
+        // very run it is about to start.
+        window.startCampaignLevel(3);
+        expect(window.campaign.active).toBe(true);
+        expect(STATE.campaign.level.id).toBe(3);
+    });
+});


### PR DESCRIPTION
903 → **907 tests**.

`window.campaign.active` is set by `loadLevel()` and cleared by `exit()` — and `exit()` was called from exactly one place, `exitCampaignToMap()`. Every other way out of a level leaves the controller running:

- Escape → pause menu → **New Game**
- Escape → pause menu → **Sandbox Mode**
- `exitCampaignToMenu()`, the menu's own campaign exit

and `animate()` calls `campaign.tick(dt)` for as long as it is active.

## The cosmetic half

The abandoned level's objectives repaint over the new run's HUD, and its scripted `burstPattern` fires into a survival board that never asked for it.

## The half that matters

`resetGame` hands the new run **reputation 100**, while `STATE.campaign.completedByType` still holds the completions banked during the campaign attempt — and those two together are the win gate.

So a level abandoned **in failure** was scored a **win**: three stars, persisted to localStorage, next level unlocked — on a sandbox board with nothing built on it.

Reproduced on level 1: quit at 50 READs with reputation 60 (a loss — `rep_above_80` is unmet), press Sandbox Mode, and one frame later:

```
controllerStillActive: true
gameMode: "sandbox"   servicesOnBoard: 0
campaignEnded: true   outcome: "win"
```

Levels with a `timeoutSec` do the mirror: a later run, in any mode, ends in a **LOSE** debrief for missing a deadline nobody was playing against, and the debrief freezes the clock over it.

Level 1's whole lesson is that you have to hold your standing up *while* serving traffic. It was available for free, and the progress the game persists was a claim about a board the player never built.

## The fix, and why it is gated

One line, next to the toolbar-gating call that already keys off the same condition. It is gated on the mode rather than unconditional because `startCampaignLevel()` runs `loadLevel()` **and then** `resetGame("campaign")` — an unconditional shutdown would disarm the very run it is starting.

The mutations prove both halves: removing the line turns the two grading tests red; making it unconditional turns the mode-gate test red **and breaks three campaign proofs**.

Four tests: the free win, the mirrored loss, the scripted traffic, and the gate itself.

Found by an adversarial sweep for state that outlives a run — the same class as the four fixed earlier today, this one at controller level, which is why it *grades* rather than merely lingers.