### PR TITLE
GOODPUT read 100% green in campaign however late every answer was

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (42 test files, 928 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (42 test files, 933 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/index.html
+++ b/index.html
@@ -198,7 +198,8 @@
              an idle board has no goodput, and printing 100% for "nothing
              happened" is the exact lie reputation already tells. -->
         <div class="flex justify-between items-center pt-2">
-          <span data-i18n="goodput_label" class="text-gray-400 text-sm" title="">GOODPUT (30s)</span>
+          <span data-i18n="goodput_label" data-i18n-title="goodput_hint" class="text-gray-400 text-sm"
+                title="Share of the last 30 seconds of demand answered while someone still wanted it.">GOODPUT (30s)</span>
           <span id="goodput-display" class="text-gray-500 font-mono text-lg font-bold">--</span>
         </div>
       </div>

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -216,6 +216,11 @@ function updateScore(req, outcome) {
         // back by reputation and by the SLOW badge.
         if (req.sloSec && req.age > req.sloSec) {
             STATE.lateCompletions = (STATE.lateCompletions || 0) + 1;
+            // The OBSERVATION that this answer missed its deadline, kept
+            // separate from req.wasLate below, which is the PRICE. Anything
+            // that merely reports what happened reads this one; anything the
+            // simulation feeds back off reads wasLate and stays survival-only.
+            req.pastSlo = true;
         }
         if (STATE.gameMode === "survival" && req.sloSec && req.age > req.sloSec) {
             // Decay toward a floor over one further SLO of lateness, so the
@@ -280,8 +285,18 @@ function finishRequest(req, viaServiceType, service) {
     }
     updateScore(req, "COMPLETED");
     // Rolling goodput (#261): an answer nobody was waiting for any more is
-    // not a win. Recorded after updateScore, which owns the wasLate verdict.
-    recordOutcome(req.wasLate ? "late" : "onTime");
+    // not a win. Recorded after updateScore, which owns both verdicts.
+    //
+    // pastSlo, NOT wasLate. wasLate is the priced flag and is survival-only
+    // on purpose — reputation and the SLOW badge read it back, so setting it
+    // elsewhere would move balance in twenty-five tuned levels. Goodput only
+    // REPORTS, so it takes the mode-independent observation, exactly like
+    // STATE.lateCompletions does for the debrief. Reading wasLate here pinned
+    // the headline HUD number at 100% green in campaign and sandbox however
+    // late every answer was: the same board measured survival 0%, campaign
+    // 100%. That is the #257 shape again — true about the variable, false
+    // about the room.
+    recordOutcome(req.pastSlo ? "late" : "onTime");
     // The badge is spawned AFTER scoring and reads the flag updateScore set,
     // so it can never change which requests are late — it only tells the
     // player which node made them wait (#156 inertness contract).

--- a/tests/i18n-usage.test.mjs
+++ b/tests/i18n-usage.test.mjs
@@ -26,6 +26,26 @@ function collectSources() {
 const CALL_RE = /i18n\.t\(\s*['"]([^'"]+)['"]/g;
 const ATTR_RE = /data-i18n(?:-title|-placeholder)?=["']([^"']+)["']/g;
 
+import { readFileSync as readIndex } from "node:fs";
+
+describe("a tooltip that exists is a tooltip a player can read", () => {
+  const INDEX = readIndex(new URL("../index.html", import.meta.url), "utf8");
+
+  it("no element carries an EMPTY title — that suppresses the tooltip entirely", () => {
+    // How the GOODPUT readout shipped with no explanation: the label had
+    // `title=""`, applyTranslations only fills titles on elements carrying
+    // data-i18n-title, and the empty string stands rather than falling back
+    // to anything. The one sentence written to explain the headline number
+    // was translated into eleven locales and never reached a player.
+    const empties = [...INDEX.matchAll(/<[a-zA-Z][^>]*\btitle=""[^>]*>/g)].map((m) => m[0]);
+    expect(empties, `remove title="" or give it text: ${empties.join(" | ")}`).toEqual([]);
+  });
+
+  it("the goodput hint is wired to the label, not just written", () => {
+    expect(INDEX).toMatch(/data-i18n-title="goodput_hint"/);
+  });
+});
+
 describe("i18n key usage", () => {
   it("every statically-referenced key exists in en", () => {
     const missing = [];

--- a/tests/sim/goodput.test.mjs
+++ b/tests/sim/goodput.test.mjs
@@ -13,6 +13,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { STATE, CONFIG, resetWorld, place, connect } from "../helpers/sim-world.mjs";
 import { Request } from "../../src/entities/Request.js";
+import { getRollingGoodput, metricsTick, resetMetrics } from "../../src/core/metrics.js";
 import { finishRequest } from "../../src/core/actions.js";
 import { mulberry32, REFERENCE_MIX, frame } from "../helpers/reference-board.mjs";
 
@@ -177,6 +178,70 @@ describe("a late completion is worth less (#248)", () => {
     }
     expect(STATE.lateCompletions).toBe(4);
     expect(STATE.lateCompletions).toBeLessThanOrEqual(STATE.requestsProcessed);
+  });
+
+  it("GOODPUT IS A REPORT, NOT A PRICE: it sees lateness in every mode", () => {
+    // The headline HUD number read the priced flag (req.wasLate), which is
+    // survival-only by design. So the same board — every answer three SLOs
+    // late — measured 0% in survival and 100% GREEN in campaign and sandbox.
+    // The one number meant to separate "healthy" from "drowning" said the
+    // opposite of the truth for two of the three modes.
+    const measure = (mode) => {
+      resetWorld({ gameMode: mode });
+      resetMetrics();
+      const db = place("db");
+      for (let i = 0; i < 10; i++) {
+        const req = new Request("READ");
+        STATE.requests.push(req);
+        req.age = SLO * 3;
+        finishRequest(req, db.type, db);
+      }
+      metricsTick(0.5);
+      return getRollingGoodput();
+    };
+    const survival = measure("survival");
+    const campaign = measure("campaign");
+    const sandbox = measure("sandbox");
+    expect(survival).toBe(0);
+    expect(campaign, "campaign read 100% while every answer was late").toBe(survival);
+    expect(sandbox, "sandbox read 100% while every answer was late").toBe(survival);
+  });
+
+  it("...and a PUNCTUAL board still reads 100% in every mode", () => {
+    // The mirror. A fix that simply buckets everything as late would satisfy
+    // the test above and be just as wrong.
+    for (const mode of ["survival", "campaign", "sandbox"]) {
+      resetWorld({ gameMode: mode });
+      resetMetrics();
+      const db = place("db");
+      for (let i = 0; i < 10; i++) {
+        const req = new Request("READ");
+        STATE.requests.push(req);
+        req.age = SLO - 0.5;
+        finishRequest(req, db.type, db);
+      }
+      metricsTick(0.5);
+      expect(getRollingGoodput(), `${mode} punished a board that was on time`).toBe(1);
+    }
+  });
+
+  it("the PRICE stays survival-only — the report moving must not move balance", () => {
+    // pastSlo is the observation; wasLate is what reputation and the SLOW
+    // badge read back. If the fix had set wasLate in every mode instead, it
+    // would have re-priced twenty-five tuned campaign levels.
+    resetWorld({ gameMode: "campaign" });
+    const db = place("db");
+    const req = new Request("READ");
+    STATE.requests.push(req);
+    req.age = SLO * 5;
+    const before = { money: STATE.money, rep: STATE.reputation };
+    finishRequest(req, db.type, db);
+    expect(req.wasLate).toBeUndefined();
+    expect(req.pastSlo).toBe(true);
+    expect(STATE.money - before.money).toBeCloseTo(CONFIG.trafficTypes.READ.reward, 5);
+    expect(STATE.reputation - before.rep).toBeCloseTo(
+      CONFIG.survival.SCORE_POINTS.SUCCESS_REPUTATION, 5
+    );
   });
 
   it("...but the campaign DEBRIEF still counts it, or it reports a lie", () => {


### PR DESCRIPTION
928 → **933 tests**. Against `9937970`, the goodput HUD merged an hour ago.

## The defect

```js
recordOutcome(req.wasLate ? "late" : "onTime");
```

`req.wasLate` is assigned only inside the survival-gated block — because `wasLate` is the **price**, and it is survival-only on purpose: reputation and the SLOW badge read it back, so setting it elsewhere would re-price twenty-five tuned levels.

Goodput does not price anything. It **reports**. Reading the priced flag pinned it at `1.0` wherever the flag is never set. Measured on one board whose every answer arrives three SLOs late:

```
survival 0%    campaign 100%    sandbox 100%
```

Byte-identical simulations — and the number is not a property of the board at all, it is a property of which menu item the player picked. The one readout meant to separate *healthy* from *drowning* said the opposite of the truth in two modes out of three, in the green that means you're fine.

## It is the #257 shape, and #257 left the note

Four lines above the bug, from the debrief fix earlier today:

> *The COUNT is taken in every mode... NOT counting it made the debrief claim 100% on time for a board where every request stood in a queue past its SLO. The PRICE below stays survival-only, because `req.wasLate` is read back by reputation and by the SLOW badge.*

An **observation** must be mode-independent; a **price** must not. `req.pastSlo` is now that observation, sitting beside `STATE.lateCompletions`, which already had it. `wasLate` is untouched.

## The tests

Three, and the middle one is the load-bearing one: **a fix that simply bucketed everything as `late` would satisfy the first test and be just as wrong**, so a punctual board is pinned at 100% in every mode too. The third pins the money and reputation that prove the price did not move.

Mutations: reading `wasLate` again kills the first; bucketing everything late kills the second; setting `wasLate` in every mode kills the third **and** `"campaign play is untouched"` from #257.

## The tooltip, while I was here

`goodput_hint` was written and translated into **eleven locales**, and `index.html` carried `title=""` with no `data-i18n-title`. `applyTranslations` only fills titles on elements with that attribute, so the empty string stood — and the one sentence explaining the game's newest headline number reached nobody. It was the only empty `title` in the file, and a test keeps it that way.

**Noted, not fixed:** three more tooltips (`Clear all`, `Music`, `SFX`) are hardcoded English in an eleven-locale game. Wiring them needs three new strings translated eleven times, which is not this change's business.