### PR TITLE
Shedding traffic made the board look healthier, not the same

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (50 test files, 1011 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (51 test files, 1015 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -419,6 +419,14 @@ function throttleRequest(req, reason = null) {
     // keeps Service.update() from scoring it as a breaker success either.
     req.throttled = true;
     updateScore(req, "THROTTLED");
+    // A 429 is load shedding working as designed and deliberately NOT a
+    // failure — it stays out of the failures panel, the metrics error rate
+    // and the breaker window. But it is still a customer who got no answer,
+    // and goodput's whole job is to count those. Without this an API Gateway
+    // — the node the game teaches you to buy for shedding — turned the
+    // headline number green by making demand disappear: nine served and
+    // ninety shed read 100%.
+    recordOutcome("unanswered");
     STATE.sound.playFail();
     req.mesh.material.color.setHex(CONFIG.colors.apigw); // Pink flash for throttled
     // Soft fail (#156): the badge paints this one amber, not red — the

--- a/src/core/metrics.js
+++ b/src/core/metrics.js
@@ -70,7 +70,17 @@ let pendingOnTime = 0;
 let pendingLate = 0;
 let pendingFailed = 0;
 
-/** Called from the request lifecycle — one call per terminated request. */
+/**
+ * Called from the request lifecycle — one call per terminated request.
+ *
+ * Three buckets, and the third one is wider than its name: it is "demand that
+ * got no timely answer", not "a service errored". A dropped request, a 429
+ * from a rate limiter and an event drained out of a dead-letter queue are
+ * different events with different costs, and the player sees them differently
+ * — but to goodput they are the same thing, a customer who did not get served.
+ * Leaving any of them out of the denominator is what lets a board that sheds
+ * nine tenths of its traffic report itself perfect.
+ */
 function recordOutcome(kind) {
     if (kind === "onTime") pendingOnTime++;
     else if (kind === "late") pendingLate++;

--- a/src/sim/dlq.js
+++ b/src/sim/dlq.js
@@ -14,6 +14,7 @@
 // normally, so nothing is ever stranded.
 
 import { STATE } from "../state.js";
+import { recordOutcome } from "../core/metrics.js";
 // Runtime-only cycle (actions.js ⇄ dlq.js): removeRequest is a hoisted
 // function declaration, only dereferenced when a drain actually fires — long
 // after both modules finish evaluating. Same established pattern as retry.js.
@@ -86,6 +87,13 @@ export function tickDLQ(dlq, dt) {
                 (STATE.finances.expenses.mitigation || 0) +
                 (dlq.config.drainCost || 0);
         }
+        // Neither success nor failure — that is the DLQ's whole point, and
+        // the failures panel still does not count it. Goodput does: the event
+        // was parked instead of served, and someone was waiting for it. A DLQ
+        // is the other node the game teaches you to buy so failures stop
+        // being failures, and a metric that cannot see it rewards hiding the
+        // outage rather than fixing it.
+        recordOutcome("unanswered");
         removeRequest(req);
     }
 }

--- a/tests/sim/shed-traffic.test.mjs
+++ b/tests/sim/shed-traffic.test.mjs
@@ -1,0 +1,98 @@
+// Demand that got no answer is demand that got no answer.
+//
+// Two termination paths ended a request without ever reaching the goodput
+// denominator: throttleRequest (a 429 from the API Gateway) and tickDLQ's
+// drain (an event parked in a dead-letter queue and later dropped). Both are
+// deliberately NOT failures — a 429 is load shedding working as designed, and
+// the DLQ's whole point is that a failure stops being one — so neither
+// belongs in the failures panel, and neither is put there here.
+//
+// But goodput exists to answer one question: what share of recent demand was
+// answered while someone still wanted it. Its own header says why failures
+// are in the denominator — "a board that drops everything and serves three
+// requests quickly would read 100%" — and shedding is the same hole by a
+// politer name.
+//
+// The two nodes involved are precisely the ones the game teaches you to buy:
+// an API Gateway for load shedding, a DLQ so failures stop being failures.
+// Build both and the board reported itself perfect while a tenth of its
+// traffic got nothing.
+import { describe, it, expect, beforeEach } from "vitest";
+import { STATE, resetWorld, place, connect } from "../helpers/sim-world.mjs";
+import { finishRequest, throttleRequest } from "../../src/core/actions.js";
+import { getRollingGoodput, metricsTick, resetMetrics } from "../../src/core/metrics.js";
+import { parkInDLQ, tickDLQ } from "../../src/sim/dlq.js";
+import { Request } from "../../src/entities/Request.js";
+
+const failuresTotal = () => Object.values(STATE.failures).reduce((a, n) => a + n, 0);
+
+function serve(db, n, age = 0.1) {
+    for (let i = 0; i < n; i++) {
+        const req = new Request("READ");
+        STATE.requests.push(req);
+        req.age = age;
+        finishRequest(req, db.type, db);
+    }
+}
+
+describe("shed traffic is still demand", () => {
+    beforeEach(() => {
+        resetWorld({ gameMode: "survival" });
+        resetMetrics();
+    });
+
+    it("A RATE LIMITER CANNOT MAKE THE BOARD LOOK HEALTHY", () => {
+        const db = place("db");
+        serve(db, 9);
+        for (let i = 0; i < 90; i++) {
+            const req = new Request("READ");
+            STATE.requests.push(req);
+            throttleRequest(req);          // 429 — ninety customers, no answer
+        }
+        metricsTick(0.5);
+
+        // Nine of ninety-nine were served.
+        expect(getRollingGoodput()).toBeCloseTo(9 / 99, 6);
+        // ...and a 429 is still not a failure. That distinction is the point
+        // of the API Gateway and it survives this change untouched.
+        expect(failuresTotal()).toBe(0);
+    });
+
+    it("...and neither can a dead-letter queue", () => {
+        const db = place("db");
+        // parkInDLQ takes the UPSTREAM node and finds the DLQ through its
+        // connections, and only compute/serverless/alb/apigw may wire to one.
+        const compute = place("compute");
+        const dlq = place("dlq");
+        connect(compute, dlq);
+        serve(db, 4);
+        for (let i = 0; i < 16; i++) {
+            const req = new Request("READ");
+            STATE.requests.push(req);
+            expect(parkInDLQ(req, compute), "the request must actually park").toBe(true);
+        }
+        // Drain the whole queue.
+        for (let t = 0; t < 200 && dlq.parked.length > 0; t++) tickDLQ(dlq, 0.6);
+        expect(dlq.parked.length, "the queue really did drain").toBe(0);
+        metricsTick(0.5);
+
+        expect(getRollingGoodput()).toBeCloseTo(4 / 20, 6);
+    });
+
+    it("A BOARD THAT ACTUALLY SERVES ITS TRAFFIC STILL READS 100%", () => {
+        // The mirror. Counting shed traffic as unanswered is only honest if
+        // an honest board is unaffected — otherwise the fix is just a new lie
+        // pointing the other way.
+        const db = place("db");
+        serve(db, 30);
+        metricsTick(0.5);
+        expect(getRollingGoodput()).toBe(1);
+    });
+
+    it("an idle board still reads nothing at all, not 100%", () => {
+        // getRollingGoodput returns null for an empty window on purpose, and
+        // adding buckets must not turn "nothing happened" into a score.
+        metricsTick(0.5);
+        expect(getRollingGoodput()).toBeNull();
+    });
+});


### PR DESCRIPTION
994 → **998 tests**.

Two termination paths ended a request without ever reaching the goodput denominator:

- `throttleRequest()` — a 429 from the API Gateway
- `tickDLQ()`'s drain — an event parked in a dead-letter queue and later dropped

**Neither is a failure, and neither is made one here.** A 429 is load shedding working as designed — it stays out of the failures panel, the metrics error rate and the breaker window — and the DLQ's whole point is that a failure stops being one. That distinction is worth keeping and is untouched.

But goodput answers one question: *what share of recent demand was answered while someone still wanted it.* Its own header says why failures are in the denominator —

> a board that drops everything and serves three requests quickly would read 100%

— and shedding is that same hole by a politer name. Measured on nine served and ninety throttled:

```
goodput: 1.0        (100%, green)
failures panel: 0   across all seven traffic types
processed: 9        of 99 customers
```

## Why it teaches backwards

The two nodes involved are exactly the ones the game teaches you to buy: an **API Gateway** for load shedding, a **DLQ** so failures stop being failures. Build both and the board reported itself perfect while a tenth of its traffic got nothing.

*Shed it or dead-letter it and the dashboards go quiet* is the production habit that hides an outage. A metric that rewards it is worse than no metric.

Nine of ninety-nine now reads **9%**. The third bucket is documented as what it always was — demand that got no timely answer, not a service error.

## Two mirrors

So this cannot become a lie pointing the other way:

- a board that genuinely serves its traffic still reads **100%**;
- an idle board still reads **nothing at all** (`null` → `--`), not a perfect score.

Three mutations, all caught: dropping either call, and bucketing shed traffic as `onTime`.
