### PR TITLE
test: the level-simulation proofs flake on a busy machine, not on a slow one

### DIFF
--- a/tests/sim/beatability.test.mjs
+++ b/tests/sim/beatability.test.mjs
@@ -45,11 +45,19 @@
 // difficulty of a campaign people have already played, and that is a decision
 // to take deliberately. What it does is pin the table above so the hollow set
 // can only ever SHRINK, and prove the reference solutions still win.
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { achievements } from "../../src/achievements/achievements.js";
 import { createConnection } from "../../src/sim/topology.js";
 import { REAL_RANDOM, placeAt, play, svc } from "../helpers/campaign-play.mjs";
 import { STATE, resetWorld } from "../helpers/sim-world.mjs";
+
+// Every test here plays several full campaign levels end to end, which is
+// seconds of simulation rather than milliseconds of assertion. Vitest's 5s
+// default is comfortable on an idle machine and not on a busy one: measured
+// here, the same tests run about ten times slower when the CPU is saturated,
+// which is exactly the condition a shared CI runner is in. A flake that only
+// appears under load is worse than a slow test, so the budget is explicit.
+vi.setConfig({ testTimeout: 60_000 });
 
 const SEEDS = [1, 2, 42];
 

--- a/tests/sim/campaign-stars.test.mjs
+++ b/tests/sim/campaign-stars.test.mjs
@@ -15,12 +15,20 @@
 //   2. The PROOFS are simulation. They play the three levels that gate an
 //      achievement through the real path and land three stars. Arithmetic
 //      cannot tell you a bonus pair is reachable; only a run can.
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { achievements } from "../../src/achievements/achievements.js";
 import { CAMPAIGN_LEVELS } from "../../src/campaign/levels.js";
 import { createConnection, deleteObject } from "../../src/sim/topology.js";
 import { REAL_RANDOM, placeAt, play, svc } from "../helpers/campaign-play.mjs";
 import { STATE, resetWorld } from "../helpers/sim-world.mjs";
+
+// The proofs here play whole campaign levels, several seeds each, which is
+// seconds of simulation rather than milliseconds of assertion. Vitest's 5s
+// default is comfortable on an idle machine and not on a busy one: measured
+// here, the same tests run about ten times slower when the CPU is saturated,
+// which is exactly the condition a shared CI runner is in. A flake that only
+// appears under load is worse than a slow test, so the budget is explicit.
+vi.setConfig({ testTimeout: 60_000 });
 
 // ---------------------------------------------------------------- the walk
 


### PR DESCRIPTION
`beatability.test.mjs` and `campaign-stars.test.mjs` each play whole campaign levels end to end, several seeds at a time — seconds of simulation, not milliseconds of assertion. Vitest's 5s default is comfortable only while the machine is idle.

Measured here with the CPU saturated:

| test | idle | loaded |
|---|---|---|
| L5 — Queue withheld | 386ms | **5311ms** (timed out) |
| the hollow set never grows | 1009ms | **9460ms** (timed out) |

Nothing about the assertions changed. The machine was busy, which is the normal condition of a shared CI runner — this has not bitten CI yet, but it is waiting to.

A flake that appears only under load is worse than a slow test: it reads as a real failure, and the retry that makes it pass teaches people to retry. Both files now state a 60s budget explicitly — about ten times the loaded measurement, and still short enough that a genuine hang fails the run instead of stalling it.