### PR TITLE
test: the beatability harness, and what it says about chapter 2 (#254)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (44 test files, 957 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (45 test files, 979 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/tests/helpers/campaign-play.mjs
+++ b/tests/helpers/campaign-play.mjs
@@ -1,0 +1,96 @@
+// Playing a campaign level for real, from a test.
+//
+// Extracted so proofs stop re-deriving it. The rule these helpers exist to
+// keep (the #184 discipline) is that a claim about a level must come from the
+// level as shipped: the real `startCampaignLevel` path, player placement
+// through `createService` (which is what stamps playerPlaced and charges the
+// money), and animate()'s own frame order. Nothing here touches tuning.
+import { achievements } from "../../src/achievements/achievements.js";
+import { spawnRequest } from "../../src/core/actions.js";
+import { createService } from "../../src/sim/topology.js";
+import { startCampaignLevel } from "../../src/ui/campaign-ui.js";
+import { STATE, resetWorld } from "./sim-world.mjs";
+
+const CAMPAIGN_KEY = "serverSurvivalCampaignProgress";
+
+/** Deterministic PRNG, so a pinned result documents one known line rather than a mood. */
+export function mulberry32(seed) {
+    let a = seed >>> 0;
+    return function () {
+        a |= 0;
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+export const REAL_RANDOM = Math.random;
+
+/** One frame of animate()'s sim-relevant work, in animate()'s order. */
+export function frame(dt) {
+    STATE.elapsedGameTime += dt;
+    if (globalThis.window.campaign?.active) globalThis.window.campaign.tick(dt);
+    STATE.services.forEach((s) => s.update(dt));
+    STATE.requests.slice().forEach((r) => r.update(dt));
+    STATE.spawnTimer += dt;
+    const rps = STATE.currentRPS * (STATE.intervention?.trafficBurstMultiplier || 1.0);
+    if (rps > 0) {
+        const interval = 1 / rps;
+        while (STATE.spawnTimer >= interval) {
+            STATE.spawnTimer -= interval;
+            spawnRequest();
+        }
+    }
+    // animate() clamps every frame, so a proof must too — a raw loop banks
+    // reputation above 100 and flatters every run that follows.
+    STATE.reputation = Math.min(100, STATE.reputation);
+    achievements.tick(dt);
+}
+
+/** Player placement through the real path, with the real money checks active. */
+export function placeAt(type, x, z) {
+    const before = STATE.services.length;
+    createService(type, new globalThis.THREE.Vector3(x, 0, z));
+    if (STATE.services.length === before) {
+        throw new Error(`placement of ${type} failed (money ${Math.round(STATE.money)}?)`);
+    }
+    return STATE.services[STATE.services.length - 1];
+}
+
+export const svc = (type) => STATE.services.find((s) => s.type === type);
+
+/**
+ * Starts a level, runs `build`, then plays to the level's own end.
+ * Returns what the campaign scored, never a verdict — the caller decides.
+ */
+export function play(levelId, seed, build, { capSec = 500, dt = 0.1 } = {}) {
+    resetWorld();
+    globalThis.localStorage.setItem(
+        CAMPAIGN_KEY,
+        JSON.stringify({ version: 1, completed: {}, highestUnlocked: 25 })
+    );
+    STATE.animationId = 1; // keep resetGame from starting the real rAF loop
+    Math.random = mulberry32(seed);
+    try {
+        startCampaignLevel(levelId);
+        build();
+        for (let t = 0; t < capSec && !STATE.campaign.ended; t += dt) frame(dt);
+        return {
+            level: levelId,
+            seed,
+            outcome: STATE.campaign.outcome,
+            elapsed: STATE.elapsedGameTime,
+            stars:
+                STATE.campaign.outcome === "win"
+                    ? globalThis.window.campaign._calculateStars()
+                    : 0,
+            bonuses: { ...STATE.campaign.bonusResults },
+            failures: Object.values(STATE.failures).reduce((a, b) => a + b, 0),
+            reputation: STATE.reputation,
+            speedBar: STATE.campaign.level.durationSec * 0.8,
+        };
+    } finally {
+        Math.random = REAL_RANDOM;
+    }
+}

--- a/tests/sim/beatability.test.mjs
+++ b/tests/sim/beatability.test.mjs
@@ -1,0 +1,197 @@
+// Is the lesson load-bearing? (#254)
+//
+// The repo already proves levels are WINNABLE. What it has never checked is
+// the other half of the #184 discipline: that a level is LOST when its own
+// mechanic is ignored. A level that passes without the thing it teaches is not
+// a lesson, it is a cutscene with a timer.
+//
+// Measuring that across chapter 2 turned up something the issue did not
+// predict. Two levers are available on every one of these levels: the service
+// the briefing teaches, and the $100 Compute tier (capacity 4 -> 10) that every
+// budget here can afford. Removing them one at a time says which one the level
+// actually turns on:
+//
+//   level  teaches   taught+tier  tier only  taught only  neither
+//   L3     CDN         5/5          5/5        5/5         5/5
+//   L4     Cache       5/5          5/5        2/5         2/5
+//   L5     Queue       5/5          5/5        5/5         4/5
+//   L6     Replica     5/5          5/5        0/5         0/5
+//   L7     Search      5/5          5/5        0/5         0/5
+//   L8     NoSQL       5/5          5/5        0/5         0/5
+//   L9     API GW      5/5          5/5        5/5         5/5
+//   L12    2nd WAF     5/5          0/5        0/5         0/5
+//
+// Three levels (3, 5, 9) pass on an untouched board. On three more (6, 7, 8)
+// the taught node is decorative in BOTH directions: without the tier they lose
+// even when it is correctly wired, and with the tier they win without it. The
+// cause is capacity — Compute runs 4 concurrent at 600ms, about 6.7 req/s,
+// and those levels arrive at 6-7 rps — so Compute binds before any downstream
+// store can matter. Mechanically, chapter 2 teaches "buy a bigger box".
+//
+// L12 is the counter-example: what a second WAF defends against is not
+// something more CPU absorbs, so it is load-bearing in every column.
+//
+// This file does not retune anything. Retuning shipped levels moves the
+// difficulty of a campaign people have already played, and that is a decision
+// to take deliberately. What it does is pin the table above so the hollow set
+// can only ever SHRINK, and prove the reference solutions still win.
+import { describe, it, expect, afterEach } from "vitest";
+import { achievements } from "../../src/achievements/achievements.js";
+import { createConnection } from "../../src/sim/topology.js";
+import { REAL_RANDOM, placeAt, play, svc } from "../helpers/campaign-play.mjs";
+import { STATE, resetWorld } from "../helpers/sim-world.mjs";
+
+const SEEDS = [1, 2, 42];
+
+// Each level's own briefed lesson, split into the two levers so either can be
+// withheld. `taught` places and wires the service the level is about; `tier`
+// buys the Compute upgrade.
+const tier = () => svc("compute").upgrade();
+
+const LEVELS = {
+    3: {
+        teaches: "CDN",
+        taught: () => {
+            const cdn = placeAt("cdn", -15, 12);
+            createConnection("internet", cdn.id);
+            createConnection(cdn.id, svc("s3").id);
+        },
+    },
+    4: {
+        teaches: "Cache",
+        taught: () => {
+            const cache = placeAt("cache", 5, 8);
+            createConnection(svc("compute").id, cache.id);
+            createConnection(cache.id, svc("db").id);
+        },
+    },
+    5: {
+        teaches: "Queue",
+        taught: () => {
+            const sqs = placeAt("sqs", -5, 10);
+            createConnection(svc("alb").id, sqs.id);
+            createConnection(sqs.id, svc("compute").id);
+        },
+    },
+    6: {
+        teaches: "Replica",
+        taught: () => {
+            const replica = placeAt("replica", 12, 10);
+            createConnection(replica.id, svc("db").id);
+            createConnection(svc("cache").id, replica.id);
+        },
+    },
+    7: {
+        teaches: "Search",
+        taught: () => {
+            const search = placeAt("search", 12, -10);
+            createConnection(svc("compute").id, search.id);
+        },
+    },
+    8: {
+        teaches: "NoSQL",
+        taught: () => {
+            const nosql = placeAt("nosql", 12, 10);
+            createConnection(svc("compute").id, nosql.id);
+        },
+    },
+    9: {
+        teaches: "API Gateway",
+        taught: () => {
+            const gw = placeAt("apigw", -15, 8);
+            createConnection(svc("alb").id, gw.id);
+            createConnection(gw.id, svc("compute").id);
+        },
+    },
+    12: {
+        teaches: "a second WAF",
+        taught: () => {
+            const waf2 = placeAt("waf", -20, 10);
+            createConnection("internet", waf2.id);
+            createConnection(waf2.id, svc("alb").id);
+        },
+    },
+};
+
+// Today's answer, measured. Membership means "this level still wins with its
+// own lesson withheld". The assertion below lets this set shrink and never
+// grow, so fixing a level is a one-line deletion and shipping a new hollow one
+// is a red build.
+const KNOWN_HOLLOW = new Set([3, 4, 5, 6, 7, 8, 9]);
+
+function winRate(id, build) {
+    return SEEDS.filter((seed) => play(Number(id), seed, build).outcome === "win").length;
+}
+
+afterEach(() => {
+    Math.random = REAL_RANDOM;
+    resetWorld();
+    achievements._reloadForTests();
+});
+
+describe("every reference solution wins the level it belongs to (#254)", () => {
+    for (const [id, level] of Object.entries(LEVELS)) {
+        it(`L${id} — ${level.teaches}, played as briefed`, () => {
+            expect(winRate(id, () => {
+                level.taught();
+                tier();
+            })).toBe(SEEDS.length);
+        });
+    }
+});
+
+describe("and the level is LOST when its own mechanic is ignored", () => {
+    for (const [id, level] of Object.entries(LEVELS)) {
+        const n = Number(id);
+        it(`L${id} — ${level.teaches} withheld, everything else the same`, () => {
+            const wins = winRate(id, tier);
+            if (KNOWN_HOLLOW.has(n)) {
+                // Recorded, not endorsed. The failure this guards against is a
+                // level QUIETLY joining the set — so the only thing asserted
+                // here is that the level is still in the state we wrote down.
+                expect(wins, `L${id} is recorded as hollow`).toBeGreaterThan(0);
+            } else {
+                expect(wins, `L${id}'s lesson must be load-bearing`).toBe(0);
+            }
+        });
+    }
+
+    it("the hollow set never grows", () => {
+        const measured = Object.keys(LEVELS)
+            .map(Number)
+            .filter((id) => winRate(id, tier) > 0);
+        const unexpected = measured.filter((id) => !KNOWN_HOLLOW.has(id));
+        expect(
+            unexpected,
+            "a level began passing without the service it teaches — either the " +
+                "tuning drifted or a new level shipped hollow"
+        ).toEqual([]);
+    });
+
+    it("L12 shows the shape a fixed level has", () => {
+        // Kept explicit because it is the target, not a passing detail: what a
+        // second WAF defends against cannot be absorbed by a faster box, so no
+        // amount of vertical scaling substitutes for it.
+        expect(winRate(12, tier)).toBe(0);
+        expect(winRate(12, () => { LEVELS[12].taught(); tier(); })).toBe(SEEDS.length);
+    });
+});
+
+describe("the Compute tier is the lever chapter 2 actually turns on", () => {
+    // The finding in one assertion. On these three the taught service loses on
+    // its own and the tier wins on its own — the level is a vertical-scaling
+    // exercise wearing an architecture briefing.
+    for (const id of [6, 7, 8]) {
+        it(`L${id} — ${LEVELS[id].teaches} alone loses, the tier alone wins`, () => {
+            expect(winRate(id, LEVELS[id].taught), `L${id} taught-only`).toBe(0);
+            expect(winRate(id, tier), `L${id} tier-only`).toBe(SEEDS.length);
+        });
+    }
+
+    it("three levels pass on a board the player never touched", () => {
+        const untouched = [3, 5, 9].filter((id) => winRate(id, () => {}) > 0);
+        // Asserting the defect so the fix has something to turn red. When a
+        // level here stops passing untouched, this list is what to edit.
+        expect(untouched).toEqual([3, 5, 9]);
+    });
+});

--- a/tests/sim/campaign-stars.test.mjs
+++ b/tests/sim/campaign-stars.test.mjs
@@ -18,12 +18,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { achievements } from "../../src/achievements/achievements.js";
 import { CAMPAIGN_LEVELS } from "../../src/campaign/levels.js";
-import { spawnRequest } from "../../src/core/actions.js";
-import { createConnection, createService, deleteObject } from "../../src/sim/topology.js";
-import { startCampaignLevel } from "../../src/ui/campaign-ui.js";
+import { createConnection, deleteObject } from "../../src/sim/topology.js";
+import { REAL_RANDOM, placeAt, play, svc } from "../helpers/campaign-play.mjs";
 import { STATE, resetWorld } from "../helpers/sim-world.mjs";
-
-const CAMPAIGN_KEY = "serverSurvivalCampaignProgress";
 
 // ---------------------------------------------------------------- the walk
 
@@ -139,70 +136,6 @@ describe("every level can be three-starred by SOME play (#256)", () => {
 });
 
 // -------------------------------------------------------------- the proofs
-
-function mulberry32(seed) {
-    let a = seed >>> 0;
-    return function () {
-        a |= 0;
-        a = (a + 0x6d2b79f5) | 0;
-        let t = Math.imul(a ^ (a >>> 15), 1 | a);
-        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-    };
-}
-const REAL_RANDOM = Math.random;
-
-// One frame of animate()'s sim-relevant work, in animate()'s order.
-function frame(dt) {
-    STATE.elapsedGameTime += dt;
-    if (globalThis.window.campaign?.active) globalThis.window.campaign.tick(dt);
-    STATE.services.forEach((s) => s.update(dt));
-    STATE.requests.slice().forEach((r) => r.update(dt));
-    STATE.spawnTimer += dt;
-    const rps = STATE.currentRPS * (STATE.intervention?.trafficBurstMultiplier || 1.0);
-    if (rps > 0) {
-        const iv = 1 / rps;
-        while (STATE.spawnTimer >= iv) {
-            STATE.spawnTimer -= iv;
-            spawnRequest();
-        }
-    }
-    STATE.reputation = Math.min(100, STATE.reputation);
-    achievements.tick(dt);
-}
-
-function placeAt(type, x, z) {
-    const before = STATE.services.length;
-    createService(type, new globalThis.THREE.Vector3(x, 0, z));
-    if (STATE.services.length === before) throw new Error(`placement of ${type} failed`);
-    return STATE.services[STATE.services.length - 1];
-}
-
-function svc(type) {
-    return STATE.services.find((s) => s.type === type);
-}
-
-/** Plays a level to its end with the given build and reports the scoring. */
-function play(levelId, seed, build) {
-    resetWorld();
-    globalThis.localStorage.setItem(
-        CAMPAIGN_KEY,
-        JSON.stringify({ version: 1, completed: {}, highestUnlocked: 25 })
-    );
-    STATE.animationId = 1; // keep resetGame from starting the real rAF loop
-    Math.random = mulberry32(seed);
-    startCampaignLevel(levelId);
-    build();
-    for (let t = 0; t < 400 && !STATE.campaign.ended; t += 0.1) frame(0.1);
-    return {
-        outcome: STATE.campaign.outcome,
-        elapsed: STATE.elapsedGameTime,
-        stars: globalThis.window.campaign._calculateStars(),
-        bonuses: { ...STATE.campaign.bonusResults },
-        failures: Object.values(STATE.failures).reduce((a, b) => a + b, 0),
-        speedBar: STATE.campaign.level.durationSec * 0.8,
-    };
-}
 
 /** What every one of these proofs must show: a perfect run, scored 3, NOT by speed. */
 function expectThreeStarsWithoutSpeed(r) {


### PR DESCRIPTION
Addresses the prerequisite named in #254. Changes no tuning.

## What was missing

The repo proves levels are **winnable**. It has never checked the other half of the #184 discipline — that a level is **lost when its own mechanic is ignored**. A level that passes without the thing it teaches is not a lesson, it is a cutscene with a timer.

## What measuring it found

Two levers exist on each of these levels: the service the briefing teaches, and the $100 Compute tier (capacity 4 → 10) that every one of these budgets can afford. Withholding them one at a time, five seeds each:

| level | teaches | taught + tier | **tier only** | **taught only** | neither |
|---|---|---|---|---|---|
| L3 | CDN | 5/5 | 5/5 | 5/5 | **5/5** |
| L4 | Cache | 5/5 | **5/5** | 2/5 | 2/5 |
| L5 | Queue | 5/5 | 5/5 | 5/5 | **4/5** |
| L6 | Replica | 5/5 | **5/5** | **0/5** | 0/5 |
| L7 | Search | 5/5 | **5/5** | **0/5** | 0/5 |
| L8 | NoSQL | 5/5 | **5/5** | **0/5** | 0/5 |
| L9 | API GW | 5/5 | 5/5 | 5/5 | **5/5** |
| L12 | 2nd WAF | 5/5 | **0/5** | 0/5 | 0/5 |

**Two separate defects.** Three levels (3, 5, 9) pass on an untouched board — place nothing, buy nothing, win. On three more (6, 7, 8) the taught node is decorative in *both* directions: without the tier they lose even when it is correctly wired, and with the tier they win without it.

The cause is capacity rather than objective text. Compute runs 4 concurrent at 600ms — about 6.7 req/s — and those levels arrive at 6–7 rps, so Compute binds before any downstream store can matter. A read replica cannot rescue a box that is already the bottleneck. Mechanically, chapter 2 teaches **buy a bigger box**, which is the opposite of every briefing in it, and it is a cheaper explanation for #74 than any amount of missing content: one dominant move, repeated.

**L12 is the counter-example and the target shape.** What a second WAF defends against is not something a faster box absorbs, so it is load-bearing in every column.

## What this PR does about it

Nothing to the tuning. Retuning shipped levels moves the difficulty of a campaign people have already played, and that deserves a deliberate decision rather than arriving as a side effect of a test PR.

What lands is the harness, carrying the table as a **pinned baseline**: `KNOWN_HOLLOW` may shrink freely — fixing a level is a one-line deletion — and a level joining it turns the build red. Plus a real beatability proof for eight levels that had none.

Also extracts the play harness into `tests/helpers/campaign-play.mjs`; three files were re-deriving the frame loop. `campaign-stars.test.mjs` moves onto it, and reverting the star fix still reddens 13 of its 19 checks, so the refactor did not hollow it out.

## Next

The fix itself, which needs a call on direction — give Compute headroom so the store binds, or take the tier off the table on levels whose lesson is horizontal. Both are measurable against this harness now.