### PR TITLE
fix: on a phone held upright the camera framed a strip of board and a field of empty grid (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (49 test files, 994 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (50 test files, 1011 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/game.js
+++ b/game.js
@@ -293,16 +293,37 @@ const scene = new THREE.Scene();
 scene.background = new THREE.Color(CONFIG.colors.bg);
 scene.fog = new THREE.FogExp2(CONFIG.colors.bg, 0.008);
 
-const aspect = window.innerWidth / window.innerHeight;
 const d = 50;
-const camera = new THREE.OrthographicCamera(
-    -d * aspect,
-    d * aspect,
-    d,
-    -d,
-    1,
-    1000
-);
+const camera = new THREE.OrthographicCamera(-d, d, d, -d, 1, 1000);
+
+// The orthographic frustum, sized so the board stays on screen whatever shape
+// the viewport is (#12).
+//
+// The two half-extents have to keep the viewport's own aspect or the world
+// shears, so only one of them is free to choose. Fixing the VERTICAL one and
+// deriving the horizontal is right for a landscape screen and wrong for a
+// portrait one: at 375x812 the aspect is 0.46, which leaves 46 world units of a
+// 120-unit grid visible sideways while still showing 100 units top to bottom.
+// That is a strip of board in a field of empty grid, which is what #12 reports.
+//
+// So the HORIZONTAL half-extent is the one that carries a floor, and the
+// vertical follows from it. Landscape is untouched by construction: d * aspect
+// is already 50 at a square viewport and only grows from there, so every
+// viewport at or above 1:1 computes exactly the numbers it always did.
+const MIN_HALF_WIDTH = 45;
+
+function applyCameraFrustum() {
+    const aspect = window.innerWidth / window.innerHeight;
+    const halfWidth = Math.max(d * aspect, MIN_HALF_WIDTH);
+    const halfHeight = halfWidth / aspect;
+    camera.left = -halfWidth;
+    camera.right = halfWidth;
+    camera.top = halfHeight;
+    camera.bottom = -halfHeight;
+    camera.updateProjectionMatrix();
+}
+
+applyCameraFrustum();
 const cameraTarget = new THREE.Vector3(0, 0, 0);
 resetCamera();
 
@@ -1772,6 +1793,7 @@ export {
     animate,
     badgeGroup,
     calculateTargetRPS,
+    applyCameraFrustum,
     camera,
     cameraTarget,
     connectionGroup,

--- a/src/input/handlers.js
+++ b/src/input/handlers.js
@@ -33,9 +33,9 @@ import {
 // at event time (or, for resetCamera's camera/cameraTarget reads, when
 // game.js's own body calls it), long after both modules evaluate.
 import {
+    applyCameraFrustum,
     camera,
     cameraTarget,
-    d,
     mouse,
     openMainMenu,
     plane,
@@ -920,12 +920,10 @@ container.addEventListener("mouseup", (e) => {
 });
 
 window.addEventListener("resize", () => {
-    const aspect = window.innerWidth / window.innerHeight;
-    camera.left = -d * aspect;
-    camera.right = d * aspect;
-    camera.top = d;
-    camera.bottom = -d;
-    camera.updateProjectionMatrix();
+    // The frustum math lives in game.js and is shared with the initial camera
+    // (#12). It used to be written out twice, which is how the two copies came
+    // to disagree about what a portrait viewport should show.
+    applyCameraFrustum();
     renderer.setSize(window.innerWidth, window.innerHeight);
 });
 

--- a/tests/sim/camera-framing.test.mjs
+++ b/tests/sim/camera-framing.test.mjs
@@ -1,0 +1,122 @@
+// The board has to be on screen, whatever shape the screen is (#12).
+//
+// The camera is orthographic, and its two half-extents must keep the viewport's
+// own aspect or the world shears. Only one of them is therefore free to choose,
+// and the original code chose the vertical one: half-height fixed at d, half-
+// width derived as d * aspect. That reads correctly on a landscape monitor and
+// inverts on a phone held upright, where aspect is well under 1 and the derived
+// half-width collapses.
+//
+// Measured on the reported viewport, 375x812: the old formula showed 46 world
+// units of a 120-unit grid sideways while still showing 100 top to bottom, so
+// the board arrived as a strip in a field of empty grid.
+//
+// The fix floors the HORIZONTAL half-extent and derives the vertical. Landscape
+// is untouched by construction, and the first describe below is what proves it:
+// every viewport at or above a square recomputes the exact numbers it always had.
+import { describe, it, expect, afterAll } from "vitest";
+import { applyCameraFrustum, camera, d } from "../../game.js";
+
+const REAL = { w: globalThis.window.innerWidth, h: globalThis.window.innerHeight };
+
+function frustumAt(width, height) {
+    Object.defineProperty(globalThis.window, "innerWidth", { value: width, configurable: true });
+    Object.defineProperty(globalThis.window, "innerHeight", { value: height, configurable: true });
+    applyCameraFrustum();
+    return {
+        left: camera.left,
+        right: camera.right,
+        top: camera.top,
+        bottom: camera.bottom,
+        worldWidth: camera.right - camera.left,
+        worldHeight: camera.top - camera.bottom,
+    };
+}
+
+/** What the code did before the fix, kept here so "unchanged" is a comparison. */
+function originalFormula(width, height) {
+    const aspect = width / height;
+    return { left: -d * aspect, right: d * aspect, top: d, bottom: -d };
+}
+
+afterAll(() => {
+    frustumAt(REAL.w, REAL.h);
+});
+
+describe("landscape is byte-identical to the formula it replaced", () => {
+    // The whole safety argument for this change: nothing at or above a square
+    // viewport moves at all, so no desktop player sees a different board.
+    for (const [w, h, label] of [
+        [1920, 1080, "1080p"],
+        [1440, 900, "laptop"],
+        [1280, 800, "the calibration size used across this repo"],
+        [1024, 768, "4:3"],
+        [900, 900, "square, the exact boundary of 'landscape'"],
+    ]) {
+        it(`${w}x${h} — ${label}`, () => {
+            const now = frustumAt(w, h);
+            const before = originalFormula(w, h);
+            expect(now.left).toBeCloseTo(before.left, 9);
+            expect(now.right).toBeCloseTo(before.right, 9);
+            expect(now.top).toBeCloseTo(before.top, 9);
+            expect(now.bottom).toBeCloseTo(before.bottom, 9);
+        });
+    }
+});
+
+describe("portrait gets the board back", () => {
+    it("375x812 shows most of the grid sideways instead of a third of it", () => {
+        const now = frustumAt(375, 812);
+        const before = originalFormula(375, 812);
+        // Measured: 46 world units before, 90 after, against a 120-unit grid.
+        expect(before.right - before.left).toBeLessThan(50);
+        expect(now.worldWidth).toBeGreaterThan(85);
+        // And it is genuinely wider than it was, which is the point.
+        expect(now.worldWidth).toBeGreaterThan((before.right - before.left) * 1.8);
+    });
+
+    it("a narrower phone gets the same horizontal reach, not a smaller one", () => {
+        // The floor is on the horizontal extent precisely so that a narrower
+        // screen does not show LESS board — it shows the same width and more
+        // height. Under the old formula 320x900 was worse than 375x812.
+        const narrow = frustumAt(320, 900);
+        const wider = frustumAt(375, 812);
+        expect(narrow.worldWidth).toBeCloseTo(wider.worldWidth, 9);
+        expect(narrow.worldHeight).toBeGreaterThan(wider.worldHeight);
+    });
+});
+
+describe("the world never shears", () => {
+    // The invariant that outranks both of the above: world units must stay
+    // square, or a service placed at a snapped grid point renders off its tile
+    // and every hit-test drifts with it.
+    for (const [w, h] of [
+        [1920, 1080], [1280, 800], [1000, 1000], [812, 375],
+        [768, 1024], [375, 812], [320, 900], [280, 1000],
+    ]) {
+        it(`${w}x${h}`, () => {
+            const f = frustumAt(w, h);
+            expect(f.worldWidth / f.worldHeight).toBeCloseTo(w / h, 9);
+        });
+    }
+});
+
+describe("the floor engages exactly where it should and nowhere else", () => {
+    it("hands over to the original formula at aspect 0.9", () => {
+        // d = 50 and the floor is 45, so d * aspect crosses the floor at 0.9.
+        // Just above it the original formula wins; just below, the floor does.
+        const above = frustumAt(901, 1000); // aspect 0.901
+        expect(above.right).toBeCloseTo(d * 0.901, 6);
+
+        const below = frustumAt(899, 1000); // aspect 0.899
+        expect(below.right).toBeGreaterThan(d * 0.899);
+        expect(below.right).toBeCloseTo(45, 6);
+    });
+
+    it("a landscape viewport never hits the floor", () => {
+        for (const [w, h] of [[1920, 1080], [1280, 800], [1024, 768], [1000, 1000]]) {
+            const f = frustumAt(w, h);
+            expect(f.right, `${w}x${h}`).toBeGreaterThan(45);
+        }
+    });
+});


### PR DESCRIPTION
Part of #12 — the smallest of the three things wrong on mobile, and the one the report names directly.

## The defect

The camera is orthographic, so its two half-extents must keep the viewport's own aspect or the world shears. Only one is free to choose, and the original pair chose the vertical — half-height pinned at `d`, half-width derived as `d * aspect`:

```js
new THREE.OrthographicCamera(-d * aspect, d * aspect, d, -d, 1, 1000)
```

That reads correctly on a landscape monitor and inverts on a phone held upright. The grid is `gridSize * tileSize` = 120 world units across:

| viewport | aspect | visible sideways | of a 120-unit grid |
|---|---|---|---|
| 1280 x 800 | 1.60 | 160 units | all of it |
| 375 x 812 | 0.46 | **46 units** | about a third |

Vertically it still showed 100 units either way, so the board arrived as a strip surrounded by grid — "empty grid which take whole screen".

## The fix

The **horizontal** half-extent carries a floor and the vertical follows from it. At 375 x 812 the board gets 90 world units of width instead of 46.

**Landscape is untouched by construction, not by care.** `d * aspect` is already 50 at a square viewport and only grows from there, so every viewport at or above 1:1 recomputes exactly the numbers it always had. Verified live at 1280 x 800: `left -80, right 80, top 50, bottom -50`, identical to the old formula to within 1e-9.

`camera-framing.test.mjs` pins that against the original formula at five landscape sizes, and pins the invariant that outranks both: **frustum aspect equals viewport aspect at every size tested**, so world units stay square and a service snapped to a grid point still renders on its tile. Reverting the floor reddens 3 of the 17 checks and leaves the other 14 green — which is right, since those hold under either formula.

The same math was also written out twice, in `game.js` and again in the resize handler at `src/input/handlers.js:922`. That is how the two copies came to disagree about what a portrait viewport should show; they now share one function.

## What this does not fix

Two larger things, both measured in [the issue comment](https://github.com/pshenok/server-survival/issues/12#issuecomment-5361737509):

- **The HUD still covers the board.** Six absolutely-positioned panels, four overlapping pairs at 375px, and a top bar that starts at x = -15 and gives the page a horizontal scroll.
- **The board still cannot be touched.** The game binds `mousedown`/`mousemove`/`wheel` and there is no `touchstart` anywhere in the source, so placing a node and panning the camera have no touch path at all.

The touch one is a defect I am happy to take. The HUD one is a layout decision — on a phone those six panels have to become something else, and which something is a product call rather than a refactor.