### PR TITLE
Two places where the money on screen was not the money that moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (47 test files, 989 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (49 test files, 994 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/game.js
+++ b/game.js
@@ -1220,7 +1220,18 @@ function animate(time) {
 
     const upkeepDisplay = document.getElementById("upkeep-display");
     if (upkeepDisplay) {
-        if (autoRepairCost > 0) {
+        if (!STATE.upkeepEnabled) {
+            // SANDBOX SHIPS WITH UPKEEP OFF, and Service.update() charges only
+            // inside `if (STATE.upkeepEnabled)`. The display was the one site
+            // that never asked — the auto-repair deduction ten lines up does —
+            // so every sandbox session showed a red "Upkeep Cost -$X.XX/s"
+            // that is never charged, next to a panel reporting $0 upkeep and a
+            // button reading "Upkeep: OFF". A learner budgeting a topology
+            // read a running cost off the HUD that the simulation does not
+            // apply.
+            upkeepDisplay.innerText = `-$0.00/s ${i18n.t('upkeep_off_label')}`;
+            upkeepDisplay.className = "text-gray-500 font-mono";
+        } else if (autoRepairCost > 0) {
             upkeepDisplay.innerText = `-$${totalUpkeep.toFixed(2)}/s ${i18n.t('plus_repair')}`;
             upkeepDisplay.className = "text-orange-400 font-mono";
         } else if (multiplier > 1.05) {

--- a/src/sim/topology.js
+++ b/src/sim/topology.js
@@ -376,7 +376,28 @@ function deleteObject(id) {
     svc.destroy();
     STATE.services = STATE.services.filter((s) => s.id !== id);
     recomputePower();
-    STATE.money += Math.floor(svc.config.cost / 2);
+    // THE REFUND IS A MONEY MOVEMENT, so it books itself like every other one.
+    // Placement writes expenses.services, byService and countByService a few
+    // lines up; repair, upgrade, upkeep and the serverless per-invocation
+    // charge all book too. This was the only dollar moving outside the ledger
+    // the finances panel computes net profit from, so selling a node left the
+    // money counter and the Net Profit line permanently disagreeing by half
+    // the purchase price — and the expense breakdown still listing hardware
+    // the player no longer owns.
+    //
+    // Booked as a REDUCTION of what the hardware cost, not as income: the
+    // player recovered part of a purchase, they did not earn anything.
+    // Clamped at zero because a preBuilt service is placed free (the campaign
+    // prebuild bypasses the charge above) and selling one must not drive the
+    // ledger negative.
+    const refund = Math.floor(svc.config.cost / 2);
+    STATE.money += refund;
+    if (STATE.finances) {
+        const e = STATE.finances.expenses;
+        e.services = Math.max(0, e.services - refund);
+        e.byService[svc.type] = Math.max(0, (e.byService[svc.type] || 0) - refund);
+        e.countByService[svc.type] = Math.max(0, (e.countByService[svc.type] || 0) - 1);
+    }
     STATE.sound.playDelete();
     updateRepairCostTable();
 }

--- a/tests/sim/money-on-screen.test.mjs
+++ b/tests/sim/money-on-screen.test.mjs
@@ -1,0 +1,70 @@
+// Two places where the money on screen was not the money that moved.
+//
+// The finances panel is a double-entry ledger: every dollar in or out books
+// itself, and net profit is income.total minus the expense lines. Placement,
+// repair, upgrade, upkeep and the serverless per-invocation charge all book.
+// The sell refund did not — the one dollar movement outside it — so the money
+// counter and the Net Profit line drifted apart by half the purchase price of
+// every node ever sold, permanently, while the expense breakdown kept listing
+// hardware the player no longer owned.
+//
+// The other one runs the other way: sandbox ships with upkeep OFF and
+// Service.update() charges only inside `if (STATE.upkeepEnabled)`, but the
+// HUD line never asked. Every sandbox session showed a running cost in red
+// that the simulation does not apply.
+import { describe, it, expect, beforeEach } from "vitest";
+import { STATE, CONFIG, resetWorld, place } from "../helpers/sim-world.mjs";
+import { deleteObject } from "../../src/sim/topology.js";
+
+const expenses = () => STATE.finances.expenses;
+const totalExpenses = () => {
+    const e = expenses();
+    return e.services + e.upkeep + e.repairs + (e.autoRepair || 0)
+        + (e.mitigation || 0) + (e.breach || 0);
+};
+
+describe("the ledger sees every dollar that moves", () => {
+    beforeEach(() => resetWorld({ gameMode: "survival" }));
+
+    it("SELLING A NODE books its refund, or Net Profit is wrong forever", () => {
+        const before = { money: STATE.money, spent: expenses().services };
+        const db = place("db");
+        const cost = CONFIG.services.db.cost;
+        expect(expenses().services).toBe(before.spent + cost);
+
+        deleteObject(db.id);
+        const refund = Math.floor(cost / 2);
+
+        // The money went up by the refund...
+        expect(STATE.money).toBe(before.money - cost + refund);
+        // ...and the ledger came down by exactly the same amount, so the two
+        // numbers on screen still agree.
+        expect(expenses().services).toBe(before.spent + cost - refund);
+    });
+
+    it("...and the per-service breakdown stops listing hardware you sold", () => {
+        const db = place("db");
+        expect(expenses().countByService.db).toBe(1);
+        deleteObject(db.id);
+        expect(expenses().countByService.db).toBe(0);
+        expect(expenses().byService.db).toBe(CONFIG.services.db.cost - Math.floor(CONFIG.services.db.cost / 2));
+    });
+
+    it("a FREE node sold does not drive the ledger negative", () => {
+        // Campaign preBuilt services are placed without the charge, so their
+        // refund has no purchase to come off.
+        const db = place("db");
+        deleteObject(db.id);
+        expenses().services = 0;
+        expenses().byService.db = 0;
+        const db2 = place("db");
+        expenses().services = 0;                 // pretend it was free
+        expenses().byService.db = 0;
+        expenses().countByService.db = 0;
+        deleteObject(db2.id);
+        expect(expenses().services).toBe(0);
+        expect(expenses().byService.db).toBe(0);
+        expect(expenses().countByService.db).toBe(0);
+        expect(totalExpenses()).toBeGreaterThanOrEqual(0);
+    });
+});

--- a/tests/sim/upkeep-display.test.mjs
+++ b/tests/sim/upkeep-display.test.mjs
@@ -1,0 +1,70 @@
+// Sandbox ships with upkeep OFF (CONFIG.sandbox.upkeepEnabled === false) and
+// Service.update() charges only inside `if (STATE.upkeepEnabled)`. The HUD
+// line never asked — the auto-repair deduction ten lines above it does — so
+// every sandbox session showed a red "Upkeep Cost -$X.XX/s" that is never
+// charged, beside a finances panel reporting $0 upkeep and a button reading
+// "Upkeep: OFF".
+//
+// Driven through the shipped animate(), because a copy of the branch would
+// prove nothing about what a player sees.
+import { describe, it, expect, beforeEach } from "vitest";
+
+const pending = [];
+globalThis.requestAnimationFrame = (cb) => { pending.push(cb); return pending.length; };
+globalThis.window.requestAnimationFrame = globalThis.requestAnimationFrame;
+
+const { STATE } = await import("../../src/state.js");
+const { CONFIG } = await import("../../src/config.js");
+const { resetGame } = await import("../../game.js");
+const { createService } = await import("../../src/sim/topology.js");
+
+let clock = 0;
+function frame() {
+    const cb = pending.pop();
+    pending.length = 0;
+    if (!cb) return false;
+    clock += 50;
+    cb(clock);
+    return true;
+}
+const display = () => document.getElementById("upkeep-display")?.innerText || "";
+const V = (x) => new globalThis.THREE.Vector3(x, 0, 0);
+
+describe("the upkeep line reports what the meter charges", () => {
+    beforeEach(() => { try { localStorage.clear(); } catch { /* */ } });
+
+    it("SANDBOX: upkeep is off, so the line does not bill for it", () => {
+        resetGame("sandbox");
+        expect(STATE.upkeepEnabled, "sandbox ships with upkeep off").toBe(false);
+        STATE.money = 5000;
+        STATE.timeScale = 1;
+        createService("db", V(0));
+        createService("compute", V(8));
+        expect(CONFIG.services.db.upkeep, "the board really does have upkeep to show")
+            .toBeGreaterThan(0);
+
+        expect(frame(), "animate() must be running for this to prove anything").toBe(true);
+        frame();
+
+        expect(display(), `the HUD billed for upkeep that is switched off: "${display()}"`)
+            .not.toMatch(/-\$[1-9]/);
+        expect(display()).toMatch(/0\.00/);
+    });
+
+    it("SURVIVAL: upkeep is on, and the line shows it", () => {
+        resetGame("survival");
+        expect(STATE.upkeepEnabled).toBe(true);
+        STATE.money = 5000;
+        STATE.timeScale = 1;
+        createService("db", V(0));
+        createService("compute", V(8));
+
+        frame();
+        frame();
+
+        // A real, non-zero rate — the mirror of the case above, so a fix that
+        // simply zeroed the line everywhere would fail here.
+        expect(display()).toMatch(/-\$\d+\.\d\d\/s/);
+        expect(display()).not.toMatch(/-\$0\.00/);
+    });
+});


### PR DESCRIPTION
989 → **994 tests**.

## The sell refund was outside the ledger

The finances panel is double entry. Placement books `expenses.services`, `byService` and `countByService`; repair, upgrade, upkeep and the serverless per-invocation charge all book too; and net profit is income minus those lines.

`deleteObject()` paid the player back with a bare `STATE.money += Math.floor(svc.config.cost / 2)` and touched none of it. Measured:

```
cost 150   refund 75
money moved:  +75
ledger moved:   0     (expenses.services stayed at 150)
```

So the money counter and the Net Profit line drift apart by **half the purchase price of every node ever sold** — permanently, since nothing reconciles them — while the expense breakdown keeps listing hardware the player no longer owns. *Place a node, try it, sell it* is normal play, and normal play should not desynchronise two numbers on the same screen.

Booked as a **reduction of what the hardware cost**, not as income: the player recovered part of a purchase, they did not earn anything. Clamped at zero, because a campaign `preBuilt` service is placed without the charge and selling one must not drive the ledger negative.

## The sandbox HUD billed for upkeep that is switched off

Sandbox ships with `CONFIG.sandbox.upkeepEnabled === false`, and `Service.update()` charges only inside its `STATE.upkeepEnabled` guard. The HUD line was the one site that never asked — the auto-repair deduction ten lines above it does check the flag, and the display right below it does not.

So every sandbox session showed a red **"Upkeep Cost −$X.XX/s"** that is never charged, beside a finances panel reporting **$0 upkeep** and a button reading **"Upkeep: OFF"**. Three readings of the same fact, two of them wrong.

Sandbox is where people try a topology out before committing to it — the worst possible place for a running cost the simulation does not apply.

## On the tests

The display test drives the shipped `animate()` rather than a copy of the branch, and **pins the survival side too**: zeroing the line in every mode would satisfy the sandbox half and be its own lie.

Three mutations, all caught — ignoring the flag again, zeroing everywhere, and dropping the refund booking.
