### PR TITLE
A loaded save wore the abandoned session's failure and lateness tallies

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (43 test files, 954 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (44 test files, 957 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/src/persistence/save-load.js
+++ b/src/persistence/save-load.js
@@ -4,6 +4,8 @@
 // keeps thin window.x = importedX assignments in its ESM-boundary block.
 
 import { STATE } from "../state.js";
+import { resetMetrics } from "../core/metrics.js";
+import { resetResilience } from "../sim/circuit-breaker.js";
 import { i18n } from "../i18n.js";
 // Achievements (#158): loading a save is a session boundary — baselines must
 // re-capture from the RESTORED board (elapsedGameTime is restored below but
@@ -210,6 +212,26 @@ function loadGameState(saveData = null) {
         STATE.money = saveData.money || 0;
         STATE.reputation = saveData.reputation || 100;
         STATE.requestsProcessed = saveData.requestsProcessed || 0;
+        // The counters that PAIR with requestsProcessed. saveGameState()
+        // spreads ...STATE, so all three have always been in the file — the
+        // load simply never read them back, while requestsProcessed jumped to
+        // the save's value. The abandoned session's tallies stayed, and
+        // getRunReport's `onTime: max(0, processed - late)` then printed a
+        // debrief that contradicts itself: "Served 0 of 5 (0% on time) - 40
+        // late", forty late answers out of five requests.
+        //
+        // Fresh objects, not the parsed ones: STATE must not alias a blob the
+        // next save spreads back out. Old saves lack the keys and restore as
+        // a clean slate, which is the same thing resetGame would have given
+        // them.
+        STATE.lateCompletions = saveData.lateCompletions || 0;
+        STATE.failures = {
+            STATIC: 0, READ: 0, WRITE: 0, UPLOAD: 0,
+            SEARCH: 0, MALICIOUS: 0, INFERENCE: 0,
+            ...(saveData.failures || {}),
+        };
+        STATE.failuresByReason = { ...(saveData.failuresByReason || {}) };
+        STATE.failuresDismissedAt = saveData.failuresDismissedAt || 0;
         // A spread of undefined is {} (truthy), so `|| default` never fired —
         // an old save without this field got {} and NaN'd the score math.
         STATE.score = saveData.score ? { ...saveData.score } : {
@@ -242,6 +264,15 @@ function loadGameState(saveData = null) {
         // $4300 and a three-Compute fleet was graded against level 15's
         // objectives and won it. Both the budget and allowedServices are
         // bypassed, the palette gate being UI-only.
+        // The rolling windows cannot be restored — a ring buffer of the last
+        // thirty seconds is not in the file, and showing the ABANDONED
+        // session's last thirty seconds next to a resumed board is worse than
+        // showing nothing. resetGame calls both of these; the load path called
+        // neither, so goodput, the service peaks and the breaker state all
+        // carried over from a run the player walked away from.
+        resetMetrics();
+        resetResilience();
+
         window.campaign?.exit();
         STATE.campaign.level = null;
         STATE.campaign.currentLevelId = null;

--- a/tests/sim/save-load-boundaries.test.mjs
+++ b/tests/sim/save-load-boundaries.test.mjs
@@ -1,0 +1,103 @@
+// Loading a save is a RUN BOUNDARY, and the load path was one short of it.
+//
+// saveGameState() spreads ...STATE, so every counter has always been in the
+// file. loadGameState() restored a chosen few — requestsProcessed, score,
+// money, reputation, elapsedGameTime, finances — and left the rest holding
+// whatever the session the player walked away from had put there.
+//
+// requestsProcessed jumping back while lateCompletions did not is the one
+// that shows: getRunReport computes onTime as max(0, processed - late), so
+// the debrief printed "Served 0 of 5 (0% on time) - 40 late" — forty late
+// answers out of five requests, on the screen whose whole job is to tell the
+// player what just happened.
+//
+// The rolling windows are the other half. A thirty-second ring buffer is not
+// in the file and cannot be, so they are CLEARED rather than carried:
+// showing the abandoned session's last thirty seconds beside a resumed board
+// is worse than showing nothing, which is what an empty window renders.
+import { describe, it, expect, beforeEach } from "vitest";
+import { STATE } from "../../src/state.js";
+import { resetGame } from "../../game.js";
+import { saveGameState, loadGameState } from "../../src/persistence/save-load.js";
+import { getRunReport, getRollingGoodput, metricsTick } from "../../src/core/metrics.js";
+import { finishRequest } from "../../src/core/actions.js";
+import { Request } from "../../src/entities/Request.js";
+import { CONFIG, place } from "../helpers/sim-world.mjs";
+
+describe("a loaded save carries its own history, and only its own", () => {
+    beforeEach(() => {
+        try { localStorage.clear(); } catch { /* storage unavailable */ }
+    });
+
+    it("A LOADED RUN DOES NOT INHERIT THE ABANDONED ONE'S TALLIES", () => {
+        // saveGameState spreads ...STATE, so lateCompletions, failures and
+        // failuresByReason were always IN the file — the load just never read
+        // them back, while requestsProcessed jumped to the save's value. The
+        // debrief then contradicted itself, because getRunReport computes
+        // onTime as max(0, processed - late).
+        resetGame("survival");
+        STATE.requestsProcessed = 5;
+        saveGameState();                       // a small, clean run
+
+        STATE.requestsProcessed = 400;         // ...then a long, messy one
+        STATE.lateCompletions = 40;
+        STATE.failures.READ = 12;
+        STATE.failuresByReason = { capacity: 12 };
+
+        loadGameState();
+
+        expect(STATE.requestsProcessed).toBe(5);
+        expect(STATE.lateCompletions).toBe(0);
+        expect(STATE.failures.READ).toBe(0);
+        expect(STATE.failuresByReason).toEqual({});
+        // The invariant the debrief divides by.
+        expect(STATE.lateCompletions).toBeLessThanOrEqual(STATE.requestsProcessed);
+        const r = getRunReport();
+        expect(r.onTime + r.late).toBe(r.processed);
+    });
+
+    it("...and a run saved WITH lateness keeps it — this is a resume, not a wipe", () => {
+        // The counters are restored, not zeroed: a save is meant to resume a
+        // run faithfully, and requestsProcessed has always been restored that
+        // way. Zeroing would make a resumed run under-report its own history.
+        resetGame("survival");
+        STATE.requestsProcessed = 20;
+        STATE.lateCompletions = 6;
+        STATE.failures.WRITE = 3;
+        saveGameState();
+        resetGame("survival");                 // walk away, start fresh
+        loadGameState();
+        expect(STATE.requestsProcessed).toBe(20);
+        expect(STATE.lateCompletions).toBe(6);
+        expect(STATE.failures.WRITE).toBe(3);
+    });
+
+    it("the rolling goodput window starts empty rather than showing the old run's", () => {
+        // Not restorable and not carried: a thirty-second ring buffer is not
+        // in the file. getRollingGoodput returns null for an empty window,
+        // which the HUD renders as "--" — the honest reading for a board that
+        // has not answered anything yet.
+        resetGame("survival");
+        saveGameState();
+
+        // Fill the window with the run the player is about to walk away from:
+        // ten answers, every one of them late, so it reads a hard 0%.
+        // resetGame starts every run PAUSED and metricsTick freezes at
+        // timeScale 0 on purpose, so the clock has to be running for the
+        // window to take a sample at all.
+        STATE.timeScale = 1;
+        const db = place("db");
+        for (let i = 0; i < 10; i++) {
+            const req = new Request("READ");
+            STATE.requests.push(req);
+            req.age = CONFIG.trafficTypes.READ.sloSec * 3;
+            finishRequest(req, db.type, db);
+        }
+        metricsTick(0.5);
+        expect(getRollingGoodput(), "the window must hold something first").toBe(0);
+
+        loadGameState();
+        expect(getRollingGoodput(), "the resumed board wore the old run's goodput")
+            .toBeNull();
+    });
+});


### PR DESCRIPTION
935 → **938 tests**.

`loadGameState()` restored a chosen few counters — `requestsProcessed`, `score`, `money`, `reputation`, `elapsedGameTime`, `finances` — and left the rest holding whatever the session the player walked away from had put there.

`requestsProcessed` jumping back while `lateCompletions` did not is the one that shows. `getRunReport` computes `onTime: Math.max(0, processed - late)`, so the debrief printed a line that contradicts itself. Measured:

```
processed: 5    late: 40    onTime: 0    failures: 12
```

*"Served 0 of 5 (0% on time) · 40 late"* — forty late answers out of five requests, on the screen whose entire job is to tell the player what just happened. The failures panel and the top-reason list described the abandoned run too.

## Restored, not zeroed

`saveGameState()` spreads `...STATE`, so all three counters have **always been in the file**. The load simply never read them back.

They are restored rather than zeroed because a save is meant to *resume* a run — `requestsProcessed` has always been restored that way, and zeroing would make a resumed run under-report its own history. Fresh objects, not the parsed ones, so `STATE` never aliases a blob the next save spreads back out; old saves lack the keys and restore as the clean slate `resetGame` would have given them.

## The rolling windows are the other half

They cannot be restored: a thirty-second ring buffer is not in the file. `resetGame` calls `resetMetrics()` and `resetResilience()`; the load path called neither, so goodput, the service peaks and the breaker state all carried over from a run nobody is playing.

Cleared instead. An empty window renders as `--`, which is the honest reading for a board that has not answered anything yet — and better than showing someone else's last thirty seconds beside a resumed board.

## On the tests

Three mutations, each caught by its own test: dropping the restore, zeroing instead of restoring, and dropping `resetMetrics()`.

The third **escaped the first version of its test**, which asserted an empty goodput window on a board whose window was already empty — green either way. It now fills the window with ten late answers first, and asserts a hard 0% before the load. Worth flagging because it is the second time today a doc-or-state test of mine passed vacuously until a mutation exposed it.

Follows #268, which stopped the same load path grading a campaign level.