### PR TITLE
The cost-spike banner promised something the meter never charged

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (51 test files, 1015 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (52 test files, 1020 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -28,8 +28,23 @@ import { spawnFailureBadge, spawnServiceBadge } from "../ui/failure-badges.js";
 import { parkInDLQ } from "../sim/dlq.js";
 
 function getUpkeepMultiplier() {
-    if (STATE.gameMode !== "survival") return 1.0;
-    if (!CONFIG.survival.upkeepScaling.enabled) return 1.0;
+    // TWO different things live here, and they had one gate between them.
+    //
+    // The RAMP below (1x to 2x over ten minutes) is a survival progression
+    // mechanic and stays survival-only — that is what the gate was written
+    // for, before the event existed.
+    //
+    // The COST SPIKE is an EVENT, and updateRandomEvents runs it inside any
+    // campaign level with enableSurvivalShifts (14 and 25). Its arrival was
+    // gated on the level; its effect was gated on the mode. So the player got
+    // an eight-second danger toast reading "Upkeep doubled for 30s" plus a
+    // full-width red bar, and the meter charged exactly what it had before.
+    // The other three event types have no such split — CAPACITY_DROP and the
+    // rest write state that is consumed ungated.
+    const spike = STATE.intervention?.costMultiplier || 1.0;
+
+    if (STATE.gameMode !== "survival") return spike;
+    if (!CONFIG.survival.upkeepScaling.enabled) return spike;
 
     const gameTime =
         STATE.elapsedGameTime ?? (performance.now() - STATE.gameStartTime) / 1000;
@@ -43,11 +58,7 @@ function getUpkeepMultiplier() {
 
     let multiplier = base + (max - base) * progress;
 
-    if (STATE.intervention?.costMultiplier) {
-        multiplier *= STATE.intervention.costMultiplier;
-    }
-
-    return multiplier;
+    return multiplier * spike;
 }
 
 function getTrafficType() {

--- a/tests/helpers/sim-world.mjs
+++ b/tests/helpers/sim-world.mjs
@@ -47,6 +47,29 @@ export function resetWorld({ money = 100000, gameMode = "sandbox" } = {}) {
   STATE.selectedNodeId = null;
   STATE.activeTool = "select";
 
+  // ...and so do the interventions, which this helper's own header has
+  // claimed since it was written ("no degradation, no upkeep drain, no
+  // INTERVENTIONS") without ever clearing them. Nothing noticed while the
+  // one that bites — costMultiplier — was suppressed outside survival by a
+  // mode gate; the moment that gate was narrowed to the survival ramp it
+  // belongs to, a COST_SPIKE left behind by one test started doubling the
+  // upkeep in the next. Same list resetGame() clears.
+  if (STATE.intervention) {
+    STATE.intervention.costMultiplier = 1.0;
+    STATE.intervention.trafficBurstMultiplier = 1.0;
+    STATE.intervention.rpsMultiplier = 1.0;
+    STATE.intervention.eventEndTime = 0;
+    STATE.intervention.randomEventTimer = 0;
+    STATE.intervention.pausedEvent = null;
+    STATE.intervention.remainingTime = 0;
+    STATE.intervention.pausedOutageServiceId = null;
+    STATE.intervention.currentMilestoneIndex = 0;
+    STATE.intervention.trafficShiftActive = false;
+    STATE.intervention.trafficShiftTimer = 0;
+    STATE.intervention.originalTrafficDist = null;
+    STATE.intervention.currentShift = null;
+  }
+
   resetResilience(); // mirrors resetGame() (#196 session counters)
 
   STATE.campaign.active = false;

--- a/tests/sim/cost-spike-bites.test.mjs
+++ b/tests/sim/cost-spike-bites.test.mjs
@@ -1,0 +1,86 @@
+// The COST SPIKE banner promised something the meter did not charge.
+//
+// getUpkeepMultiplier() bundled two different things behind one gate:
+//
+//   the RAMP  — upkeep climbing 1x to 2x over ten minutes, a survival
+//               progression mechanic, and what `gameMode !== "survival"` was
+//               written to guard;
+//   the SPIKE — STATE.intervention.costMultiplier, set by a random EVENT.
+//
+// updateRandomEvents runs inside any campaign level with enableSurvivalShifts
+// (14 and 25), so the event's ARRIVAL was gated on the level while its EFFECT
+// was gated on the mode. The player got an eight-second danger toast reading
+// "CLOUD COST SPIKE! Upkeep doubled for 30s" and a full-width red bar, and the
+// upkeep charged exactly what it had the second before.
+//
+// The other three event types have no such split: CAPACITY_DROP and the rest
+// write state that is consumed ungated.
+//
+// What it costs, measured before making the change — worst case, the spike
+// pinned on for the WHOLE level rather than its real 30 s window:
+//   L14 (90 s, a five-service board): 644 -> 629, fifteen dollars
+//   L25 (300 s, nine prebuilt):      2134 -> 1801
+// against a moneyBelow floor of -500 in both. Both levels are lost on
+// reputation, which a cost spike does not touch.
+import { describe, it, expect, beforeEach } from "vitest";
+import { STATE, CONFIG, resetWorld, place } from "../helpers/sim-world.mjs";
+import { getUpkeepMultiplier } from "../../src/core/actions.js";
+
+describe("a cost spike costs money in every mode that can raise its banner", () => {
+    beforeEach(() => resetWorld({ gameMode: "campaign" }));
+
+    it("THE LIE: the campaign banner said doubled and the meter charged 1x", () => {
+        expect(getUpkeepMultiplier()).toBe(1.0);
+        STATE.intervention.costMultiplier = 2.0;        // what the event sets
+        expect(getUpkeepMultiplier(), "the banner is up and nothing changed").toBe(2.0);
+    });
+
+    it("...and a service really is charged double while it is up", () => {
+        STATE.upkeepEnabled = true;
+        const db = place("db");
+        const rate = CONFIG.services.db.upkeep / 60;
+
+        let before = STATE.money;
+        db.update(1);
+        const plain = before - STATE.money;
+
+        STATE.intervention.costMultiplier = 2.0;
+        before = STATE.money;
+        db.update(1);
+        const spiked = before - STATE.money;
+
+        expect(plain).toBeCloseTo(rate, 6);
+        expect(spiked).toBeCloseTo(rate * 2, 6);
+    });
+
+    it("THE RAMP STAYS SURVIVAL-ONLY — the gate still guards what it was for", () => {
+        // Narrowing the gate must not import survival's ten-minute upkeep
+        // climb into a campaign level, which would re-price all twenty-five.
+        STATE.elapsedGameTime = CONFIG.survival.upkeepScaling.scaleTime;  // fully ramped
+        expect(getUpkeepMultiplier(), "the survival ramp leaked into a campaign").toBe(1.0);
+
+        resetWorld({ gameMode: "survival" });
+        STATE.elapsedGameTime = CONFIG.survival.upkeepScaling.scaleTime;
+        expect(getUpkeepMultiplier()).toBeCloseTo(CONFIG.survival.upkeepScaling.maxMultiplier, 6);
+    });
+
+    it("...and the two multiply in survival, where both apply", () => {
+        resetWorld({ gameMode: "survival" });
+        STATE.elapsedGameTime = CONFIG.survival.upkeepScaling.scaleTime;
+        STATE.intervention.costMultiplier = 2.0;
+        expect(getUpkeepMultiplier())
+            .toBeCloseTo(CONFIG.survival.upkeepScaling.maxMultiplier * 2, 6);
+    });
+
+    it("the test world starts with no intervention running, as its header claims", () => {
+        // resetWorld's own comment has said "no interventions" since it was
+        // written, without ever clearing them. Nothing noticed while the mode
+        // gate suppressed the one that bites.
+        resetWorld({ gameMode: "survival" });
+        STATE.intervention.costMultiplier = 2.0;
+        STATE.intervention.trafficBurstMultiplier = 3.0;
+        resetWorld({ gameMode: "survival" });
+        expect(STATE.intervention.costMultiplier).toBe(1.0);
+        expect(STATE.intervention.trafficBurstMultiplier).toBe(1.0);
+    });
+});


### PR DESCRIPTION
1015 → **1020 tests**.

`getUpkeepMultiplier()` bundled two different things behind one gate:

- **the ramp** — upkeep climbing 1x to 2x over ten minutes, a survival progression mechanic, and what `if (STATE.gameMode !== "survival") return 1.0` was written to guard;
- **the spike** — `STATE.intervention.costMultiplier`, set by a random **event**.

`updateRandomEvents` runs inside any campaign level with `enableSurvivalShifts` — levels **14** and **25**. So the event's *arrival* was gated on the level while its *effect* was gated on the mode. The player got an eight-second danger toast reading **"CLOUD COST SPIKE! Upkeep doubled for 30s"**, plus a full-width red **COST SPIKE ACTIVE** bar, and the meter charged exactly what it had the second before.

The other three event types have no such split: `CAPACITY_DROP` and the rest write state that is consumed ungated.

The gate now guards only the ramp it was written for.

## What it costs, measured before changing it

The beatability harness covers levels 3–9 and 12 — **not 14 or 25** — so the suite passing proves nothing about the two levels this touches. Measured instead, with the spike pinned on for the **whole level** rather than its real 30-second window:

| level | without | with | delta |
|---|---|---|---|
| L14 — 90 s, five-service board | 644 | 629 | **−15** |
| L25 — 300 s, nine prebuilt | 2134 | 1801 | −333 |

against a `moneyBelow` floor of **−500** in both, and both levels are lost on **reputation**, which a cost spike does not touch. The real window is a third of L14 and a tenth of L25, so the true cost is a few dollars.

## The ramp stays where it was

A test pins that a fully-ramped campaign clock still reads `1.0` — losing that would import survival's ten-minute climb into all twenty-five levels. The mutation that drops the gate entirely turns it red.

## One thing found on the way

`resetWorld` now clears `STATE.intervention`, which its own header has claimed since it was written — *"no degradation, no upkeep drain, no interventions"* — without ever doing it. Nothing noticed while the mode gate suppressed the one that bites; the moment it was narrowed, a `COST_SPIKE` left behind by one test started doubling the upkeep in the next.

Three mutations, all caught: restoring the old gate, dropping the gate entirely, and un-clearing the helper.
