### PR TITLE
fix: level 3 said your site went viral and then never sent a spike (#254)

### DIFF
--- a/src/campaign/levels.js
+++ b/src/campaign/levels.js
@@ -94,7 +94,10 @@ export const CAMPAIGN_LEVELS = [
         id: 3, chapter: 1,
         icon: "🌍",
         diagramHighlights: {},
-        budget: 150,
+        // 170, not 150: the level's own reference build is a CDN (60) plus the
+        // Compute tier (100), and at 150 the upgrade silently failed the
+        // affordability check — the briefed solution could not be bought.
+        budget: 170,
         durationSec: 60,
         preBuilt: {
             services: [
@@ -108,6 +111,15 @@ export const CAMPAIGN_LEVELS = [
         },
         trafficDistribution: { STATIC: 0.8, READ: 0.1, WRITE: 0.05, UPLOAD: 0, SEARCH: 0, MALICIOUS: 0.05 },
         rps: 8,
+        // "Your site went viral" is a SPIKE, and that is what makes the CDN
+        // load-bearing (#254). At a flat 8 rps the level was won by an
+        // untouched board — 80% STATIC at 0.5 processing weight fits inside a
+        // tier-1 Compute, so nothing the briefing teaches was needed. A burst
+        // arrives 20ms apart, i.e. 50 req/s while it lasts, and 80% of it is
+        // STATIC: the origin path needs ~17 concurrent slots to hold it and
+        // the biggest box the budget buys has 10. Only moving STATIC to the
+        // edge removes the demand instead of queueing it.
+        burstPattern: { enabled: true, intervalSec: 5, burstSize: 30 },
         allowedServices: ["cdn"],
         objectives: {
             primary: [

--- a/tests/sim/beatability.test.mjs
+++ b/tests/sim/beatability.test.mjs
@@ -12,7 +12,7 @@
 // actually turns on (five seeds, with the levels' own burst patterns firing):
 //
 //   level  teaches   taught+tier  tier only  taught only  neither
-//   L3     CDN         5/5          5/5        5/5         5/5
+//   L3     CDN         5/5          0/5        5/5         0/5
 //   L4     Cache       5/5          5/5        2/5         2/5
 //   L5     Queue       5/5          0/5        0/5         0/5
 //   L6     Replica     5/5          5/5        0/5         0/5
@@ -21,17 +21,22 @@
 //   L9     API GW      0/5          0/5        0/5         0/5
 //   L12    2nd WAF     5/5          0/5        0/5         0/5
 //
-// Two levels (3, 4) pass on an untouched board. On three more (6, 7, 8) the
-// taught node is decorative in BOTH directions: without the tier they lose
-// even when it is correctly wired, and with the tier they win without it. The
-// cause is capacity — Compute runs 4 concurrent at 600ms, about 6.7 req/s, and
-// those levels arrive at 6-7 rps — so Compute binds before any downstream
-// store can matter. For those five, chapter 2 mechanically teaches "buy a
-// bigger box".
+// L4 still passes on an untouched board. On three more (6, 7, 8) the taught
+// node is decorative in BOTH directions: without the tier they lose even when
+// it is correctly wired, and with the tier they win without it. The cause is
+// capacity — Compute runs 4 concurrent at 600ms, about 6.7 req/s, and those
+// levels arrive at 6-7 rps — so Compute binds before any downstream store can
+// matter. For those four, chapter 2 mechanically teaches "buy a bigger box".
 //
-// L5 and L12 are what a working lesson looks like: withhold the queue or the
-// second WAF and the level is lost 0/5, whatever else is bought. Neither a
-// spike nor a malicious share is something more CPU absorbs.
+// L3, L5 and L12 are what a working lesson looks like: withhold the CDN, the
+// queue or the second WAF and the level is lost, whatever else is bought.
+// Neither a spike nor a malicious share is something more CPU absorbs.
+//
+// L3 is the strongest shape of the three, and the only one where the taught
+// node is not merely necessary but SUFFICIENT: the CDN alone wins 5/5 while
+// the Compute tier alone, a DB tier, auto-scaling, and tier-plus-auto-scaling
+// each lose 5/5. It got there by making its own briefing true — "your site
+// went viral" is a spike, and it did not have one.
 //
 // L9 is broken rather than hollow — no legal build wins it at all (#276).
 //
@@ -64,7 +69,24 @@ const SEEDS = [1, 2, 42];
 // Each level's own briefed lesson, split into the two levers so either can be
 // withheld. `taught` places and wires the service the level is about; `tier`
 // buys the Compute upgrade.
-const tier = () => svc("compute").upgrade();
+const tier = () => {
+    const compute = svc("compute");
+    const before = compute.tier;
+    compute.upgrade();
+    // Service.upgrade() returns silently when the money is not there, so a
+    // level whose budget cannot afford its own reference build quietly
+    // measures something other than the row it is printed under. L3 sat like
+    // that: budget 150 against a $60 CDN plus a $100 tier, so every number it
+    // ever produced in the "taught + tier" column was really taught-only, and
+    // nothing said so. Loud is better.
+    if (compute.tier === before) {
+        throw new Error(
+            `L${STATE.campaign.level?.id}: the Compute tier did not land ` +
+                `($${Math.round(STATE.money)} left) — this level cannot afford ` +
+                `the build this file claims to measure`
+        );
+    }
+};
 
 const LEVELS = {
     3: {
@@ -136,7 +158,7 @@ const LEVELS = {
 // grow, so fixing a level is a one-line deletion and shipping a new hollow one
 // is a red build. L9 is absent because it wins with NOTHING withheld either
 // (#276) — broken is a different state from hollow, and it is asserted apart.
-const KNOWN_HOLLOW = new Set([3, 4, 6, 7, 8]);
+const KNOWN_HOLLOW = new Set([4, 6, 7, 8]);
 
 // Winnable by nobody (#276). Kept out of the hollow set: a level that no build
 // can beat is a different defect from one that any build can.
@@ -231,12 +253,12 @@ describe("the Compute tier is the lever chapter 2 actually turns on", () => {
         });
     }
 
-    it("two levels pass on a board the player never touched", () => {
+    it("one level still passes on a board the player never touched", () => {
         const untouched = [3, 4, 5, 9].filter((id) => winRate(id, () => {}) > 0);
         // Asserting the defect so the fix has something to turn red. When a
-        // level here stops passing untouched, this list is what to edit.
-        // L5 and L9 are probed and expected to be absent: L5's burst makes its
-        // queue load-bearing, and L9 cannot be won by anyone.
-        expect(untouched).toEqual([3, 4]);
+        // level here stops passing untouched, this list is what to edit — L3
+        // just did. L5 and L9 are probed and expected to be absent: L5's burst
+        // makes its queue load-bearing, and L9 cannot be won by anyone.
+        expect(untouched).toEqual([4]);
     });
 });


### PR DESCRIPTION
First level out of `KNOWN_HOLLOW`. The set shrinks for the first time.

## The level did not do what it said

`level_3_scenario`: *"Your site went viral and 80% of traffic is static assets — your servers are drowning."*
`level_3_learn`: *"Traffic served by CDN never touches your origin servers."*

Measured, none of that was true. An untouched board won L3 **5/5** — place nothing, buy nothing, win. Nothing was drowning, so nothing the CDN does was needed, and the sentence about origin servers was flavour text rather than a mechanic.

## The fix is to make the briefing true

The level now sends the spike it describes. A burst spawns 20ms apart — 50 req/s while it lasts — and 80% of that is STATIC. Holding it on the origin needs roughly 17 concurrent slots; the biggest box this budget buys has 10. Moving STATIC to the edge is the only move that *removes* the demand instead of queueing it.

Verified on seeds the tuning was **not** fitted to (11, 23, 57, 101, 999):

| build | result |
|---|---|
| CDN + Compute tier | **5/5 win**, reputation 100, zero failures, 3 stars |
| **CDN alone** | **5/5 win**, reputation 96–100, 3 stars |
| Compute tier alone | 0/5 |
| DB tier instead | 0/5 |
| auto-scaling only | 0/5 |
| tier + auto-scaling | 0/5 |
| nothing | 0/5 |

That is the strongest shape in the chapter, and the only one so far where the taught node is not merely *necessary* but **sufficient**. L5 and L12 both need their lesson *and* the tier; here the CDN wins on its own and no amount of vertical scaling substitutes for it.

A flat rate increase was tried first and rejected: there is no arrival rate where CDN-only wins 5/5 while tier-only loses 0/5, because CDN-only starts degrading (around rps 26) before tier-only does (around rps 30) and the bands never separate. The spike separates them because it attacks the one thing a faster box cannot fix — and it is what the level already claimed to be about.

## The budget move is a defect, not tuning

L3's own reference build is a $60 CDN plus the $100 Compute tier — $160 against a $150 budget. `Service.upgrade()` fails its affordability check and **returns in silence**.

So every "taught + tier" number L3 has ever produced — including the row I published in #272 — was really measuring CDN-only. Instrumented on main before this change:

```
L3 {"budgetAtStart":150,"afterCdn":90,"tierBefore":1,"tierAfter":1,"capacity":4}
L4 {"budget":200,"afterTaught":140,"tierBefore":1,"tierAfter":2}   <- lands
L6 {"budget":200,"afterTaught":100,"tierBefore":1,"tierAfter":2}   <- lands
```

At 170 the tier lands with $10 to spare, and nothing degenerate becomes affordable: tier 3 is another $160 and `allowedServices` is `["cdn"]`.

**`beatability.test.mjs` now makes this impossible to repeat.** Buying the tier asserts the tier actually landed, naming the level and the money left when it did not. Reverting the budget to 150 turns the row red with:

```
L3: the Compute tier did not land ($90 left) — this level cannot afford
the build this file claims to measure
```

rather than quietly measuring something else, which is what it did before.

## Scope

Two fields on one level, both carrying their reasoning in the file. `rps` stays 8, the traffic mix stays 80% STATIC (the briefing states that number), and objectives, duration, fail conditions and pre-built board are untouched. `campaign-stars.test.mjs` still passes 19/19 — L3's three-star proof holds, now with a Compute tier that is actually bought.