### PR TITLE
Leaving the tutorial by the pause menu left it armed and invisible

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (45 test files, 982 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (46 test files, 986 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/game.js
+++ b/game.js
@@ -407,6 +407,13 @@ function resetGame(mode = "survival") {
     // is about to start.
     if (mode !== "campaign") window.campaign?.exit();
 
+    // ...and a half-finished lesson stops with the run it belonged to. See
+    // Tutorial.abandon: this does NOT mark the tutorial completed, so the
+    // offer survives for a player who wandered off mid-lesson.
+    // window.startTutorial calls resetGame() BEFORE tutorial.reset() and
+    // start(), so re-arming still works.
+    window.tutorial?.abandon();
+
     // Set budget based on mode
     if (mode === "campaign") {
         STATE.money = 0; // will be set by startCampaignLevel from level.budget

--- a/src/tutorial.js
+++ b/src/tutorial.js
@@ -461,6 +461,26 @@ class Tutorial {
         STATE?.sound?.playSuccess();
     }
 
+    // LEAVING THE LESSON WITHOUT FINISHING IT. hide() only hides the modal —
+    // isActive stays true, and the step machine keeps listening. Escape opens
+    // the pause menu and calls hide(), and every way out of that menu starts a
+    // NEW run, so the tutorial used to stay armed and invisible for the life
+    // of the page: it suppressed the pulse-green button hints for the whole
+    // session, took onAction("start_game") from a run it was not teaching,
+    // and — if those stray actions walked it to the end — ran complete(),
+    // which calls markCompleted() and writes 'tutorial done' to localStorage
+    // for a lesson the player never saw.
+    //
+    // Deliberately NOT skip() or complete(): both mark it done, and someone
+    // who wandered off mid-lesson has not chosen to be finished with it. The
+    // offer survives.
+    abandon() {
+        if (!this.isActive) return false;
+        this.isActive = false;
+        this.hide();
+        return true;
+    }
+
     hide() {
         this.modal.classList.add('hidden');
         this.clearHighlights();

--- a/tests/sim/tutorial-lifetime.test.mjs
+++ b/tests/sim/tutorial-lifetime.test.mjs
@@ -1,0 +1,79 @@
+// A lesson belongs to the run it is teaching.
+//
+// Tutorial.hide() only hides the modal — isActive stays true and the step
+// machine keeps listening. Escape opens the pause menu and calls hide(), and
+// every way out of that menu starts a NEW run, so the tutorial stayed armed
+// and invisible for the life of the page.
+//
+// Three consequences, none of them visible to the player:
+//   - the pulse-green button hints are suppressed for the whole session
+//     (game.js gates them on !tutorial.isActive);
+//   - the hidden machine takes onAction("start_game") from a run it is not
+//     teaching, and advances;
+//   - if stray actions walk it to the end, complete() calls markCompleted()
+//     and the game records a lesson the player never saw, removing the offer.
+import { describe, it, expect, beforeEach } from "vitest";
+import { resetGame, openMainMenu } from "../../game.js";
+
+// The real key, read from the module rather than retyped: my first draft
+// wrote "...Completed" for a key that is "...Complete", so the assertion
+// below passed on a key that never existed.
+const TUTORIAL_KEY = "serverSurvivalTutorialComplete";
+const read = (k) => { try { return localStorage.getItem(k); } catch { return null; } };
+
+function beginLesson() {
+    // What window.startTutorial does, minus its 500 ms setTimeout.
+    resetGame();
+    window.tutorial.reset();
+    window.tutorial.start();
+}
+
+describe("the tutorial does not outlive the run it was teaching", () => {
+    beforeEach(() => { try { localStorage.clear(); } catch { /* storage unavailable */ } });
+
+    it("THE BUG: Escape then New Game used to leave it armed and invisible", () => {
+        beginLesson();
+        expect(window.tutorial.isActive).toBe(true);
+
+        openMainMenu();                              // Escape
+        expect(document.getElementById("tutorial-modal").classList.contains("hidden")).toBe(true);
+
+        window.startGame();                          // ...and out to a plain run
+        expect(window.tutorial.isActive, "a new run inherited an armed tutorial").toBe(false);
+    });
+
+    it("...through every door out of the menu", () => {
+        for (const start of [() => window.startGame(), () => window.startSandbox()]) {
+            beginLesson();
+            openMainMenu();
+            start();
+            expect(window.tutorial.isActive).toBe(false);
+        }
+    });
+
+    it("ABANDONING IS NOT FINISHING: the offer survives", () => {
+        // skip() and complete() both markCompleted(), and someone who
+        // wandered off mid-lesson has not chosen to be done with it.
+        beginLesson();
+        openMainMenu();
+        window.startGame();
+        // The control first: finishing DOES record it, so a null here means
+        // "abandoning did not mark it", not "this key is never written".
+        expect(read(TUTORIAL_KEY)).not.toBe("true");
+        window.tutorial.markCompleted();
+        expect(read(TUTORIAL_KEY), "the key this test watches must be the real one").toBe("true");
+        localStorage.removeItem(TUTORIAL_KEY);
+        // Idempotent: leaving twice is not an error.
+        expect(window.tutorial.abandon()).toBe(false);
+    });
+
+    it("...and the lesson can still be started, which is the point of not marking it", () => {
+        beginLesson();
+        openMainMenu();
+        window.startGame();
+        expect(window.tutorial.isActive).toBe(false);
+        beginLesson();                               // the door is still there
+        expect(window.tutorial.isActive).toBe(true);
+        expect(window.tutorial.currentStep).toBe(0);
+    });
+});


### PR DESCRIPTION
982 → **986 tests**.

`Tutorial.hide()` only hides the modal — `isActive` stays true and the step machine keeps listening:

```js
hide() {
    this.modal.classList.add('hidden');
    this.clearHighlights();
}
```

Escape opens the pause menu and calls it, and **every way out of that menu starts a new run**. `reset()` is called by `window.startTutorial` and nothing else. So the lesson stayed armed for the life of the page. Verified:

```
afterMenu: true    afterNewRun: true    modalHidden: true
```

## Three consequences, none of them visible

- **The pulse-green button hints are suppressed for the whole session** — `game.js` gates them on `!tutorial.isActive`, twice.
- The hidden machine takes `onAction("start_game")` from a run it is not teaching, and advances.
- If stray actions walk it to the end, `complete()` calls `markCompleted()` — so the game records a lesson **the player never saw**, stops offering it, and plays a success sound over an unrelated run.

## Abandoning is not finishing

`abandon()` clears the flag and hides. Deliberately **not** `skip()` or `complete()`: both mark the tutorial done, and someone who wandered off mid-lesson has not chosen to be finished with it. The offer survives, and a test proves the lesson can still be started afterwards.

Same shape as the campaign controller in #264: a lifetime flag with exactly one clearing path, and that path not being the one players take.

## One note on the tests

My first draft watched `serverSurvivalTutorialCompleted` for a key that is actually `serverSurvivalTutorialComplete` — so *"abandoning does not mark it done"* passed on a key that never existed. It now writes the key first as a control, so a null reading means what it claims to mean.

Mutations: making `abandon()` mark it done kills that test; removing the `resetGame` call kills three.