### PR TITLE
fix: the test harness never fired a single level burst, and two published measurements were wrong

### DIFF
--- a/tests/helpers/campaign-play.mjs
+++ b/tests/helpers/campaign-play.mjs
@@ -5,6 +5,7 @@
 // level as shipped: the real `startCampaignLevel` path, player placement
 // through `createService` (which is what stamps playerPlaced and charges the
 // money), and animate()'s own frame order. Nothing here touches tuning.
+import { vi } from "vitest";
 import { achievements } from "../../src/achievements/achievements.js";
 import { spawnRequest } from "../../src/core/actions.js";
 import { createService } from "../../src/sim/topology.js";
@@ -27,10 +28,21 @@ export function mulberry32(seed) {
 
 export const REAL_RANDOM = Math.random;
 
-/** One frame of animate()'s sim-relevant work, in animate()'s order. */
+/**
+ * One frame of animate()'s sim-relevant work, in animate()'s order.
+ *
+ * The timer advance is not decoration. A level's `burstPattern` schedules its
+ * spawns on real `setTimeout` (campaign.js stagggers them 20ms apart), so a
+ * synchronous loop never sees a single burst: five of the shipped levels
+ * declare one and all five played as if they had none. At timeScale 1 the game
+ * advances one second of game time per second of wall clock, so advancing fake
+ * timers by dt*1000 is exactly what the browser does. Calibrated on L21, whose
+ * reference solution wins 3/3 both with timers and without.
+ */
 export function frame(dt) {
     STATE.elapsedGameTime += dt;
     if (globalThis.window.campaign?.active) globalThis.window.campaign.tick(dt);
+    if (vi.isFakeTimers()) vi.advanceTimersByTime(dt * 1000);
     STATE.services.forEach((s) => s.update(dt));
     STATE.requests.slice().forEach((r) => r.update(dt));
     STATE.spawnTimer += dt;
@@ -64,7 +76,7 @@ export const svc = (type) => STATE.services.find((s) => s.type === type);
  * Starts a level, runs `build`, then plays to the level's own end.
  * Returns what the campaign scored, never a verdict — the caller decides.
  */
-export function play(levelId, seed, build, { capSec = 500, dt = 0.1 } = {}) {
+export function play(levelId, seed, build, { capSec = 500, dt = 0.1, bursts = true } = {}) {
     resetWorld();
     globalThis.localStorage.setItem(
         CAMPAIGN_KEY,
@@ -72,6 +84,8 @@ export function play(levelId, seed, build, { capSec = 500, dt = 0.1 } = {}) {
     );
     STATE.animationId = 1; // keep resetGame from starting the real rAF loop
     Math.random = mulberry32(seed);
+    // Fake timers so the level's own burstPattern actually fires (see frame()).
+    if (bursts) vi.useFakeTimers({ shouldAdvanceTime: false });
     try {
         startCampaignLevel(levelId);
         build();
@@ -91,6 +105,7 @@ export function play(levelId, seed, build, { capSec = 500, dt = 0.1 } = {}) {
             speedBar: STATE.campaign.level.durationSec * 0.8,
         };
     } finally {
+        if (bursts) vi.useRealTimers();
         Math.random = REAL_RANDOM;
     }
 }

--- a/tests/sim/beatability.test.mjs
+++ b/tests/sim/beatability.test.mjs
@@ -9,27 +9,37 @@
 // predict. Two levers are available on every one of these levels: the service
 // the briefing teaches, and the $100 Compute tier (capacity 4 -> 10) that every
 // budget here can afford. Removing them one at a time says which one the level
-// actually turns on:
+// actually turns on (five seeds, with the levels' own burst patterns firing):
 //
 //   level  teaches   taught+tier  tier only  taught only  neither
 //   L3     CDN         5/5          5/5        5/5         5/5
 //   L4     Cache       5/5          5/5        2/5         2/5
-//   L5     Queue       5/5          5/5        5/5         4/5
+//   L5     Queue       5/5          0/5        0/5         0/5
 //   L6     Replica     5/5          5/5        0/5         0/5
 //   L7     Search      5/5          5/5        0/5         0/5
 //   L8     NoSQL       5/5          5/5        0/5         0/5
-//   L9     API GW      5/5          5/5        5/5         5/5
+//   L9     API GW      0/5          0/5        0/5         0/5
 //   L12    2nd WAF     5/5          0/5        0/5         0/5
 //
-// Three levels (3, 5, 9) pass on an untouched board. On three more (6, 7, 8)
-// the taught node is decorative in BOTH directions: without the tier they lose
+// Two levels (3, 4) pass on an untouched board. On three more (6, 7, 8) the
+// taught node is decorative in BOTH directions: without the tier they lose
 // even when it is correctly wired, and with the tier they win without it. The
-// cause is capacity — Compute runs 4 concurrent at 600ms, about 6.7 req/s,
-// and those levels arrive at 6-7 rps — so Compute binds before any downstream
-// store can matter. Mechanically, chapter 2 teaches "buy a bigger box".
+// cause is capacity — Compute runs 4 concurrent at 600ms, about 6.7 req/s, and
+// those levels arrive at 6-7 rps — so Compute binds before any downstream
+// store can matter. For those five, chapter 2 mechanically teaches "buy a
+// bigger box".
 //
-// L12 is the counter-example: what a second WAF defends against is not
-// something more CPU absorbs, so it is load-bearing in every column.
+// L5 and L12 are what a working lesson looks like: withhold the queue or the
+// second WAF and the level is lost 0/5, whatever else is bought. Neither a
+// spike nor a malicious share is something more CPU absorbs.
+//
+// L9 is broken rather than hollow — no legal build wins it at all (#276).
+//
+// An earlier revision of this file recorded L5 as hollow and L9 as winnable.
+// Both were wrong for the same reason: `burstPattern` schedules its spawns on
+// real setTimeout, the harness ran a synchronous loop, and all five burst
+// levels were measured as if they had no bursts. campaign-play.mjs now
+// advances timers per frame, calibrated on L21.
 //
 // This file does not retune anything. Retuning shipped levels moves the
 // difficulty of a campaign people have already played, and that is a decision
@@ -116,8 +126,13 @@ const LEVELS = {
 // Today's answer, measured. Membership means "this level still wins with its
 // own lesson withheld". The assertion below lets this set shrink and never
 // grow, so fixing a level is a one-line deletion and shipping a new hollow one
-// is a red build.
-const KNOWN_HOLLOW = new Set([3, 4, 5, 6, 7, 8, 9]);
+// is a red build. L9 is absent because it wins with NOTHING withheld either
+// (#276) — broken is a different state from hollow, and it is asserted apart.
+const KNOWN_HOLLOW = new Set([3, 4, 6, 7, 8]);
+
+// Winnable by nobody (#276). Kept out of the hollow set: a level that no build
+// can beat is a different defect from one that any build can.
+const BROKEN = 9;
 
 function winRate(id, build) {
     return SEEDS.filter((seed) => play(Number(id), seed, build).outcome === "win").length;
@@ -131,6 +146,7 @@ afterEach(() => {
 
 describe("every reference solution wins the level it belongs to (#254)", () => {
     for (const [id, level] of Object.entries(LEVELS)) {
+        if (Number(id) === BROKEN) continue;
         it(`L${id} — ${level.teaches}, played as briefed`, () => {
             expect(winRate(id, () => {
                 level.taught();
@@ -138,11 +154,21 @@ describe("every reference solution wins the level it belongs to (#254)", () => {
             })).toBe(SEEDS.length);
         });
     }
+
+    it(`L${BROKEN} has no reference solution — it cannot be won (#276)`, () => {
+        // Asserted as a loss on purpose, so fixing #276 turns this red and the
+        // level rejoins the loop above. Its own burst puts ~29 requests into
+        // the peak second against a gateway limit of 30: the limiter never
+        // engages, a circuit breaker opens at t=8, and reputation crosses the
+        // floor by t=20. Measured across seven builds including auto-scaling.
+        expect(winRate(BROKEN, () => { LEVELS[BROKEN].taught(); tier(); })).toBe(0);
+    });
 });
 
 describe("and the level is LOST when its own mechanic is ignored", () => {
     for (const [id, level] of Object.entries(LEVELS)) {
         const n = Number(id);
+        if (n === BROKEN) continue;
         it(`L${id} — ${level.teaches} withheld, everything else the same`, () => {
             const wins = winRate(id, tier);
             if (KNOWN_HOLLOW.has(n)) {
@@ -159,6 +185,7 @@ describe("and the level is LOST when its own mechanic is ignored", () => {
     it("the hollow set never grows", () => {
         const measured = Object.keys(LEVELS)
             .map(Number)
+            .filter((id) => id !== BROKEN)
             .filter((id) => winRate(id, tier) > 0);
         const unexpected = measured.filter((id) => !KNOWN_HOLLOW.has(id));
         expect(
@@ -168,7 +195,15 @@ describe("and the level is LOST when its own mechanic is ignored", () => {
         ).toEqual([]);
     });
 
-    it("L12 shows the shape a fixed level has", () => {
+    it("L5 and L12 show the shape a fixed level has", () => {
+        // Withhold the queue and the level is lost however much Compute is
+        // bought: a spike is not something a faster box absorbs. This is the
+        // row that was recorded backwards before the harness ran the timers.
+        expect(winRate(5, tier)).toBe(0);
+        expect(winRate(5, () => { LEVELS[5].taught(); tier(); })).toBe(SEEDS.length);
+    });
+
+    it("L12 shows it too, against a malicious share instead of a spike", () => {
         // Kept explicit because it is the target, not a passing detail: what a
         // second WAF defends against cannot be absorbed by a faster box, so no
         // amount of vertical scaling substitutes for it.
@@ -188,10 +223,12 @@ describe("the Compute tier is the lever chapter 2 actually turns on", () => {
         });
     }
 
-    it("three levels pass on a board the player never touched", () => {
-        const untouched = [3, 5, 9].filter((id) => winRate(id, () => {}) > 0);
+    it("two levels pass on a board the player never touched", () => {
+        const untouched = [3, 4, 5, 9].filter((id) => winRate(id, () => {}) > 0);
         // Asserting the defect so the fix has something to turn red. When a
         // level here stops passing untouched, this list is what to edit.
-        expect(untouched).toEqual([3, 5, 9]);
+        // L5 and L9 are probed and expected to be absent: L5's burst makes its
+        // queue load-bearing, and L9 cannot be won by anyone.
+        expect(untouched).toEqual([3, 4]);
     });
 });

--- a/tests/sim/campaign-stars.test.mjs
+++ b/tests/sim/campaign-stars.test.mjs
@@ -251,13 +251,16 @@ describe("the rule stays honest at the edges", () => {
     });
 });
 
-describe("and the other eight levels speed could never carry", () => {
+describe("and the other levels speed could never carry", () => {
     // #256 blocked eleven levels. Three of them gate an achievement and are
-    // proven above, one build at a time. These are the remaining eight, each
-    // playing its own briefed lesson inside its own budget. Together they say
-    // the thing the walk cannot: on every level the fix reopened, some real
-    // play reaches three stars. (The other fourteen levels were never blocked
-    // — their speed star was reachable all along.)
+    // proven above, one build at a time. These are the rest, each playing its
+    // own briefed lesson inside its own budget. Together they say the thing
+    // the walk cannot: on the levels the fix reopened, some real play reaches
+    // three stars. (The other fourteen were never blocked — their speed star
+    // was reachable all along.)
+    //
+    // L9 is the exception and it is NOT a gap in this file: it cannot be won
+    // at all. See the block below, and #276.
     const BUILDS = {
         3: () => {
             // STATIC belongs at the edge, not on the origin.
@@ -277,13 +280,6 @@ describe("and the other eight levels speed could never carry", () => {
             // NoSQL takes the writes off the SQL box.
             const nosql = placeAt("nosql", 12, 10);
             createConnection(svc("compute").id, nosql.id);
-            svc("compute").upgrade();
-        },
-        9: () => {
-            // An API Gateway between the balancer and Compute.
-            const gw = placeAt("apigw", -15, 8);
-            createConnection(svc("alb").id, gw.id);
-            createConnection(gw.id, svc("compute").id);
             svc("compute").upgrade();
         },
         11: () => {
@@ -353,4 +349,22 @@ describe("and the other eight levels speed could never carry", () => {
             }
         });
     }
+
+    it("L9 cannot be three-starred because it cannot be WON (#276)", () => {
+        // This proof used to pass, and it was wrong. The harness ran a
+        // synchronous loop, so the setTimeout-scheduled `burstPattern` never
+        // fired and L9 played as though it had no bursts. With its own bursts
+        // running, no legal build survives: the first one trips a circuit
+        // breaker at t=8 and reputation crosses the floor by t=20.
+        //
+        // Asserted as a LOSS on purpose. When #276 is fixed this turns red,
+        // and the fix is to move L9 back into the table above.
+        const r = play(9, 1, () => {
+            const gw = placeAt("apigw", -15, 8);
+            createConnection(svc("alb").id, gw.id);
+            createConnection(gw.id, svc("compute").id);
+            svc("compute").upgrade();
+        });
+        expect(r.outcome, "L9 is expected to lose until #276 lands").toBe("lose");
+    });
 });


### PR DESCRIPTION
Corrects #272 and part of #271. Opens #276.

## The blind spot

`campaign.js` schedules a level's `burstPattern` through real `setTimeout`, staggered 20ms apart. Every headless proof in this repo runs a synchronous loop, so those callbacks never fired — and **all five levels that declare a burst** (L5, L9, L18, L21, L23) were being proven as if they had none.

The fix advances fake timers by `dt * 1000` per frame in the shared frame loop. At timeScale 1 the game advances one second of game time per second of wall clock, so that is exactly what the browser does.

Calibrated rather than assumed: L21 (which declares a burst) wins 3/3 both with timers and without, so the model is not systematically harsh. Verdicts are also unchanged at frame steps 0.1s and 1/60s, and across speed settings 1x/2x/3x.

## Two results change, and I published both

**1. L5 is not hollow.** I recorded it as passing without its queue. With its burst running the queue is exactly load-bearing:

| build | wins |
|---|---|
| queue + tier | **5/5** |
| tier only | **0/5** |
| queue only | 0/5 |
| nothing | 0/5 |

A spike is not something a faster box absorbs. L5 is now the file's example of a *working* lesson, alongside L12.

**2. L9 cannot be won at all** — filed as #276. `campaign-stars.test.mjs` proved it three-starrable; that proof ran without bursts. With them, seven builds lose 0/5, including auto-scaling and a tier 3 bought as soon as it is affordable. Its burst puts ~29 requests into the peak second against a gateway `rateLimit` of 30, so the limiter never engages; a circuit breaker opens at t=8 and reputation crosses the floor by t=20.

Both are now asserted as the losses they are, so **fixing #276 turns them red** and forces the proofs back in.

## Corrected matrix

| level | teaches | taught+tier | tier only | taught only | neither |
|---|---|---|---|---|---|
| L3 | CDN | 5/5 | 5/5 | 5/5 | 5/5 |
| L4 | Cache | 5/5 | 5/5 | 2/5 | 2/5 |
| L5 | Queue | 5/5 | **0/5** | 0/5 | 0/5 |
| L6 | Replica | 5/5 | 5/5 | 0/5 | 0/5 |
| L7 | Search | 5/5 | 5/5 | 0/5 | 0/5 |
| L8 | NoSQL | 5/5 | 5/5 | 0/5 | 0/5 |
| L9 | API GW | **0/5** | 0/5 | 0/5 | 0/5 |
| L12 | 2nd WAF | 5/5 | 0/5 | 0/5 | 0/5 |

`KNOWN_HOLLOW` drops from {3,4,5,6,7,8,9} to **{3,4,6,7,8}**.

## What does not change

The central finding of #272 survives: on L6, L7 and L8 the taught node is decorative in *both* directions, and the $100 Compute tier is what those levels actually turn on. Two levels still pass on a board the player never touched (L3, L4).

## Limitation

I could not confirm any of this in a live browser — the preview tab runs hidden and hidden tabs suspend requestAnimationFrame, so the game loop does not advance there. Everything above is the headless harness, calibrated as described.