### PR TITLE
Pub/Sub subscribers were a revenue multiplier

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (45 test files, 979 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (45 test files, 982 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -191,8 +191,14 @@ function updateScore(req, outcome) {
             `MALICIOUS PASSED: ${points.MALICIOUS_PASSED_REPUTATION} Rep. (Critical Failure)`
         );
     } else if (outcome === "COMPLETED") {
-        let reward = typeConfig.reward;
-        const score = typeConfig.score;
+        // A fan-out copy is an extra DELIVERY of one arrival, not an extra
+        // arrival: sim/handlers/pubsub.js mints one per additional subscriber.
+        // It is counted, it occupies capacity, it can fail and cost standing
+        // — but the customer paid once, so it earns nothing. Without this,
+        // subscribers were a revenue multiplier and the lesson ran backwards.
+        const paid = !req.isFanoutCopy;
+        let reward = paid ? typeConfig.reward : 0;
+        const score = paid ? typeConfig.score : 0;
 
         if (req.cached) {
             reward *= 1 + points.CACHE_HIT_BONUS;
@@ -253,9 +259,16 @@ function updateScore(req, outcome) {
         // A late completion earns the late tax INSTEAD of the success bonus,
         // so a board serving everything late bleeds slowly while its failure
         // counter reads zero — the production experience of a full queue.
-        STATE.reputation += req.wasLate
-            ? (points.LATE_REPUTATION ?? -0.3)
-            : (points.SUCCESS_REPUTATION || 0.5);
+        // Standing follows the customer, not the delivery count: one arrival
+        // satisfied is one arrival satisfied however many subscribers it was
+        // fanned out to, so a copy earns no bonus either. A copy that FAILS
+        // still costs — which is the honest shape of fan-out, more places for
+        // one event to go wrong and no more revenue for the risk.
+        if (paid) {
+            STATE.reputation += req.wasLate
+                ? (points.LATE_REPUTATION ?? -0.3)
+                : (points.SUCCESS_REPUTATION || 0.5);
+        }
     } else if (outcome === "THROTTLED") {
         // Soft fail from API Gateway rate limiting — much less reputation loss
         STATE.reputation += points.THROTTLED_REPUTATION || -0.2;

--- a/src/sim/handlers/pubsub.js
+++ b/src/sim/handlers/pubsub.js
@@ -36,6 +36,14 @@ export function process(service, job) {
     // One clone per ADDITIONAL subscriber, minted before the original is re-flown.
     for (let i = 1; i < subs.length; i++) {
         const clone = new Request(job.req.type);
+        // A DELIVERY, NOT AN ARRIVAL. The clone is a real Request and must
+        // terminate like one, but it is not a second customer: marking it
+        // here is what stops updateScore paying for it. Wiring a second and
+        // third subscriber used to triple the money and the score from
+        // unchanged customer traffic — measured $6 -> $18 on the same five
+        // events — which is fan-out backwards. Real fan-out costs MORE per
+        // event; it does not get paid more.
+        clone.isFanoutCopy = true;
         STATE.requests.push(clone);
         clone.flyTo(subs[i]);
     }

--- a/tests/sim/archetypes.test.mjs
+++ b/tests/sim/archetypes.test.mjs
@@ -172,6 +172,89 @@ describe("Pub/Sub Topic (#197)", () => {
         expect(STATE.requests.length).toBe(0); // TERMINATION: every clone drained
     });
 
+    it("THE MONEY PRINTER: subscribers used to multiply the money from one event", () => {
+        // A clone is an extra DELIVERY of one arrival, not an extra arrival.
+        // It used to run the full success path — money, score and standing —
+        // so wiring a second and third subscriber tripled the income from
+        // unchanged customer traffic at a few dollars of extra upkeep. That
+        // is fan-out backwards: real fan-out costs MORE per event and is not
+        // paid more for it.
+        const board = (subscriberCount) => {
+            resetWorld({ gameMode: "survival" });
+            const pubsub = place("pubsub");
+            // Each subscriber gets its OWN database. Sharing one would make
+            // the three-subscriber board saturate it — three times the writes
+            // through one node — and the capacity effect is real but it is
+            // not what this test is measuring. Isolating it leaves subscriber
+            // count as the only variable.
+            for (let i = 0; i < subscriberCount; i++) {
+                const c = place("compute");
+                const db = place("db");
+                connect(pubsub, c);
+                connect(c, db);
+            }
+            const before = { money: STATE.money, score: STATE.score.total, rep: STATE.reputation };
+            for (let i = 0; i < 5; i++) flyInto("WRITE", pubsub);   // five customer events
+            run(20);
+            return {
+                earned: +(STATE.money - before.money).toFixed(4),
+                score: STATE.score.total - before.score,
+                rep: +(STATE.reputation - before.rep).toFixed(4),
+                processed: STATE.requestsProcessed,
+                leftover: STATE.requests.length,
+                fails: Object.values(STATE.failures).reduce((a, n) => a + n, 0),
+            };
+        };
+        const one = board(1);
+        const three = board(3);
+
+        // The same five customers pay the same, whatever the topology behind
+        // them: $6 vs $18 before this.
+        expect(three.earned).toBeCloseTo(one.earned, 6);
+        expect(three.score).toBe(one.score);
+        expect(three.rep).toBeCloseTo(one.rep, 6);
+
+        // ...and the deliveries themselves are still real and still counted:
+        // three subscribers really did do three times the work.
+        expect(three.processed).toBe(one.processed * 3);
+        expect(three.leftover).toBe(0);          // TERMINATION still holds
+        expect(three.fails).toBe(0);             // ...and nothing was dropped
+    });
+
+    it("the ORIGINAL still pays in full — only the copies are unpaid", () => {
+        resetWorld({ gameMode: "survival" });
+        const pubsub = place("pubsub");
+        const compute = place("compute");
+        const db = place("db");
+        connect(pubsub, compute);
+        connect(compute, db);
+        const before = STATE.money;
+        flyInto("WRITE", pubsub);
+        run(15);
+        expect(STATE.money - before).toBeCloseTo(CONFIG.trafficTypes.WRITE.reward, 6);
+    });
+
+    it("...and a copy that FAILS still costs — fan-out buys risk, not revenue", () => {
+        // The other half of the lesson. If copies were made inert entirely,
+        // extra subscribers would be free, which is its own lie.
+        resetWorld({ gameMode: "survival" });
+        const pubsub = place("pubsub");
+        const good = place("compute");
+        const db = place("db");
+        connect(pubsub, good);
+        connect(good, db);
+        // A second subscriber with nowhere to send its work.
+        const orphan = place("compute");
+        connect(pubsub, orphan);
+
+        const before = { rep: STATE.reputation, fails: Object.values(STATE.failures).reduce((a, n) => a + n, 0) };
+        for (let i = 0; i < 5; i++) flyInto("WRITE", pubsub);
+        run(20);
+        const failsAfter = Object.values(STATE.failures).reduce((a, n) => a + n, 0);
+        expect(failsAfter, "a delivery that goes nowhere is still a failure").toBeGreaterThan(before.fails);
+        expect(STATE.reputation).toBeLessThan(before.rep);
+    });
+
     it("one subscriber: the original is delivered, no clone is minted", () => {
         const pubsub = place("pubsub");
         const notify = place("notify");


### PR DESCRIPTION
957 → **960 tests**.

`sim/handlers/pubsub.js` mints one clone per additional subscriber, and the module header says it plainly: clones are *"indistinct from organically spawned traffic thereafter."* So each one ran the full success path — money, score and standing — exactly like a new customer arriving.

Measured on five customer events, one subscriber vs three:

```
one   subscriber: earned $6    score 40    processed 5
three subscribers: earned $18   score 120   processed 15
```

Wiring a second and third subscriber **tripled the income from unchanged demand** at a few dollars of extra upkeep. A straight money printer — and the lesson upside down. Real fan-out costs *more* per event; it does not get paid more.

## What a clone is

An extra **delivery** of one arrival, not an extra arrival. It stays a real `Request`: it terminates exactly once, occupies capacity, is counted in `requestsProcessed` (the delivery count is deliberate — the existing test pinning `3` for one event is untouched), and it can still **fail** and cost standing.

It just earns nothing, because the customer paid once. Standing follows the customer for the same reason: one arrival satisfied is one arrival satisfied, however many subscribers it reached.

## The mutation worth reading

Making copies **fully inert** — no reward *and* no failure cost — would satisfy the money test and turn extra subscribers free, which is its own lie. A test pins that a delivery going nowhere is still a failure, so fan-out buys **risk without revenue**: the shape it has in production.

Three mutations, all caught: paying the copies again, not marking the clone, and making copies inert.

## One note on the test

The first version of the money test gave the three-subscriber board a **shared** database, and it flaked — three times the writes through one node occasionally saturated it, costing a failure and a dropped delivery. That capacity effect is real and is exactly what the third test is about, but it is not what the money test measures, so each subscriber now gets its own database and subscriber count is the only variable. Three consecutive clean runs.