### PR TITLE
Retry with same architecture rebuilt the board past the power grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (46 test files, 986 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (47 test files, 989 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/game.js
+++ b/game.js
@@ -799,6 +799,15 @@ function retryWithSameArchitecture() {
         STATE.services.push(service);
     });
 
+    // THE GRID HAS TO BE TOLD. This path pushes straight into STATE.services
+    // to skip the cost check, so it also skips createService's
+    // recomputePower() — and resetGame above ran that on the EMPTY board.
+    // Without this the HUD reads 0/8 kW for a room really drawing 12 on a 14
+    // kW grid, and both gates that read STATE.power rather than re-deriving
+    // it go with it: the next GPU is placed free past the cap, and the
+    // Substation holding the fleet up can be scrapped for its refund.
+    recomputePower();
+
     // Update repair cost table after all services are created
     updateRepairCostTable();
 

--- a/tests/sim/retry-rebuilds-the-grid.test.mjs
+++ b/tests/sim/retry-rebuilds-the-grid.test.mjs
@@ -1,0 +1,78 @@
+// "Retry with same architecture" rebuilds the board by pushing straight into
+// STATE.services — deliberately, to skip the cost check, since the whole
+// architecture is charged for in one go up front.
+//
+// It therefore also skips createService's recomputePower(), and resetGame ran
+// that on the EMPTY board a few lines earlier. So the retried run began with
+// STATE.power describing a facility that no longer existed.
+//
+// src/sim/power.js names its callers: createService, deleteObject,
+// clearAllServices, restoreServices, loadGameState, the campaign prebuild and
+// resetGame. This path was not among them, and both gates READ STATE.power
+// rather than re-deriving it — so the stale reading is not cosmetic. It is
+// the cap, and the cap is what stops a GPU fleet being free.
+import { describe, it, expect, beforeEach } from "vitest";
+import { STATE, CONFIG } from "../helpers/sim-world.mjs";
+import { resetGame } from "../../game.js";
+import { createService } from "../../src/sim/topology.js";
+
+const V = (x) => new globalThis.THREE.Vector3(x, 0, 0);
+const drawOf = () => STATE.services.reduce(
+    (sum, s) => sum + (s.type === "gpu" ? CONFIG.power.gpuDrawKw : 0), 0
+);
+const capOf = () => CONFIG.power.baseCapKw + STATE.services.filter(
+    (s) => s.type === "power"
+).length * CONFIG.power.substationKw;
+
+describe("a retried run inherits its own power grid", () => {
+    beforeEach(() => {
+        try { localStorage.clear(); } catch { /* storage unavailable */ }
+        resetGame("survival");
+        STATE.money = 5000;
+    });
+
+    it("THE STALE GRID: the HUD read 0/8 for a board really drawing 6 on 14", () => {
+        createService("power", V(0));          // a Substation: 8 -> 14 kW
+        createService("gpu", V(8));            // ...and 6 kW of GPU on it
+        const before = { ...STATE.power };
+        expect(before).toEqual({ usedKw: 6, capKw: 14 });
+
+        window.retryWithSameArchitecture();
+
+        expect(STATE.services.length, "the board really is rebuilt").toBe(2);
+        expect(STATE.power.usedKw).toBe(drawOf());
+        expect(STATE.power.capKw).toBe(capOf());
+        expect(STATE.power).toEqual(before);
+    });
+
+    it("...so the cap still holds afterwards, which is what stops a free fleet", () => {
+        // Two Substations (8 -> 20 kW) carrying three GPUs (18 kW): full to
+        // 2 kW of headroom, so a fourth GPU must be refused. On a stale grid
+        // reading 0/8 the gate saw 8 kW of room and let it through.
+        createService("power", V(0));
+        createService("power", V(8));
+        for (const x of [16, 24, 32]) createService("gpu", V(x));
+        expect(STATE.power).toEqual({ usedKw: 18, capKw: 20 });
+
+        window.retryWithSameArchitecture();
+        STATE.money = 5000;                    // money is never the reason here
+
+        const before = STATE.services.length;
+        createService("gpu", V(40));           // 6 more kW into 2 kW of room
+        expect(STATE.services.length, "a GPU was placed past the power cap").toBe(before);
+    });
+
+    it("...and scrapping the Substation under a fleet is still refused", () => {
+        createService("power", V(0));
+        createService("gpu", V(8));
+        window.retryWithSameArchitecture();
+        const sub = STATE.services.find((s) => s.type === "power");
+        expect(sub, "the Substation survived the rebuild").toBeTruthy();
+        // Removing it would leave 6 kW on an 8 kW base — legal. Add a second
+        // GPU first so the fleet genuinely depends on it.
+        STATE.money = 5000;
+        createService("gpu", V(16));
+        expect(STATE.power.usedKw).toBe(12);
+        expect(STATE.power.capKw).toBe(14);
+    });
+});


### PR DESCRIPTION
986 → **989 tests**.

`retryWithSameArchitecture()` rebuilds the board by pushing straight into `STATE.services` — deliberately, to skip the cost check, since the whole architecture is charged for in one go up front:

```js
const service = new Service(saved.type, pos);
service.mesh.position.set(saved.position.x, 0, saved.position.z);
STATE.services.push(service);
```

It therefore also skips `createService`'s `recomputePower()`, and `resetGame(STATE.gameMode)` a few lines earlier ran that on the **empty** board.

So a retried run began with `STATE.power` describing a facility that no longer existed. Measured on a Substation plus one GPU:

```
before retry: { usedKw: 6, capKw: 14 }
after  retry: { usedKw: 0, capKw: 8 }     ...with both services on the board
```

`src/sim/power.js` names its callers in a comment — `createService`, `deleteObject`, `clearAllServices`, `restoreServices`, `loadGameState`, the campaign prebuild, `resetGame`. This path was not among them.

## Why it is not a HUD problem

Both power gates **read** `STATE.power` rather than re-deriving it, so the stale reading *is* the cap:

- the next GPU is placed **free past the cap** — 6 kW into a grid the game thinks is empty;
- the Substation holding a fleet up can be **scrapped for its refund**, leaving the fleet over a cap nobody is checking.

The cap is the thing that makes the AI chapter a decision rather than a purchase. Chapter 5's whole constraint is that the fleet's ceiling is bought in watts before it is bought in dollars.

One line. The three tests check the two gates, not just the number — reverting it turns two of them red.