### PR TITLE
A node dragged and released off the canvas kept following the mouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ python3 -m http.server 8000    # then open http://localhost:8000
 
 There is still **zero build step** — the dev tooling is optional and for contributors only:
 
-- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (53 test files, 1032 tests).
+- `npm install` once, then `npm run check` runs ESLint + the full Vitest suite (54 test files, 1037 tests).
 - CI runs the same check on every PR.
 - The code is native ESM: `game.js` plus focused modules under `src/` (`sim/`, `core/`, `ui/`, `campaign/`, `persistence/`, `input/`).
 

--- a/game.js
+++ b/game.js
@@ -94,6 +94,7 @@ import {
     orbitCamera,
     panCameraScreen,
     resetCamera,
+    endPointerInteraction,
 } from "./src/input/handlers.js";
 // Share Architecture (#157): the share modal, PNG export, and the ?arch=
 // link. consumeSharedArchParam/rebuildSharedArch are called from the boot
@@ -434,6 +435,12 @@ function resetGame(mode = "survival") {
     // window.startTutorial calls resetGame() BEFORE tutorial.reset() and
     // start(), so re-arming still works.
     window.tutorial?.abandon();
+
+    // ...and the pointer lets go of whatever it was holding. See
+    // endPointerInteraction: a drag or a pan released off the canvas is never
+    // cleared by the container's own handler, and a run boundary is not a
+    // place for the last run's grab to still be live.
+    endPointerInteraction();
 
     // Set budget based on mode
     if (mode === "campaign") {

--- a/src/input/handlers.js
+++ b/src/input/handlers.js
@@ -878,7 +878,21 @@ function setupUITooltips() {
 setupUITooltips();
 window.addEventListener("toolbarRendered", setupUITooltips);
 
-container.addEventListener("mouseup", (e) => {
+// The pointer can be RELEASED ANYWHERE. This handler lived only on
+// #canvas-container, and the HUD panels are pointer-events-auto siblings of
+// the canvas, so letting go over the Finances panel — or off the window edge,
+// which delivers no mouseup at all to the container — left isDraggingNode,
+// draggedNode, isPanning and isOrbiting armed with nothing holding them.
+//
+// Nothing cleared them afterwards either: resetGame did not, so the state
+// crossed the run boundary. Grab the Internet node, release over a panel,
+// start a new run, and the node teleported on the first mouse MOVE with
+// nobody clicking — measured from x -40 to x 0.
+//
+// Bound to the window as well as the container. The release on the canvas
+// bubbles to both, and every branch below is guarded on the flag it clears,
+// so running twice is a no-op the second time.
+function handlePointerRelease(e) {
     if (e.button === 2 || e.button === 1) {
         isPanning = false;
         isOrbiting = false;
@@ -917,7 +931,27 @@ container.addEventListener("mouseup", (e) => {
         container.style.cursor = "default";
         return;
     }
-});
+}
+
+container.addEventListener("mouseup", handlePointerRelease);
+window.addEventListener("mouseup", handlePointerRelease);
+
+// A release that happens with the window unfocused (dragged off the edge and
+// let go) delivers no mouseup at all. Coming back to the page is the next
+// moment we can know the button is not held any more.
+window.addEventListener("blur", () => handlePointerRelease({ button: 0 }));
+
+// Ends any drag/pan in progress. Called by resetGame: a run boundary is not
+// a place for the pointer to still be holding something from the last one.
+export function endPointerInteraction() {
+    const wasActive = isDraggingNode || isPanning || isOrbiting;
+    isDraggingNode = false;
+    draggedNode = null;
+    isPanning = false;
+    isOrbiting = false;
+    if (container) container.style.cursor = "default";
+    return wasActive;
+}
 
 window.addEventListener("resize", () => {
     // The frustum math lives in game.js and is shared with the initial camera

--- a/tests/helpers/three-stub.mjs
+++ b/tests/helpers/three-stub.mjs
@@ -262,11 +262,26 @@ export class Plane {
   }
 }
 
+// What the next raycast should hit. Empty by default, so every test written
+// before this existed behaves exactly as it did: no picking, everything falls
+// through to the ground plane.
+//
+// Priming it is what makes the INPUT layer testable at all. getIntersect()
+// (src/input/handlers.js) is the single gate in front of node dragging,
+// selection, connecting and deleting, and none of that could be reached from
+// a test while both methods always returned nothing.
+export const raycastHits = { services: [], internet: [] };
+
+export function resetRaycastHits() {
+  raycastHits.services = [];
+  raycastHits.internet = [];
+}
+
 export class Raycaster {
   constructor() {
     this.ray = {
-      // Tests never raycast for real; the ground-plane intersection just
-      // needs to produce a point so callers don't crash.
+      // Real geometry is still never computed; the ground-plane intersection
+      // just needs to produce a point so callers don't crash.
       intersectPlane(plane, target) {
         target.set(0, 0, 0);
         return target;
@@ -275,10 +290,10 @@ export class Raycaster {
   }
   setFromCamera() {}
   intersectObjects() {
-    return [];
+    return raycastHits.services;
   }
   intersectObject() {
-    return [];
+    return raycastHits.internet;
   }
 }
 
@@ -341,6 +356,8 @@ export const THREE_STUB = {
   WebGLRenderer,
   Plane,
   Raycaster,
+  raycastHits,
+  resetRaycastHits,
   FogExp2,
   DoubleSide,
 };

--- a/tests/sim/pointer-release.test.mjs
+++ b/tests/sim/pointer-release.test.mjs
@@ -1,0 +1,100 @@
+// The pointer can be released anywhere, and this game only listened on the
+// canvas.
+//
+// isDraggingNode, draggedNode, isPanning and isOrbiting are module-scope lets
+// in src/input/handlers.js, armed on the container's mousedown and cleared
+// only in the container's mouseup. The HUD panels are pointer-events-auto
+// SIBLINGS of the canvas, and a release outside the window delivers no
+// mouseup to the container at all — so letting go anywhere but the board left
+// the grab live with nothing holding it.
+//
+// resetGame did not clear them either, so the grab crossed the run boundary:
+// drag the Internet node, release over the Finances panel, start a different
+// run, and the node teleported on the first mouse MOVE with nobody clicking.
+//
+// These tests exist because the THREE stub's raycaster became primeable. It
+// returned nothing unconditionally before, with a comment saying tests never
+// raycast — which meant the entire input layer (dragging, selecting,
+// connecting, deleting) could not be reached from a test at all.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { STATE } from "../../src/state.js";
+import { resetGame } from "../../game.js";
+import { raycastHits, resetRaycastHits } from "../helpers/three-stub.mjs";
+
+const container = () => document.getElementById("canvas-container");
+const at = (target, type, x, y) => target.dispatchEvent(
+    new globalThis.MouseEvent(type, { bubbles: true, button: 0, clientX: x, clientY: y })
+);
+const pos = () => ({ x: STATE.internetNode.position.x, z: STATE.internetNode.position.z });
+const offCanvas = () => document.getElementById("failures-panel") || document.body;
+
+function grabInternet() {
+    STATE.activeTool = "select";
+    raycastHits.internet = [{ object: STATE.internetNode.mesh }];
+    at(container(), "mousedown", 100, 100);
+    expect(container().style.cursor, "the drag must arm or the test proves nothing")
+        .toBe("grabbing");
+    resetRaycastHits();
+}
+
+describe("a grab ends wherever the button is released", () => {
+    beforeEach(() => {
+        try { localStorage.clear(); } catch { /* storage unavailable */ }
+        resetRaycastHits();
+        resetGame("survival");
+    });
+    afterEach(resetRaycastHits);
+
+    it("THE TELEPORT: released over a HUD panel, then a new run", () => {
+        grabInternet();
+        at(offCanvas(), "mouseup", 500, 500);
+
+        resetGame("survival");
+        const before = pos();
+        at(container(), "mousemove", 700, 400);
+        expect(pos(), "the node moved with nobody holding it").toEqual(before);
+    });
+
+    it("...and within the same run, the release alone is enough", () => {
+        grabInternet();
+        at(offCanvas(), "mouseup", 500, 500);
+        const before = pos();
+        at(container(), "mousemove", 700, 400);
+        expect(pos()).toEqual(before);
+        expect(container().style.cursor).toBe("default");
+    });
+
+    it("a drag released ON the canvas still works — the normal path is untouched", () => {
+        const before = pos();
+        grabInternet();
+        at(container(), "mousemove", 700, 400);
+        expect(pos(), "the node should follow the cursor while held").not.toEqual(before);
+        at(container(), "mouseup", 700, 400);
+        // Dropped: it stays where it was put, and stops following.
+        const dropped = pos();
+        at(container(), "mousemove", 200, 200);
+        expect(pos()).toEqual(dropped);
+    });
+
+    it("a run boundary lets go too, even with no release and no blur", () => {
+        // The window listener covers every release that actually happens and
+        // blur covers the one that does not, so this is the last resort: a
+        // grab still live when the world is torn down. Cheap, and this
+        // codebase has now shipped six separate bugs that were exactly some
+        // flag outliving the run that set it.
+        grabInternet();
+        resetGame("sandbox");                 // no mouseup, no blur
+        const before = pos();
+        at(container(), "mousemove", 700, 400);
+        expect(pos()).toEqual(before);
+        expect(container().style.cursor).toBe("default");
+    });
+
+    it("losing the window mid-drag ends it too — no mouseup is ever delivered", () => {
+        grabInternet();
+        globalThis.window.dispatchEvent(new globalThis.Event("blur"));
+        const before = pos();
+        at(container(), "mousemove", 700, 400);
+        expect(pos()).toEqual(before);
+    });
+});


### PR DESCRIPTION
1032 → **1037 tests**.

`isDraggingNode`, `draggedNode`, `isPanning` and `isOrbiting` are module-scope `let`s in `src/input/handlers.js`, armed on the container's `mousedown` and cleared **only** in the container's `mouseup`.

The HUD panels are `pointer-events-auto` **siblings** of the canvas, and a release outside the browser window delivers no `mouseup` to the container at all. So letting go anywhere but the board left the grab live with nothing holding it — and `resetGame` did not clear it either, so it crossed the run boundary.

Measured end to end through the real event path:

```
grab Internet → release over the Finances panel → new run → one mousemove
node position: x -40  →  x 0     (nobody clicked)
```

## Three ways out, each with its own test

- the release is listened for on the **window** as well as the container — an on-canvas release bubbles to both, and every branch is guarded on the flag it clears, so the second run is a no-op;
- **blur** ends a drag that left the window and was released where no event reaches us;
- **`resetGame`** lets go of whatever is still held — the last resort, and the class this codebase has now shipped six of.

## The harness change is the bigger part

The THREE stub's raycaster returned nothing unconditionally:

```js
// Tests never raycast for real
intersectObjects() { return []; }
intersectObject()  { return []; }
```

`getIntersect()` is the single gate in front of **dragging, selecting, connecting and deleting**, so that one stub method made the entire input layer unreachable from a test. This bug could not have been written down as a failing test before — and my first attempt at reproducing it "passed", because the probe silently never grabbed anything.

`raycastHits` is empty by default, so every test written before this behaves exactly as it did: **all 1032 passed unchanged** with the new stub in place, before a line of the fix was written.

Three mutations, all caught: dropping the window listener, dropping the blur fallback, and dropping the reset call. The third escaped the first version of its test — the window listener already covered that path — so it now has a case that isolates it: a grab still live with no release and no blur.
