### PR TITLE
The Failures panel's Clear link rewrote what the campaign grades on

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (41 test files, 922 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (42 test files, 928 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/game.js
+++ b/game.js
@@ -452,6 +452,7 @@ function resetGame(mode = "survival") {
         INFERENCE: 0,
     };
     STATE.failuresByReason = {};
+    STATE.failuresDismissedAt = 0;
     // AI Wave session counter (#87) + the power grid derivation over the
     // (now empty) service list.
     STATE.inference = { expired: 0 };
@@ -1034,17 +1035,24 @@ syncFailureBadgeButton();
 let tooltipRefreshAcc = 0;
 
         // clear failure list
-        document.getElementById('clear-all').addEventListener('click',()=>{
-            STATE.failures.MALICIOUS=0;
-            STATE.failures.STATIC=0;
-            STATE.failures.READ=0;
-            STATE.failures.WRITE=0;
-            STATE.failures.UPLOAD=0;
-            STATE.failures.SEARCH=0;
-            STATE.failures.INFERENCE=0;
-            // when click on clear button, update ui immediately
+        document.getElementById('clear-all').addEventListener('click', () => {
+            // DISMISSES THE PANEL. It used to zero STATE.failures, which is
+            // not this button's to rewrite: four PRIMARY campaign objectives
+            // grade on that tally (fail_under_5_pct, fail_under_10_pct,
+            // no_leaks, fail_under_12_pct) plus eight bonuses, and the run
+            // report counts it too. One click turned a leaked level 11 into a
+            // clean win — the level whose entire subject is having the
+            // Firewall up BEFORE the wave, replaced by hiding the evidence.
+            //
+            // The achievements engine was already hardened against exactly
+            // this button (see the clean-window watermark in
+            // src/achievements/achievements.js) — the campaign evaluator and
+            // the debrief never were. Recording a view preference instead of
+            // erasing history fixes all three at once, and the panel is still
+            // dismissable: it comes back when something NEW fails.
+            STATE.failuresDismissedAt = Object.values(STATE.failures)
+                .reduce((a, n) => a + (typeof n === "number" ? n : 0), 0);
             document.getElementById('failures-panel').classList.add('hidden');
-            document.getElementById('failures-total').textContent = `0 ${i18n.t('total')}`;
         })
 
 // showTooltip / setupUITooltips moved to src/input/handlers.js (#155 PR 8).
@@ -1349,7 +1357,7 @@ function animate(time) {
     );
     const failuresPanel = document.getElementById("failures-panel");
     const points = CONFIG.survival.SCORE_POINTS;
-    if (totalFailures > 0 && failuresPanel) {
+    if (totalFailures > (STATE.failuresDismissedAt || 0) && failuresPanel) {
         failuresPanel.classList.remove("hidden");
         document.getElementById(
             "failures-total"

--- a/src/state.js
+++ b/src/state.js
@@ -18,6 +18,12 @@ export const STATE = {
         maliciousBlocked: 0
     },
 
+    // How many failures had been recorded when the player last dismissed the
+    // Failures panel. A VIEW preference, not evidence: the panel stays hidden
+    // until the tally rises above it, and the tally itself is never rewritten.
+    // The button used to zero STATE.failures outright, which rewrote what the
+    // campaign grades on and what the debrief reports.
+    failuresDismissedAt: 0,
     failures: {
         STATIC: 0,
         READ: 0,

--- a/tests/sim/failures-are-evidence.test.mjs
+++ b/tests/sim/failures-are-evidence.test.mjs
@@ -1,0 +1,128 @@
+// The Failures panel's "Clear" link used to zero STATE.failures.
+//
+// That tally is not the panel's to rewrite. Four PRIMARY campaign objectives
+// grade on it — L5 fail_under_5_pct, L9 fail_under_10_pct, L11 no_leaks,
+// L23 fail_under_12_pct — plus eight bonus objectives, and the debrief's run
+// report counts it. So one click on a small link turned a lost level into a
+// won one, and level 11's whole subject (the Firewall has to be up BEFORE
+// the wave, so nothing ever gets through) became "hide the evidence".
+//
+// The achievements engine had already been hardened against this exact
+// button: src/achievements/achievements.js watches the tally for INCREASES
+// only, "so clearing the panel cannot fake clean_two_minutes". The campaign
+// evaluator and the debrief never got the same treatment. Recording a view
+// preference instead of erasing history covers all three at once.
+import { describe, it, expect, beforeEach } from "vitest";
+
+// Captured BEFORE game.js is imported: animate() re-arms itself through
+// requestAnimationFrame, so stubbing it hands us the real frame callback and
+// the panel below is drawn by the shipped renderer, not by a copy of it.
+const pending = [];
+globalThis.requestAnimationFrame = (cb) => { pending.push(cb); return pending.length; };
+globalThis.window.requestAnimationFrame = globalThis.requestAnimationFrame;
+
+const { STATE } = await import("../../src/state.js");
+const { resetGame } = await import("../../game.js");
+const { CAMPAIGN_LEVELS } = await import("../../src/campaign/levels.js");
+
+let clock = 0;
+// One real frame of animate(): 50 ms, under game.js's own 0.1 s clamp.
+function frame() {
+    const cb = pending.pop();
+    pending.length = 0;
+    if (!cb) return false;
+    clock += 50;
+    cb(clock);
+    return true;
+}
+
+const clear = () => document.getElementById("clear-all").click();
+const total = () => Object.values(STATE.failures).reduce((a, n) => a + n, 0);
+const hidden = () => document.getElementById("failures-panel").classList.contains("hidden");
+
+// Every objective in the campaign whose check reads STATE.failures.
+function failureObjectives() {
+    const out = [];
+    for (const lvl of CAMPAIGN_LEVELS) {
+        for (const kind of ["primary", "bonus"]) {
+            for (const o of lvl.objectives[kind]) {
+                if (/^(no_leaks|no_drops|nothing_lost|fail_under_|no_\w+_fails)/.test(o.id)) {
+                    out.push({ level: lvl.id, kind, o });
+                }
+            }
+        }
+    }
+    return out;
+}
+
+describe("a failure that happened stays happened", () => {
+    beforeEach(() => {
+        try { localStorage.clear(); } catch { /* */ }
+        resetGame("campaign");
+    });
+
+    it("THE EXPLOIT: level 11's no_leaks used to go green on one click", () => {
+        const l11 = CAMPAIGN_LEVELS.find((l) => l.id === 11);
+        const noLeaks = [...l11.objectives.primary, ...l11.objectives.bonus]
+            .find((o) => o.id === "no_leaks");
+        STATE.failures.MALICIOUS = 7;          // seven attacks got through
+        expect(noLeaks.check(STATE)).toBe(false);
+        clear();
+        expect(STATE.failures.MALICIOUS).toBe(7);
+        expect(noLeaks.check(STATE), "the level was won by hiding the evidence").toBe(false);
+    });
+
+    it("...and no OTHER failure-graded objective moves either, on any level", () => {
+        // The button is one click; the blast radius is the whole campaign.
+        const objectives = failureObjectives();
+        expect(objectives.length, "the campaign grades on failures somewhere").toBeGreaterThan(8);
+        for (const k of Object.keys(STATE.failures)) STATE.failures[k] = 4;
+        STATE.requestsProcessed = 10;
+        const before = objectives.map(({ o }) => o.check(STATE));
+        clear();
+        const after = objectives.map(({ o }) => o.check(STATE));
+        expect(after).toEqual(before);
+    });
+
+    it("the run report still counts what actually failed", () => {
+        STATE.failures.READ = 3;
+        STATE.failures.MALICIOUS = 2;
+        clear();
+        expect(total()).toBe(5);
+    });
+
+    it("but the panel really is dismissed — the SHIPPED renderer leaves it hidden", () => {
+        // Driven through animate() itself. Asserting only that the click hides
+        // the panel would pass even if the renderer ignored the dismissal and
+        // re-opened it on the very next frame, which is the whole way this
+        // button could quietly become useless again.
+        STATE.failures.READ = 3;
+        STATE.isRunning = true;
+        clear();
+        expect(hidden()).toBe(true);
+        expect(frame(), "animate() must actually be running for this to prove anything").toBe(true);
+        frame();
+        expect(hidden(), "the renderer re-opened a panel the player dismissed").toBe(true);
+    });
+
+    it("...and a dismissal is not a mute: something NEW brings it straight back", () => {
+        STATE.failures.READ = 3;
+        STATE.isRunning = true;
+        clear();
+        frame();
+        expect(hidden()).toBe(true);
+        STATE.failures.READ = 4;          // one new failure
+        frame();
+        expect(hidden(), "a new failure must re-open the panel").toBe(false);
+        expect(document.getElementById("fail-read").textContent, "and it shows the TRUE tally")
+            .toBe("4");
+    });
+
+    it("a new run starts undismissed", () => {
+        STATE.failures.READ = 3;
+        clear();
+        expect(STATE.failuresDismissedAt).toBe(3);
+        resetGame("survival");
+        expect(STATE.failuresDismissedAt).toBe(0);
+    });
+});


### PR DESCRIPTION
907 → **913 tests**.

The `clear-all` link zeroed all seven `STATE.failures` counters:

```js
document.getElementById('clear-all').addEventListener('click',()=>{
    STATE.failures.MALICIOUS=0;
    STATE.failures.STATIC=0;
    ...
```

That tally is not the panel's to rewrite. **Four PRIMARY campaign objectives grade on it** — L5 `fail_under_5_pct`, L9 `fail_under_10_pct`, L11 `no_leaks`, L23 `fail_under_12_pct` — plus eight bonus objectives, and the debrief's run report counts it.

So one click on a small link turned a lost level into a won one. Level 11 is the clearest case, verified with the real button:

```
maliciousBefore: 7   maliciousAfter: 0
objectiveBefore: false   objectiveAfter: true
```

The level whose entire subject is having the Firewall up **before** the wave — so that nothing ever gets through — was beatable by hiding the evidence afterwards.

## This was already known to be a hazard

`src/achievements/achievements.js` watches the failure tally for **increases only**, and its comment names this exact button: *"a decrease updates the watermark without ever moving the clean-window start backward, so clearing the panel cannot fake `clean_two_minutes`."*

The achievements engine was hardened. The campaign evaluator and the debrief never were.

## The fix

Clear now records a **view preference** — how many failures had been seen when the player dismissed the panel — instead of erasing history. One change fixes the objectives, the debrief and the achievements watermark together.

The button stays useful: the panel is dismissed, and comes back the moment something new fails. It then shows the **true running tally**, not a count-since-last-click — which would make the panel's own `N total` label a lie, and this repo does not ship those.

## On the tests

The renderer's half is driven through `animate()` itself, by stubbing `requestAnimationFrame` before importing `game.js` and calling the real frame callback.

That is not decoration. My first version asserted only that the click hides the panel — and it **passed even when I reverted the renderer**, because the click hides the panel directly. That mutation escaping is exactly how this button could quietly become useless again. Two tests now catch it.

Three mutations, all caught: zeroing the counters again (4 tests red), ignoring the dismissal in the renderer (2 red), and letting a dismissal survive into the next run (1 red).