### PR TITLE
fix: the third star was unreachable on eleven levels (#256)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (42 test files, 935 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (43 test files, 946 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/index.html
+++ b/index.html
@@ -1700,7 +1700,10 @@
       <div class="glass-panel rounded-2xl p-8 max-w-md w-full text-center border border-gray-600">
         <div id="campaign-debrief-icon" class="text-6xl mb-2"></div>
         <h2 id="campaign-debrief-title" class="text-3xl font-bold mb-2 text-white"></h2>
-        <div id="campaign-debrief-stars" class="text-3xl mb-4"></div>
+        <div id="campaign-debrief-stars" class="text-3xl mb-1"></div>
+        <!-- Why the third star is missing (#256). The screen showed the empty
+             star and never said what would fill it. -->
+        <p id="campaign-debrief-star-hint" class="text-gray-500 mb-3 text-xs"></p>
         <p id="campaign-debrief-reason" class="text-gray-400 mb-3 text-sm"></p>
         <div class="bg-blue-900/30 border border-blue-500/40 rounded-lg p-3 mb-6 text-left">
           <div class="text-blue-400 text-xs font-bold uppercase mb-1">💡 Tip</div>

--- a/src/campaign/campaign.js
+++ b/src/campaign/campaign.js
@@ -287,12 +287,39 @@ export class CampaignController {
         const level = STATE.campaign.level;
         let stars = 1; // base for completion
 
-        // +1 if any bonus objective met
-        const anyBonus = level.objectives.bonus.some((o) => STATE.campaign.bonusResults[o.id]);
-        if (anyBonus) stars++;
+        const bonuses = level.objectives.bonus || [];
+        const met = bonuses.filter((o) => STATE.campaign.bonusResults[o.id]).length;
 
-        // +1 if speedrun (finished under durationSec * 0.8)
-        if (STATE.elapsedGameTime <= level.durationSec * 0.8) stars++;
+        // +1 if any bonus objective met
+        if (met > 0) stars++;
+
+        // +1 for doing MORE than finishing — by speed, or by completeness.
+        //
+        // Speed alone could not carry this star (#256). A level ends the
+        // instant its primaries all pass, so on the eleven levels whose
+        // primary is `survive_Ns` the earliest possible win is exactly N and
+        // the star wanted 0.8N: unreachable by any play, however perfect, and
+        // with it went cache_master, replica_master, search_master and
+        // completionist. "Hold the line for sixty seconds" cannot be rushed,
+        // so on those levels the third star has to mean something else.
+        //
+        // Every bonus met is that something else, and it costs nothing to
+        // read: both bonus objectives are already listed on screen. It also
+        // gives the second bonus a purpose for the first time — under the old
+        // rule the first bonus bought a star and the second bought nothing.
+        //
+        // Strictly additive: this only ever adds a path, so no run that
+        // scored three stars before scores fewer now, and no saved star is
+        // revoked (_persistWin keeps the max).
+        //
+        // The `>= 2` guard is what keeps the star earned. With a single bonus,
+        // "any" and "every" are the same condition and the third star would
+        // fall out with the second. A future level that has one bonus AND a
+        // time-gated primary must grow a second bonus instead — the
+        // reachability walk in campaign-stars.test.mjs fails until it does.
+        const fast = STATE.elapsedGameTime <= level.durationSec * 0.8;
+        const flawless = bonuses.length >= 2 && met === bonuses.length;
+        if (fast || flawless) stars++;
 
         return Math.min(3, stars);
     }

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -978,6 +978,7 @@ export const DE_TRANSLATIONS = {
     "campaign_level_failed": "LEVEL GESCHEITERT",
     "campaign_completed_in": "Abgeschlossen in {sec}s",
     "campaign_objectives_not_met": "Ziele nicht erreicht",
+    "campaign_third_star_hint": "Dritter Stern: alle Bonus-Ziele oder ein Abschluss unter {sec}s.",
     "campaign_fail_rep": "Reputation unter {n}% gefallen",
     "campaign_fail_money": "Geld unter ${n} gefallen",
     "campaign_fail_timeout": "Zeit abgelaufen",

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -979,6 +979,7 @@ export const EN_TRANSLATIONS = {
     "campaign_level_failed": "LEVEL FAILED",
     "campaign_completed_in": "Completed in {sec}s",
     "campaign_objectives_not_met": "Objectives not met",
+    "campaign_third_star_hint": "Third star: every bonus objective, or a finish under {sec}s.",
     "campaign_fail_rep": "Reputation dropped below {n}%",
     "campaign_fail_money": "Money dropped below ${n}",
     "campaign_fail_timeout": "Ran out of time",

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -978,6 +978,7 @@ export const FR_TRANSLATIONS = {
     "campaign_level_failed": "ÉCHEC DU NIVEAU",
     "campaign_completed_in": "Terminé en {sec} s",
     "campaign_objectives_not_met": "Objectifs non atteints",
+    "campaign_third_star_hint": "Troisième étoile : tous les objectifs bonus, ou une victoire en moins de {sec} s.",
     "campaign_fail_rep": "Réputation tombée sous {n} %",
     "campaign_fail_money": "Argent tombé sous ${n}",
     "campaign_fail_timeout": "Temps épuisé",

--- a/src/locales/hi.js
+++ b/src/locales/hi.js
@@ -1013,6 +1013,7 @@ export const HI_TRANSLATIONS = {
     "campaign_level_failed": "LEVEL विफल",
     "campaign_completed_in": "{sec}s में पूरा",
     "campaign_objectives_not_met": "लक्ष्य पूरे नहीं हुए",
+    "campaign_third_star_hint": "तीसरा star: सारे bonus लक्ष्य, या {sec}s से कम में finish.",
     "campaign_fail_rep": "Reputation {n}% से नीचे गिर गई",
     "campaign_fail_money": "पैसा ${n} से नीचे गिर गया",
     "campaign_fail_timeout": "समय खत्म हो गया",

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -978,6 +978,7 @@ export const IT_TRANSLATIONS = {
     "campaign_level_failed": "LIVELLO FALLITO",
     "campaign_completed_in": "Completato in {sec}s",
     "campaign_objectives_not_met": "Obiettivi non raggiunti",
+    "campaign_third_star_hint": "Terza stella: tutti gli obiettivi bonus, oppure chiudere sotto i {sec}s.",
     "campaign_fail_rep": "Reputazione scesa sotto il {n}%",
     "campaign_fail_money": "Denaro sceso sotto ${n}",
     "campaign_fail_timeout": "Tempo scaduto",

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -978,6 +978,7 @@ export const KO_TRANSLATIONS = {
     "campaign_level_failed": "레벨 실패",
     "campaign_completed_in": "{sec}초 만에 클리어",
     "campaign_objectives_not_met": "목표를 달성하지 못했습니다",
+    "campaign_third_star_hint": "세 번째 별: 보너스 목표 전부, 또는 {sec}초 이내 클리어.",
     "campaign_fail_rep": "평판이 {n}% 아래로 떨어졌습니다",
     "campaign_fail_money": "돈이 ${n} 아래로 떨어졌습니다",
     "campaign_fail_timeout": "시간이 초과되었습니다",

--- a/src/locales/nep.js
+++ b/src/locales/nep.js
@@ -978,6 +978,7 @@ export const NE_TRANSLATIONS = {
     "campaign_level_failed": "लेभल असफल",
     "campaign_completed_in": "{sec} से मा पूरा भयो",
     "campaign_objectives_not_met": "उद्देश्यहरू पूरा भएनन्",
+    "campaign_third_star_hint": "तेस्रो तारा: सबै bonus उद्देश्य, वा {sec} से भित्र सक्नु।",
     "campaign_fail_rep": "प्रतिष्ठा {n}% भन्दा तल झर्‍यो",
     "campaign_fail_money": "पैसा ${n} भन्दा तल झर्‍यो",
     "campaign_fail_timeout": "समय सकियो",

--- a/src/locales/pt-BR.js
+++ b/src/locales/pt-BR.js
@@ -978,6 +978,7 @@ export const PT_BR_TRANSLATIONS = {
     "campaign_level_failed": "FALHA NO NÍVEL",
     "campaign_completed_in": "Concluído em {sec}s",
     "campaign_objectives_not_met": "Objetivos não atendidos",
+    "campaign_third_star_hint": "Terceira estrela: todos os objetivos bônus, ou terminar em menos de {sec}s.",
     "campaign_fail_rep": "A reputação caiu abaixo de {n}%",
     "campaign_fail_money": "O dinheiro caiu abaixo de ${n}",
     "campaign_fail_timeout": "O tempo acabou",

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -978,6 +978,7 @@ export const RU_TRANSLATIONS = {
     "campaign_level_failed": "УРОВЕНЬ ПРОВАЛЕН",
     "campaign_completed_in": "Пройден за {sec} с",
     "campaign_objectives_not_met": "Цели не выполнены",
+    "campaign_third_star_hint": "Третья звезда: все бонусные цели или финиш быстрее {sec} с.",
     "campaign_fail_rep": "Репутация упала ниже {n}%",
     "campaign_fail_money": "Деньги упали ниже ${n}",
     "campaign_fail_timeout": "Время вышло",

--- a/src/locales/uk.js
+++ b/src/locales/uk.js
@@ -961,6 +961,7 @@ export const UK_TRANSLATIONS = {
     "campaign_level_failed": "РІВЕНЬ ПРОВАЛЕНО",
     "campaign_completed_in": "Пройдено за {sec} с",
     "campaign_objectives_not_met": "Цілі не виконано",
+    "campaign_third_star_hint": "Третя зірка: усі бонусні цілі або фініш швидше за {sec} с.",
     "campaign_fail_rep": "Репутація впала нижче {n}%",
     "campaign_fail_money": "Баланс упав нижче ${n}",
     "campaign_fail_timeout": "Час вийшов",

--- a/src/locales/zh.js
+++ b/src/locales/zh.js
@@ -978,6 +978,7 @@ export const ZH_TRANSLATIONS = {
     "campaign_level_failed": "关卡失败",
     "campaign_completed_in": "用时 {sec} 秒",
     "campaign_objectives_not_met": "目标未达成",
+    "campaign_third_star_hint": "第三颗星：完成全部奖励目标，或在 {sec} 秒内通关。",
     "campaign_fail_rep": "声誉跌破 {n}%",
     "campaign_fail_money": "资金跌破 ${n}",
     "campaign_fail_timeout": "时间耗尽",

--- a/src/ui/campaign-ui.js
+++ b/src/ui/campaign-ui.js
@@ -369,6 +369,7 @@ function showCampaignDebrief(outcome, reason, level) {
     const iconEl = document.getElementById("campaign-debrief-icon");
     const starsEl = document.getElementById("campaign-debrief-stars");
     const reasonEl = document.getElementById("campaign-debrief-reason");
+    const starHintEl = document.getElementById("campaign-debrief-star-hint");
     const tipEl = document.getElementById("campaign-debrief-tip");
     const nextBtn = document.getElementById("campaign-debrief-next-btn");
 
@@ -378,6 +379,18 @@ function showCampaignDebrief(outcome, reason, level) {
         titleEl.textContent = i18n.t("campaign_level_complete");
         titleEl.className = "text-3xl font-bold mb-2 text-green-400";
         starsEl.textContent = "★".repeat(stars) + "☆".repeat(3 - stars);
+        // Say what the empty star wants (#256). Both paths are named because
+        // both are real: on a level that ends on a timer the speed bar is out
+        // of reach and the bonus sweep is the way in, and seeing the two side
+        // by side is how the player works that out.
+        if (starHintEl) {
+            starHintEl.textContent =
+                stars < 3
+                    ? i18n.t("campaign_third_star_hint", {
+                          sec: Math.round(level.durationSec * 0.8),
+                      })
+                    : "";
+        }
         reasonEl.textContent = i18n.t("campaign_completed_in", { sec: Math.round(STATE.elapsedGameTime) });
         tipEl.textContent = levelText(level.id, "debrief");
 
@@ -389,6 +402,7 @@ function showCampaignDebrief(outcome, reason, level) {
         titleEl.textContent = i18n.t("campaign_level_failed");
         titleEl.className = "text-3xl font-bold mb-2 text-red-400";
         starsEl.textContent = "";
+        if (starHintEl) starHintEl.textContent = "";
         // The sim layer reports WHY as { key, vars } (campaign.js knows no
         // display text); the boundary translates at render time so a locale
         // switch between death and debrief still shows the right language.

--- a/tests/sim/campaign-stars.test.mjs
+++ b/tests/sim/campaign-stars.test.mjs
@@ -1,0 +1,319 @@
+// The third star, and whether any play can reach it (#256).
+//
+// The formula was covered and correct; what nothing covered was whether a
+// real level could satisfy it. A level ends the instant its primaries all
+// pass, so on the eleven levels whose primary is `survive_Ns` the earliest
+// possible win is exactly N — and the third star wanted 0.8N. `N <= 0.8N` is
+// false for every positive N, so those levels capped at two stars however
+// perfectly they were played, and cache_master, replica_master, search_master
+// and completionist went with them.
+//
+// Two kinds of check live here, and they answer different questions:
+//   1. The WALK is arithmetic. It asks, for every shipped level, whether any
+//      path to the third star is structurally open. It is the regression
+//      guard: the next `survive_*` primary re-closes this silently otherwise.
+//   2. The PROOFS are simulation. They play the three levels that gate an
+//      achievement through the real path and land three stars. Arithmetic
+//      cannot tell you a bonus pair is reachable; only a run can.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { achievements } from "../../src/achievements/achievements.js";
+import { CAMPAIGN_LEVELS } from "../../src/campaign/levels.js";
+import { spawnRequest } from "../../src/core/actions.js";
+import { createConnection, createService } from "../../src/sim/topology.js";
+import { startCampaignLevel } from "../../src/ui/campaign-ui.js";
+import { STATE, resetWorld } from "../helpers/sim-world.mjs";
+
+const CAMPAIGN_KEY = "serverSurvivalCampaignProgress";
+
+// ---------------------------------------------------------------- the walk
+
+// A state stub that varies in ONE dimension: game time. Everything else reads
+// as an untouched board, so a check that ignores the clock answers the same at
+// every t and registers no floor.
+function stubAt(t) {
+    return {
+        elapsedGameTime: t,
+        reputation: 100,
+        money: 1000,
+        netProfit: 0,
+        failures: {},
+        services: [],
+        requests: [],
+        campaign: {
+            completedByType: {},
+            completedByService: {},
+            objectiveResults: {},
+            bonusResults: {},
+            upgradesPerformed: 0,
+        },
+    };
+}
+
+/**
+ * The earliest game time at which this objective could possibly pass, as far
+ * as the clock alone decides it.
+ *
+ * Deliberately narrow: it detects a PURE time gate — a check that is false at
+ * t=0, flips true at some t, and stays true. That is the shape that caused
+ * #256 (`(s) => s.elapsedGameTime >= 60`). A check that needs a built board
+ * reads false at every probed t and reports no floor, which is the honest
+ * answer — this probe measures the clock, not winnability.
+ */
+function timeFloor(check, maxT) {
+    const at = (t) => {
+        try {
+            return !!check(stubAt(t));
+        } catch {
+            return false;
+        }
+    };
+    if (at(0)) return 0;
+    for (let t = 0.5; t <= maxT; t += 0.5) {
+        if (at(t)) return t;
+    }
+    return 0;
+}
+
+function classify(level) {
+    const floors = level.objectives.primary.map((o) => timeFloor(o.check, level.durationSec));
+    const earliestWin = floors.length ? Math.max(...floors) : 0;
+    const speedBar = level.durationSec * 0.8;
+    return {
+        id: level.id,
+        durationSec: level.durationSec,
+        earliestWin,
+        speedBar,
+        speedReachable: earliestWin <= speedBar,
+        bonusCount: level.objectives.bonus.length,
+    };
+}
+
+describe("every level can be three-starred by SOME play (#256)", () => {
+    const rows = CAMPAIGN_LEVELS.map(classify);
+
+    it("no level is left without a path to the third star", () => {
+        // Asks the SHIPPED formula, not a restatement of it: hand it the best
+        // a perfect player could present — every bonus met, the win landing at
+        // the earliest moment the clock allows — and see what it pays.
+        const unreachable = [];
+        for (const level of CAMPAIGN_LEVELS) {
+            const { earliestWin } = classify(level);
+            STATE.campaign.level = level;
+            STATE.campaign.bonusResults = Object.fromEntries(
+                level.objectives.bonus.map((o) => [o.id, true])
+            );
+            STATE.elapsedGameTime = earliestWin;
+            const stars = globalThis.window.campaign._calculateStars();
+            if (stars < 3) unreachable.push(`L${level.id} (best possible: ${stars})`);
+        }
+        expect(unreachable, "a perfect run must be able to score three stars").toEqual([]);
+    });
+
+    it("names the levels that speed alone cannot carry — the reason the rule changed", () => {
+        const timeGated = rows.filter((r) => !r.speedReachable);
+        console.log(
+            "\nspeed star unreachable on:\n" +
+                timeGated
+                    .map(
+                        (r) =>
+                            `  L${String(r.id).padStart(2)}  wins no earlier than ${r.earliestWin}s, ` +
+                            `star wanted <= ${r.speedBar}s  (${r.bonusCount} bonuses carry it now)`
+                    )
+                    .join("\n")
+        );
+        // Measured on the shipped levels: eleven are hard-blocked. This is not
+        // a target to preserve — it is a statement of today's board, and it
+        // exists so a change in the level set is noticed rather than absorbed.
+        expect(timeGated.length).toBeGreaterThanOrEqual(11);
+        for (const r of timeGated) expect(r.bonusCount).toBeGreaterThanOrEqual(2);
+    });
+
+    it("the walk actually detects a time gate — it is not reporting zeroes", () => {
+        // Guards the probe itself. If stubAt() ever drifts out of shape the
+        // checks would all throw, every floor would read 0, and the walk above
+        // would pass by seeing nothing at all.
+        const l4 = rows.find((r) => r.id === 4);
+        expect(l4.earliestWin).toBe(60);
+        expect(l4.speedReachable).toBe(false);
+    });
+});
+
+// -------------------------------------------------------------- the proofs
+
+function mulberry32(seed) {
+    let a = seed >>> 0;
+    return function () {
+        a |= 0;
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+const REAL_RANDOM = Math.random;
+
+// One frame of animate()'s sim-relevant work, in animate()'s order.
+function frame(dt) {
+    STATE.elapsedGameTime += dt;
+    if (globalThis.window.campaign?.active) globalThis.window.campaign.tick(dt);
+    STATE.services.forEach((s) => s.update(dt));
+    STATE.requests.slice().forEach((r) => r.update(dt));
+    STATE.spawnTimer += dt;
+    const rps = STATE.currentRPS * (STATE.intervention?.trafficBurstMultiplier || 1.0);
+    if (rps > 0) {
+        const iv = 1 / rps;
+        while (STATE.spawnTimer >= iv) {
+            STATE.spawnTimer -= iv;
+            spawnRequest();
+        }
+    }
+    STATE.reputation = Math.min(100, STATE.reputation);
+    achievements.tick(dt);
+}
+
+function placeAt(type, x, z) {
+    const before = STATE.services.length;
+    createService(type, new globalThis.THREE.Vector3(x, 0, z));
+    if (STATE.services.length === before) throw new Error(`placement of ${type} failed`);
+    return STATE.services[STATE.services.length - 1];
+}
+
+function svc(type) {
+    return STATE.services.find((s) => s.type === type);
+}
+
+/** Plays a level to its end with the given build and reports the scoring. */
+function play(levelId, seed, build) {
+    resetWorld();
+    globalThis.localStorage.setItem(
+        CAMPAIGN_KEY,
+        JSON.stringify({ version: 1, completed: {}, highestUnlocked: 25 })
+    );
+    STATE.animationId = 1; // keep resetGame from starting the real rAF loop
+    Math.random = mulberry32(seed);
+    startCampaignLevel(levelId);
+    build();
+    for (let t = 0; t < 400 && !STATE.campaign.ended; t += 0.1) frame(0.1);
+    return {
+        outcome: STATE.campaign.outcome,
+        elapsed: STATE.elapsedGameTime,
+        stars: globalThis.window.campaign._calculateStars(),
+        bonuses: { ...STATE.campaign.bonusResults },
+        failures: Object.values(STATE.failures).reduce((a, b) => a + b, 0),
+        speedBar: STATE.campaign.level.durationSec * 0.8,
+    };
+}
+
+/** What every one of these proofs must show: a perfect run, scored 3, NOT by speed. */
+function expectThreeStarsWithoutSpeed(r) {
+    expect(r.outcome).toBe("win");
+    expect(r.stars).toBe(3);
+    expect(Object.values(r.bonuses).every(Boolean)).toBe(true);
+    // The point of the fix: this run is SLOWER than the speed bar it could
+    // never have beaten, and the third star arrives anyway. Under the old rule
+    // this identical run scored 2.
+    expect(r.elapsed).toBeGreaterThan(r.speedBar);
+}
+
+beforeEach(() => {
+    resetWorld();
+    achievements._reloadForTests();
+});
+afterEach(() => {
+    Math.random = REAL_RANDOM;
+});
+
+describe("the three achievement-gating levels, three-starred through the real path", () => {
+    // Each build is the level's own briefed lesson, bought inside its budget,
+    // and each was measured across seeds before being pinned here.
+
+    it("L4 cache_master — cache-aside plus the Compute tier that pays for it", () => {
+        // $60 cache + $100 upgrade of $200. The cache alone loses half its
+        // seeds: Compute runs at ~90% of its throughput ceiling at 6 rps, so
+        // it cooks itself before the cache can matter.
+        for (const seed of [1, 2, 3, 42]) {
+            const r = play(4, seed, () => {
+                const compute = svc("compute");
+                const cache = placeAt("cache", 5, 8);
+                createConnection(compute.id, cache.id);
+                createConnection(cache.id, svc("db").id);
+                compute.upgrade();
+            });
+            expect(r.failures, `seed ${seed}`).toBe(0);
+            expectThreeStarsWithoutSpeed(r);
+        }
+    });
+
+    it("L6 replica_master — a replica needs a master AND the miss traffic", () => {
+        // Compute only diverts READs to a replica once the Cache is past 60%
+        // load, which never happens here. The replica earns its half from the
+        // cache MISS cascade instead, and it must be wired to the DB or every
+        // read routed to it fails NO_MASTER.
+        for (const seed of [1, 2, 3, 42]) {
+            const r = play(6, seed, () => {
+                const compute = svc("compute");
+                const replica = placeAt("replica", 12, 10);
+                createConnection(replica.id, svc("db").id);
+                createConnection(svc("cache").id, replica.id);
+                compute.upgrade();
+            });
+            expect(r.failures, `seed ${seed}`).toBe(0);
+            expectThreeStarsWithoutSpeed(r);
+        }
+    });
+
+    it("L7 search_master — a search node plus the Compute tier", () => {
+        // 60% of this level's traffic is SEARCH, which Compute hands straight
+        // to a connected search node.
+        for (const seed of [1, 2, 3, 42]) {
+            const r = play(7, seed, () => {
+                const compute = svc("compute");
+                const search = placeAt("search", 12, -10);
+                createConnection(compute.id, search.id);
+                compute.upgrade();
+            });
+            expect(r.failures, `seed ${seed}`).toBe(0);
+            expectThreeStarsWithoutSpeed(r);
+        }
+    });
+});
+
+describe("the rule stays honest at the edges", () => {
+    function synthetic({ durationSec, bonuses, met, elapsed }) {
+        STATE.campaign.level = {
+            durationSec,
+            objectives: { primary: [], bonus: bonuses.map((id) => ({ id })) },
+        };
+        STATE.campaign.bonusResults = Object.fromEntries(met.map((id) => [id, true]));
+        STATE.elapsedGameTime = elapsed;
+        return globalThis.window.campaign._calculateStars();
+    }
+
+    it("one bonus does NOT hand over the third star with the second", () => {
+        // With a single bonus, "any" and "every" are the same condition. If
+        // the flawless path ignored that, a one-bonus level would pay three
+        // stars for the same work the second star already bought.
+        expect(synthetic({ durationSec: 100, bonuses: ["b1"], met: ["b1"], elapsed: 95 })).toBe(2);
+    });
+
+    it("zero bonuses cannot be 'all met' — the empty set pays nothing", () => {
+        expect(synthetic({ durationSec: 100, bonuses: [], met: [], elapsed: 95 })).toBe(1);
+    });
+
+    it("half the bonuses is still two stars", () => {
+        expect(
+            synthetic({ durationSec: 100, bonuses: ["b1", "b2"], met: ["b1"], elapsed: 95 })
+        ).toBe(2);
+    });
+
+    it("every bonus is three, at any pace", () => {
+        expect(
+            synthetic({ durationSec: 100, bonuses: ["b1", "b2"], met: ["b1", "b2"], elapsed: 99 })
+        ).toBe(3);
+    });
+
+    it("speed still pays on its own, with a single bonus met", () => {
+        // Strictly additive: the path that already existed is untouched.
+        expect(synthetic({ durationSec: 100, bonuses: ["b1", "b2"], met: ["b1"], elapsed: 79 })).toBe(3);
+    });
+});


### PR DESCRIPTION
Closes #256.

## The defect

A level ends the moment its primary objectives all pass. Eleven levels carry a primary of the form `survive_Ns` where N is the level's whole duration, so the earliest possible win is exactly N — and the third star wanted `elapsed <= 0.8 * durationSec`. `N <= 0.8N` is false for every positive N.

Max attainable on those levels was two stars, by any play, forever. Four achievements gate on a third star in that set: `cache_master` (L4), `replica_master` (L6), `search_master` (L7), and `completionist` (every level).

The formula itself was tested and correct. What nothing tested was whether a real level could satisfy it.

## The fix

The third star means "more than finishing", and there are now two ways to show it:

- finish inside 80% of the duration (unchanged), **or**
- meet **every** bonus objective.

Both bonus objectives are already listed on screen while the level runs, so the new bar costs the player nothing to read. It also gives the second bonus a purpose for the first time — under the old rule the first bonus bought a star and the second bought nothing at all.

**Strictly additive.** The change only ever adds a path: no run that scored three stars before scores fewer now, and no saved star is revoked (`_persistWin` keeps the max). The existing `_calculateStars` unit tests pass untouched.

The `>= 2 bonuses` guard is what keeps the star earned. With a single bonus, "any" and "every" are the same condition and the third star would fall out together with the second.

The debrief now also says what the empty star wants. It used to show a hollow star and never explain it.

## Proof, not assertion

`tests/sim/campaign-stars.test.mjs` has two halves that answer different questions.

**The walk** is arithmetic. It probes each primary as a function of game time alone to find the earliest moment a level can end, then hands the shipped `_calculateStars()` the best a perfect player could present and asks what it pays. Revert the fix and it names all eleven:

```
L3 (best possible: 2), L4 (best possible: 2), L5 ... L14 (best possible: 2)
```

**The proofs** are simulation, because arithmetic cannot tell you a bonus pair is actually reachable — only a run can. Each of the three achievement-gating levels is played through the real path (`startCampaignLevel` -> `createService` -> the frame order `animate()` uses), across four seeds, landing three stars with zero failures:

| level | build (inside the level's own budget) | unblocks |
|---|---|---|
| 4 | cache-aside + the Compute tier that pays for it | `cache_master` |
| 6 | replica wired to its master, fed by cache misses | `replica_master` |
| 7 | a search node + the Compute tier | `search_master` |

Every one of those runs finishes **slower** than the speed bar it could never have beaten, and each asserts that explicitly. That is the fix in one line: these identical runs scored two stars before.

## What measuring them turned up

Worth recording, since it is the levels' real shape rather than their briefing's:

- **L4** — Compute sits at roughly 90% of its throughput ceiling at 6 rps (capacity 4, 600ms), so the cache alone loses half its seeds: Compute cooks itself before the cache can matter. The level is only stable once the $100 tier is bought alongside the $60 cache, which is exactly what the $200 budget affords.
- **L6** — Compute only diverts READs to a replica once the Cache is past 60% load, which never happens here. The replica earns its half from the cache **miss** cascade instead, and it must be wired to the DB or every read routed to it fails `NO_MASTER`.

## Verified in the browser

Level 4, won past the speed bar: `★☆☆` with the new line under it, and `★★★` with the hint gone once both bonuses are met. Checked in English and Hindi (Devanagari fits on one line), no console errors.
