### PR TITLE
The Operator Manual priced the Message Queue at $35; it costs $45

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (52 test files, 1020 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (53 test files, 1032 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -304,7 +304,7 @@ export const DE_TRANSLATIONS = {
     "traffic_malicious_desc": "DDoS & Angriffe. Blockieren mit <span class=\"text-purple-400\">Firewall</span>.",
     "services": "DIENSTE",
     "fw_desc_short": "Blockiert Betrug ($40)",
-    "queue_desc_short": "Puffert 200 Anfragen ($35)",
+    "queue_desc_short": "Puffert 200 Anfragen ($45)",
     "lb_desc_short": "Verteilt Traffic ($50)",
     "compute_desc_short": "Verarbeitet Anfragen ($60)",
     "db_desc_short": "Speichert API-Daten ($150)",

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -304,7 +304,7 @@ export const EN_TRANSLATIONS = {
     "traffic_malicious_desc": "DDoS & attacks. Block with <span class=\"text-purple-400\">Firewall</span>.",
     "services": "SERVICES",
     "fw_desc_short": "Blocks Fraud ($40)",
-    "queue_desc_short": "Buffers 200 requests ($35)",
+    "queue_desc_short": "Buffers 200 requests ($45)",
     "lb_desc_short": "Distributes Traffic ($50)",
     "compute_desc_short": "Processes Requests ($60)",
     "db_desc_short": "Stores API Data ($150)",

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -304,7 +304,7 @@ export const FR_TRANSLATIONS = {
     "traffic_malicious_desc": "DDoS et attaques. Bloquer avec <span class=\"text-purple-400\">Pare-feu</span>.",
     "services": "SERVICES",
     "fw_desc_short": "Bloque la fraude ($40)",
-    "queue_desc_short": "Tamponne 200 requêtes ($35)",
+    "queue_desc_short": "Tamponne 200 requêtes ($45)",
     "lb_desc_short": "Distribue le trafic ($50)",
     "compute_desc_short": "Traite les requêtes ($60)",
     "db_desc_short": "Stocke les données API ($150)",

--- a/src/locales/hi.js
+++ b/src/locales/hi.js
@@ -338,7 +338,7 @@ export const HI_TRANSLATIONS = {
     "traffic_malicious_desc": "DDoS और attacks। <span class=\"text-purple-400\">Firewall</span> से block करें।",
     "services": "SERVICES",
     "fw_desc_short": "Fraud block करता है ($40)",
-    "queue_desc_short": "200 requests buffer करती है ($35)",
+    "queue_desc_short": "200 requests buffer करती है ($45)",
     "lb_desc_short": "Traffic बाँटता है ($50)",
     "compute_desc_short": "Requests process करता है ($60)",
     "db_desc_short": "API data store करता है ($150)",

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -304,7 +304,7 @@ export const IT_TRANSLATIONS = {
     "traffic_malicious_desc": "DDoS e attacchi. Blocca con il <span class=\"text-purple-400\">Firewall</span>.",
     "services": "SERVIZI",
     "fw_desc_short": "Blocca Frodi ($40)",
-    "queue_desc_short": "Bufferizza 200 richieste ($35)",
+    "queue_desc_short": "Bufferizza 200 richieste ($45)",
     "lb_desc_short": "Distribuisce il Traffico ($50)",
     "compute_desc_short": "Elabora le Richieste ($60)",
     "db_desc_short": "Memorizza Dati API ($150)",

--- a/src/locales/ko.js
+++ b/src/locales/ko.js
@@ -304,7 +304,7 @@ export const KO_TRANSLATIONS = {
     "traffic_malicious_desc": "DDoS 및 공격. <span class=\"text-purple-400\">방화벽</span>으로 차단.",
     "services": "서비스",
     "fw_desc_short": "악성 차단 ($40)",
-    "queue_desc_short": "요청 200개 버퍼 ($35)",
+    "queue_desc_short": "요청 200개 버퍼 ($45)",
     "lb_desc_short": "트래픽 분산 ($50)",
     "compute_desc_short": "요청 처리 ($60)",
     "db_desc_short": "API 데이터 저장 ($150)",

--- a/src/locales/nep.js
+++ b/src/locales/nep.js
@@ -304,7 +304,7 @@ export const NE_TRANSLATIONS = {
     "traffic_malicious_desc": "DDoS र आक्रमणहरू। <span class=\"text-purple-400\">फायरवाल</span> सँग अवरुद्ध गर्नुहोस्।",
     "services": "सेवाहरू",
     "fw_desc_short": "धोखाधडी अवरुद्ध ($40)",
-    "queue_desc_short": "200 अनुरोधहरू बफर ($35)",
+    "queue_desc_short": "200 अनुरोधहरू बफर ($45)",
     "lb_desc_short": "ट्राफिक वितरण ($50)",
     "compute_desc_short": "अनुरोधहरू प्रक्रिया ($60)",
     "db_desc_short": "API डाटा भण्डारण ($150)",

--- a/src/locales/pt-BR.js
+++ b/src/locales/pt-BR.js
@@ -304,7 +304,7 @@ export const PT_BR_TRANSLATIONS = {
     "traffic_malicious_desc": "DDoS e ataques. Use <span class=\"text-purple-400\">firewall</span> para bloquear.",
     "services": "Componentes de Serviço",
     "fw_desc_short": "Bloqueia fraudes ($40)",
-    "queue_desc_short": "Buffer de 200 solicitações ($35)",
+    "queue_desc_short": "Buffer de 200 solicitações ($45)",
     "lb_desc_short": "Distribui tráfego ($50)",
     "compute_desc_short": "Processa solicitações ($60)",
     "db_desc_short": "Armazena dados de API ($150)",

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -304,7 +304,7 @@ export const RU_TRANSLATIONS = {
     "traffic_malicious_desc": "DDoS и атаки. Блокировать <span class=\"text-purple-400\">Firewall</span>.",
     "services": "СЕРВИСЫ",
     "fw_desc_short": "Блокирует мошенничество ($40)",
-    "queue_desc_short": "Буфер 200 запросов ($35)",
+    "queue_desc_short": "Буфер 200 запросов ($45)",
     "lb_desc_short": "Распределяет трафик ($50)",
     "compute_desc_short": "Обрабатывает запросы ($60)",
     "db_desc_short": "Хранит API‑данные ($150)",

--- a/src/locales/uk.js
+++ b/src/locales/uk.js
@@ -302,7 +302,7 @@ export const UK_TRANSLATIONS = {
     "traffic_malicious_desc": "DDoS та атаки. Блокуй через <span class=\"text-purple-400\">Фаєрвол</span>.",
     "services": "СЕРВІСИ",
     "fw_desc_short": "Блокує фрод ($40)",
-    "queue_desc_short": "Буферизує 200 запитів ($35)",
+    "queue_desc_short": "Буферизує 200 запитів ($45)",
     "lb_desc_short": "Розподіляє трафік ($50)",
     "compute_desc_short": "Обробляє запити ($60)",
     "db_desc_short": "Зберігає дані API ($150)",

--- a/src/locales/zh.js
+++ b/src/locales/zh.js
@@ -304,7 +304,7 @@ export const ZH_TRANSLATIONS = {
     "traffic_malicious_desc": "DDoS 和攻击。使用 <span class=\"text-purple-400\">防火墙</span> 拦截。",
     "services": "服务组件",
     "fw_desc_short": "拦截欺诈 ($40)",
-    "queue_desc_short": "缓冲 200 个请求 ($35)",
+    "queue_desc_short": "缓冲 200 个请求 ($45)",
     "lb_desc_short": "流量分发 ($50)",
     "compute_desc_short": "请求处理 ($60)",
     "db_desc_short": "存储 API 数据 ($150)",

--- a/tests/manual-prices.test.mjs
+++ b/tests/manual-prices.test.mjs
@@ -1,0 +1,68 @@
+// The Operator Manual is the game's own help screen, reached from the main
+// menu, and it prices every service by hand.
+//
+// The toolbar badge two clicks away is GENERATED from CONFIG
+// (`CONFIG.services[type].cost` in ui/toolbar.js), so it cannot drift. The
+// manual's twenty-two rows are hand-written locale strings, so they can — and
+// one had: queue_desc_short still said $35 for a Message Queue that costs $45,
+// a config line that carries its own history (`cost: 45, // Increased from
+// 35`). The stale figure had been translated into all eleven locales.
+//
+// A 29% error on a node the level-5 briefing tells you to buy on a $180
+// budget, on the surface a player consults precisely BECAUSE they are
+// budgeting. Two screens contradicting each other, and the wrong one reads
+// like documentation.
+import { describe, expect, it } from "vitest";
+import { CONFIG } from "../src/config.js";
+import { LOCALES, loadLocale } from "./helpers/load-globals.mjs";
+
+// Which service each manual row is about. Written out rather than inferred:
+// three keys do not match their service id (fw/lb/storage are the WAF, the
+// ALB and S3), and a guess that silently resolves to null is how a row stops
+// being checked without anyone noticing.
+const ROW_SERVICE = {
+    fw: "waf", queue: "sqs", lb: "alb", compute: "compute", db: "db",
+    cache: "cache", storage: "s3", apigw: "apigw", nosql: "nosql",
+    search: "search", replica: "replica", serverless: "serverless",
+    monitor: "monitor", dlq: "dlq", pubsub: "pubsub", auth: "auth",
+    scheduler: "scheduler", notify: "notify", container: "container",
+    stream: "stream", dns: "dns", warehouse: "warehouse",
+};
+
+const rowsOf = (t) => Object.keys(t).filter((k) => k.endsWith("_desc_short"));
+
+describe("the Operator Manual prices what the game charges", () => {
+    it("every row maps to a real service — no row quietly stops being checked", async () => {
+        const en = await loadLocale(LOCALES.find((l) => l.code === "en"));
+        const rows = rowsOf(en);
+        expect(rows.length).toBeGreaterThan(20);
+        for (const key of rows) {
+            const stem = key.replace("_desc_short", "");
+            const service = ROW_SERVICE[stem];
+            expect(service, `manual row "${key}" has no entry in ROW_SERVICE`).toBeTruthy();
+            expect(CONFIG.services[service], `ROW_SERVICE maps ${stem} to a service that does not exist`)
+                .toBeTruthy();
+        }
+        // ...and the map has nothing stale in it either.
+        for (const stem of Object.keys(ROW_SERVICE)) {
+            expect(rows, `ROW_SERVICE lists ${stem}, which the manual no longer has`)
+                .toContain(`${stem}_desc_short`);
+        }
+    });
+
+    for (const locale of LOCALES) {
+        it(`${locale.code}: every price in the manual is the price in CONFIG`, async () => {
+            const t = await loadLocale(locale);
+            for (const key of rowsOf(t)) {
+                const text = t[key];
+                const m = /\$(\d+)/.exec(text);
+                expect(m, `${locale.code}/${key} lost its price: "${text}"`).not.toBeNull();
+                const service = ROW_SERVICE[key.replace("_desc_short", "")];
+                expect(
+                    Number(m[1]),
+                    `${locale.code}/${key} says $${m[1]}, the game charges $${CONFIG.services[service].cost}`
+                ).toBe(CONFIG.services[service].cost);
+            }
+        });
+    }
+});


### PR DESCRIPTION
1020 → **1032 tests**.

The Operator Manual is the game's own help screen, reached from the main menu, and it prices every service **by hand**. The toolbar badge two clicks away is generated from `CONFIG.services[type].cost`, so it cannot drift. The manual's twenty-two rows are locale strings, so they can — and one had:

```js
queue_desc_short: "Buffers 200 requests ($35)"
CONFIG.services.sqs.cost: 45,   // Increased from 35   ← the config line's own comment
```

A **29% error** on a node the level-5 briefing tells the player to buy on a $180 budget — on the one surface people consult precisely *because* they are budgeting. Two screens contradicting each other, and the wrong one reads like documentation.

The stale figure had been translated into **all eleven locales**.

## Fixed, and pinned

All eleven locales corrected, and all twenty-two rows are now checked against `CONFIG` in every one of them. Repricing a service turns **eleven tests red** until the manual follows — that is the point. I checked the other twenty-one rows by hand first: this was the only one that disagreed.

## On the mapping

The row-to-service map is written out rather than inferred. Three keys do not match their service id — `fw`, `lb` and `storage` are the WAF, the ALB and S3 — and a guess that silently resolves to `null` is exactly how a row stops being checked without anyone noticing. My first pass at this did exactly that and reported those three as unverifiable.

So a test asserts the map covers every row **and** lists no row the manual has dropped.

Three mutations, all caught: restoring the stale price in one locale, repricing a service in `CONFIG` without touching the manual (eleven tests red), and a row losing its price entirely.
