### PR TITLE
main fails about one full run in two, and nothing is wrong with it

### DIFF
--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -23,6 +23,22 @@ export default defineConfig({
           environment: "happy-dom",
           include: ["tests/sim/*.test.mjs"],
           setupFiles: ["tests/helpers/sim-setup.mjs"],
+          // These tests PLAY the game. The beatability harness (#254) runs
+          // every campaign level through several builds, and "the hollow set
+          // never grows" runs all twenty-four of them in one test: 2.2 s on an
+          // idle machine, and over 5 s when the rest of the suite is running
+          // beside it. Vitest's default is 5 s — a default, not a budget
+          // anyone chose for a suite like this — so main currently fails
+          // roughly one full run in two, on a machine that is merely busy.
+          //
+          // Reproduced before this change: 2 spurious failures in 4 full runs
+          // of an unmodified main, the failing test reporting 5071 ms, 5245 ms
+          // and 6134 ms against a 5000 ms limit.
+          //
+          // 20 s still catches a genuine hang, which is the only thing a
+          // timeout is for here: nothing in these tests waits on IO, a timer
+          // or a clock. They are pure simulation over a fixed dt.
+          testTimeout: 20000,
         },
       },
     ],


### PR DESCRIPTION
`the hollow set never grows` plays **all twenty-four campaign levels in a single test**. It takes 2.2 s on an idle machine and over 5 s when the rest of the suite runs beside it — and the `sim` project had no `testTimeout`, so vitest's 5 s default applied.

Measured on an **unmodified main**:

```
run 1:  × the hollow set never grows  6134ms
run 2:  ✓ 994 passed
run 3:  ✓ 994 passed
run 4:  × the hollow set never grows  5245ms
```

**Two spurious failures in four full runs.** The file passes every time on its own. Six consecutive clean full runs after this change.

## Why it matters more than it looks

A red CI nobody believes is worse than no CI. The next *real* failure in that file gets waved through as "the flaky one" — and that file is the one guarding the promise that every level's lesson is load-bearing.

## Why 20 s and not something tighter

20 s still catches a genuine hang, which is the only thing a timeout can usefully do here: nothing in these tests waits on IO, a timer or a clock. They are pure simulation over a fixed dt. A test that has not finished in 20 s is not slow — it is stuck.

Found while running the suite for an unrelated fix and briefly mistaking it for my own regression, which is exactly the cost this imposes on everyone. The sibling project had the same latent problem in its economics pair and took the same treatment.
