### PR TITLE
Loading a save mid-level swapped the board while the level kept grading

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (42 test files, 933 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (42 test files, 935 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/src/persistence/save-load.js
+++ b/src/persistence/save-load.js
@@ -229,6 +229,22 @@ function loadGameState(saveData = null) {
         STATE.gameStartTime = performance.now();
 
         STATE.gameMode = saveData.gameMode || "survival";
+
+        // A SAVE IS A DIFFERENT RUN, so the campaign stops here — the same
+        // rule resetGame() follows, for the same reason and one path short of
+        // it. This module never saved or restored campaign state, but nothing
+        // shut the controller down either: Escape opens the pause menu during
+        // a level, "Continue Game" is offered whenever a save exists, and the
+        // load replaced the board while window.campaign kept grading it.
+        //
+        // The level's constraints go with the board it graded. Level 15 hands
+        // the player $190 and a monitor-only palette; a sandbox save carrying
+        // $4300 and a three-Compute fleet was graded against level 15's
+        // objectives and won it. Both the budget and allowedServices are
+        // bypassed, the palette gate being UI-only.
+        window.campaign?.exit();
+        STATE.campaign.level = null;
+        STATE.campaign.currentLevelId = null;
         STATE.sandboxBudget = saveData.sandboxBudget || 2000;
         STATE.upkeepEnabled = saveData.upkeepEnabled !== false;
         // Same dead-fallback pattern as score above: spread of undefined is {}.
@@ -362,7 +378,11 @@ function loadGameState(saveData = null) {
             }
         } else {
             if (sandboxPanel) sandboxPanel.classList.add("hidden");
-            if (objectivesPanel) objectivesPanel.classList.remove("hidden");
+            // ...and NOT un-hidden: this branch used to reveal the objectives
+            // panel for any non-sandbox save, which after the shutdown above
+            // means revealing the last level's goals over a run that is not
+            // playing it. A save has no campaign in it to show.
+            if (objectivesPanel) objectivesPanel.classList.add("hidden");
         }
 
         document.getElementById("main-menu-modal").classList.add("hidden");

--- a/tests/sim/campaign-lifetime.test.mjs
+++ b/tests/sim/campaign-lifetime.test.mjs
@@ -15,6 +15,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { STATE } from "../../src/state.js";
 import { resetGame } from "../../game.js";
+import { saveGameState, loadGameState } from "../../src/persistence/save-load.js";
 
 // What the campaign map writes before a level is playable.
 function unlock(upTo = 25) {
@@ -80,6 +81,47 @@ describe("a campaign level does not keep grading after you leave it", () => {
         const before = STATE.requests.length;
         for (let i = 0; i < 200; i++) frame(0.1);
         expect(STATE.requests.length, "a level's bursts fired into a survival run").toBe(before);
+    });
+
+    it("A SAVE IS A DIFFERENT RUN: loading one stops the level it landed on", () => {
+        // Escape opens the pause menu during a level, and "Continue Game" is
+        // offered whenever a save exists. save-load.js never saved or restored
+        // campaign state — but nothing shut the controller down either, so the
+        // load swapped the whole board while the level kept grading it.
+        //
+        // Level 15 hands the player $190 and a monitor-only palette. A sandbox
+        // save carrying $4300 and whatever the player felt like building was
+        // graded against level 15's objectives, and won it: both the budget
+        // and allowedServices bypassed, the palette gate being UI-only.
+        resetGame("sandbox");
+        STATE.money = 4300;
+        saveGameState();
+
+        window.startCampaignLevel(15);
+        const levelBudget = STATE.money;
+        expect(window.campaign.active).toBe(true);
+        expect(levelBudget).toBeLessThan(4300);
+
+        loadGameState();
+
+        expect(window.campaign.active, "a loaded save kept grading a level").toBe(false);
+        expect(STATE.campaign.level, "and it kept pointing at that level").toBeNull();
+        expect(STATE.money).toBe(4300);
+        // ...and a frame of the loaded run resolves nothing.
+        for (let i = 0; i < 10; i++) frame(0.1);
+        expect(STATE.campaign.ended).toBe(false);
+        expect(STATE.campaign.outcome).not.toBe("win");
+    });
+
+    it("...and the loaded run does not wear the abandoned level's objectives", () => {
+        resetGame("survival");
+        saveGameState();
+        window.startCampaignLevel(1);
+        frame(0.6);
+        loadGameState();
+        const panel = document.getElementById("objectivesPanel");
+        expect(panel.classList.contains("hidden"),
+            "a save has no campaign in it to show").toBe(true);
     });
 
     it("...but starting a campaign level still arms it — the gate is the mode, not the call", () => {


### PR DESCRIPTION
933 → **935 tests**.

`save-load.js` never saved or restored campaign state — the word *campaign* does not appear in the file. But nothing shut the controller down either, and both halves of the path are reachable:

- Escape opens the pause menu **during a campaign level** (`openMainMenu()` is unconditional)
- **Continue Game** is offered whenever a save exists

So the load replaces `STATE.services` wholesale, restores money, rps and traffic mix from the save, and `window.campaign` goes on evaluating the level's objectives against whatever arrived.

## The level's constraints go with the board it was grading

Level 15 hands the player **$190** and a monitor-only palette. Measured:

```
levelBudget: 190        moneyAfterLoad: 4300
campaignStillActive: true    stillGradingLevel: 15
```

A sandbox board — sandbox has traffic sliders and a large budget — built to whatever shape the player liked, saved, then loaded into a campaign level, and graded by it. **Both the budget and `allowedServices` are bypassed**: the palette gate is UI-only, so it never enters the picture at all.

## The fix

The same rule `resetGame()` already follows, one path short of it: **a save is a different run, so the campaign stops here.**

It also stops the loader un-hiding the objectives panel for any non-sandbox save. After the shutdown above, that branch would reveal the last level's goals over a run that is not playing it — and a save has no campaign in it to show.

Two mutations, both caught: removing the shutdown, and un-hiding the panel again.

Related to #264, which closed the pause-menu paths through `resetGame`. This is the path that does not go through `resetGame` at all.